### PR TITLE
chore: drop unused anyhow and time dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,7 +754,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
- "serde_core",
 ]
 
 [[package]]
@@ -2051,7 +2050,6 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 name = "rustyant"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "aws-config",
  "aws-sdk-s3",
@@ -2063,7 +2061,6 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
- "time",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2398,7 +2395,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ name = "rustyant"
 path = "src/main.rs"
 
 [dependencies]
-anyhow = "1"
 async-trait = "0.1"
 bytes = "1"
 bytes-utils = "0.1"
@@ -32,7 +31,6 @@ aws-sdk-s3 = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-time = { version = "0.3", features = ["formatting", "serde"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 thiserror = "1"


### PR DESCRIPTION
## Summary

- Removes `anyhow` and `time` from `[dependencies]` in `Cargo.toml`.
- Both were carried over from rustyhip's template but never imported by rustyant code.
- `cargo-machete` flagged them in the [first CI run](https://github.com/monkut/rustyant/actions/runs/24602424900) (step is `continue-on-error: true`, so CI was green but flagged the finding).

## Test plan

- [x] `cargo check --all-targets` clean
- [x] `cargo test --all-targets` — 42 pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] CI green on this PR (including the floci-backed suite in the `test` job)