### PR TITLE
feat: SAM template for the WebSocket API + bump GHA actions to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     name: fmt + clippy + typos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -58,7 +58,7 @@ jobs:
       RUSTYANT_FLOCI_URL: http://localhost:4566
       RUSTYANT_FLOCI_BUCKET: rustyant-ci
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
@@ -74,7 +74,7 @@ jobs:
         run: cargo test --doc --all-features
       - name: upload junit
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: junit
           path: target/nextest/ci/junit.xml
@@ -84,7 +84,7 @@ jobs:
     name: cargo-audit + cargo-deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
@@ -99,7 +99,7 @@ jobs:
     name: MSRV build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Extract MSRV from Cargo.toml
         id: msrv
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,9 @@ coverage/
 # Cached toolchain/docs
 .cargo-cache/
 docs-build/
+
+# Python clients
+**/.venv/
+**/__pycache__/
+**/*.egg-info/
+**/.pytest_cache/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-apigatewaymanagement"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a57d1f6c98de5463b8d1cdeb302b09214906fb2d3d0cc0ceae2d75c3464ae91"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-s3"
 version = "1.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,6 +525,22 @@ name = "aws_lambda_events"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7319a086b79c3ff026a33a61e80f04fd3885fbb73237981ea080d21944e1cb1c"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-serde",
+ "query_map",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "aws_lambda_events"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144ec7565561115498a288850cc6a42b279e09b6c4b88f623eecb9c8ca96c08c"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1452,7 +1490,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67fe279be7f89f5f72c97c3a96f45c43db8edab1007320ecc6a5741273b4d6db"
 dependencies = [
- "aws_lambda_events",
+ "aws_lambda_events 0.15.1",
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
@@ -2052,10 +2090,14 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "aws-config",
+ "aws-sdk-apigatewaymanagement",
  "aws-sdk-s3",
+ "aws_lambda_events 0.16.1",
+ "base64 0.22.1",
  "bytes",
  "bytes-utils",
  "lambda_http",
+ "lambda_runtime",
  "redis-protocol",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,23 @@ path = "src/lib.rs"
 name = "rustyant"
 path = "src/main.rs"
 
+# WebSocket transport variant — same library, different Lambda event shape.
+[[bin]]
+name = "rustyant-ws"
+path = "src/bin/ws.rs"
+
 [dependencies]
 async-trait = "0.1"
+base64 = "0.22"
 bytes = "1"
 bytes-utils = "0.1"
 lambda_http = { version = "0.13", default-features = false, features = ["apigw_rest", "apigw_http", "tracing"] }
+lambda_runtime = "0.13"
+aws_lambda_events = { version = "0.16", default-features = false, features = ["apigw"] }
 redis-protocol = { version = "5", features = ["resp2", "resp3", "bytes"] }
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 aws-sdk-s3 = "1"
+aws-sdk-apigatewaymanagement = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,21 @@
 # rustyant
 
-RustyAnt is a Lambda front end providing a Redis-compatible (RESP-over-HTTP) key-value store backed by S3.
+RustyAnt is a Lambda front end providing a Redis-compatible key-value store backed by S3.
 
 Sibling project to [rustyhip](https://github.com/monkut/rustyhip) (SQLite-over-S3). Same architectural wedge — your data is just files in your S3 bucket — applied to Redis semantics.
 
-## Protocol
+## Transports
 
-RESP commands are sent as HTTP POST bodies to the Lambda URL. The response body is a RESP reply.
+Two Lambda binaries ship from the same library:
+
+| Binary | Transport | AWS front door | Use when |
+|---|---|---|---|
+| `rustyant` | RESP-over-HTTP | Lambda URL / API Gateway HTTP | One-shot batch calls, curl/CI, fewer moving parts |
+| `rustyant-ws` | RESP-over-WebSocket | API Gateway WebSocket API | redis-py-style client usage, persistent connection, pipelining |
+
+### HTTP transport
+
+RESP commands as HTTP POST bodies to the Lambda URL; reply is the response body.
 
 ```
 POST /  HTTP/1.1
@@ -15,8 +24,6 @@ Content-Type: application/resp
 *3\r\n$3\r\nSET\r\n$5\r\nhello\r\n$5\r\nworld\r\n
 ```
 
-Response:
-
 ```
 HTTP/1.1 200 OK
 Content-Type: application/resp
@@ -24,7 +31,20 @@ Content-Type: application/resp
 +OK\r\n
 ```
 
-This is not a drop-in replacement for a real Redis client — pipelining, MULTI/EXEC, and PUB/SUB are not supported by the HTTP transport. Suited for agent tool calls, batch KV reads/writes, and serverless workloads.
+### WebSocket transport
+
+API Gateway WS API routes `$connect` / `$disconnect` / `$default` events to the `rustyant-ws` Lambda. Each inbound WebSocket frame carries one RESP2 command; the Lambda posts the reply back on the same connection via the API Gateway Management API. Persistent connection → no per-command HTTP handshake, pipelining works, lower tail latency.
+
+Use the [Python client](clients/python/README.md) for a `redis-py`-shaped API:
+
+```python
+from rustyant import Client
+c = Client("wss://abc.execute-api.us-east-1.amazonaws.com/prod")
+c.set("k", "v")
+c.get("k")  # b"v"
+```
+
+Neither transport supports `MULTI`/`EXEC`, `SUBSCRIBE`/`PUBLISH`, or streams.
 
 ## Command Surface
 
@@ -96,4 +116,6 @@ printf '*3\r\n$3\r\nSET\r\n$5\r\nhello\r\n$5\r\nworld\r\n' | \
 
 ## Status
 
-Working scaffold: RESP-over-HTTP transport, full string/hash/list/set/zset command dispatch, S3-backed storage with per-key TTL. 8 RESP round-trip tests passing. No integration tests against a real Lambda runtime yet; no CI, no deny.toml, no pre-commit config (see the sibling rustyhip repo for the full tooling template).
+Working: RESP over HTTP and WebSocket, full string/hash/list/set/zset command dispatch, S3-backed storage with per-key TTL, 56+ Rust tests (8 RESP units + 8 WS units + 34 handler integration + 6 floci-gated S3), 8 Python client encoder tests, CI on GitHub Actions with floci as a service container.
+
+Not wired: no SAM/Terraform template for deploying the WebSocket API (see [clients/python/README.md](clients/python/README.md) for the expected API shape). No conditional-write concurrency control — read-modify-write commands (INCR, HSET, etc.) are last-writer-wins under concurrency.

--- a/README.md
+++ b/README.md
@@ -114,8 +114,28 @@ printf '*3\r\n$3\r\nSET\r\n$5\r\nhello\r\n$5\r\nworld\r\n' | \
   curl -s --data-binary @- http://localhost:9000/lambda-url/rustyant/
 ```
 
+## Deploying the WebSocket API
+
+The [`infra/template.yaml`](infra/template.yaml) SAM template provisions the API Gateway WebSocket API, the `rustyant-ws` Lambda, the S3 bucket, and the IAM policy granting `execute-api:ManageConnections`. Deployment requires the `sam` CLI, `cargo-lambda`, and AWS credentials for the target account.
+
+```bash
+just ws-template-validate                       # sam validate --lint
+just ws-template-build                          # sam build (invokes cargo-lambda)
+just ws-template-deploy BUCKET=my-kv-bucket     # creates stack rant-rustyant-ws
+```
+
+Outputs include `WebSocketUrl`, which is the `wss://…` URL to hand to the Python client:
+
+```python
+from rustyant import Client
+c = Client("wss://abc123.execute-api.ap-northeast-1.amazonaws.com/prod")
+c.set("hello", "world")
+```
+
+The HTTP variant (Lambda URL fronting the `rustyant` binary) is deployed separately via `just lambda-deploy` — not provisioned by this template.
+
 ## Status
 
-Working: RESP over HTTP and WebSocket, full string/hash/list/set/zset command dispatch, S3-backed storage with per-key TTL, 56+ Rust tests (8 RESP units + 8 WS units + 34 handler integration + 6 floci-gated S3), 8 Python client encoder tests, CI on GitHub Actions with floci as a service container.
+Working: RESP over HTTP and WebSocket, full string/hash/list/set/zset command dispatch, S3-backed storage with per-key TTL, 56+ Rust tests (8 RESP units + 8 WS units + 34 handler integration + 6 floci-gated S3), 8 Python client encoder tests, CI on GitHub Actions with floci as a service container, SAM template for the WebSocket stack.
 
-Not wired: no SAM/Terraform template for deploying the WebSocket API (see [clients/python/README.md](clients/python/README.md) for the expected API shape). No conditional-write concurrency control — read-modify-write commands (INCR, HSET, etc.) are last-writer-wins under concurrency.
+Not wired: no CI step for `sam validate`; no end-to-end test driving a real WebSocket connection against the deployed binary. No conditional-write concurrency control — read-modify-write commands (INCR, HSET, etc.) are last-writer-wins under concurrency.

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -1,0 +1,70 @@
+# rustyant — Python client
+
+Python client for [rustyant](https://github.com/monkut/rustyant) — a Redis-compatible key-value store served over AWS API Gateway WebSocket + Lambda + S3.
+
+## Install
+
+```bash
+pip install rustyant
+# or
+uv pip install rustyant
+```
+
+## Usage
+
+```python
+from rustyant import Client
+
+c = Client("wss://abc123.execute-api.us-east-1.amazonaws.com/prod")
+
+c.set("hello", "world")
+assert c.get("hello") == b"world"
+
+c.hset("profile", "name", "alice", "age", "30")
+assert c.hget("profile", "name") == b"alice"
+assert c.hgetall("profile") == {b"name": b"alice", b"age": b"30"}
+
+c.rpush("queue", "a", "b", "c")
+assert c.lrange("queue", 0, -1) == [b"a", b"b", b"c"]
+
+c.zadd("scores", {"alice": 10, "bob": 5})
+assert c.zrange("scores", 0, -1) == [b"bob", b"alice"]
+
+c.close()
+```
+
+Context-manager form auto-closes the WebSocket:
+
+```python
+with Client("wss://…") as c:
+    c.set("k", "v")
+```
+
+## Command surface
+
+| Group       | Methods                                                                  |
+| ----------- | ------------------------------------------------------------------------ |
+| Server      | `ping`                                                                   |
+| Strings     | `get`, `set` (`ex=`, `px=`), `delete`, `exists`, `expire`, `ttl`, `incr`, `incrby` |
+| Hashes      | `hset`, `hget`, `hdel`, `hgetall`                                        |
+| Lists       | `lpush`, `rpush`, `lpop` (optional `count`), `rpop` (optional `count`), `lrange`  |
+| Sets        | `sadd`                                                                   |
+| Sorted sets | `zadd`, `zrange`                                                         |
+
+Return values mirror `redis-py` defaults: bytes for bulk-string replies, `None` for nil, `int` for integer replies, `dict[bytes, bytes]` for `hgetall`. Server-side errors are raised as `RustyAntError`.
+
+## Requirements
+
+- Python ≥ 3.9
+- `websocket-client` ≥ 1.7 (TCP WebSocket transport)
+- `hiredis` ≥ 2.0 (RESP2 parser)
+
+## Transport
+
+Each command is sent as one binary WebSocket frame carrying a RESP2 array. The server replies on the same connection via the API Gateway Management API. Multi-frame pipelines work but are serialized (one in flight per connection) — use multiple clients to parallelize.
+
+Unsupported vs. real Redis: `MULTI`/`EXEC`, `SUBSCRIBE`/`PUBLISH`, scripting, streams, geo.
+
+## License
+
+See the parent [LICENSE](../../LICENSE) in the rustyant repository.

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "rustyant"
+version = "0.1.0"
+description = "Python client for rustyant — Redis-compatible key-value store on AWS Lambda + S3"
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "LicenseRef-KICONIAWORKS-Customers" }
+authors = [{ name = "monkut" }]
+dependencies = [
+    "hiredis>=2.0",
+    "websocket-client>=1.7",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/monkut/rustyant"
+Repository = "https://github.com/monkut/rustyant"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["rustyant"]

--- a/clients/python/rustyant/__init__.py
+++ b/clients/python/rustyant/__init__.py
@@ -1,0 +1,6 @@
+"""Python client for rustyant (Redis-compatible KV over AWS Lambda + S3)."""
+
+from rustyant.client import Client, RustyAntError
+
+__all__ = ["Client", "RustyAntError"]
+__version__ = "0.1.0"

--- a/clients/python/rustyant/client.py
+++ b/clients/python/rustyant/client.py
@@ -1,0 +1,213 @@
+"""
+Rustyant client — WebSocket transport, RESP2 wire format.
+
+Connects to an API Gateway WebSocket endpoint fronting the rustyant Lambda
+and issues Redis-style commands against the S3-backed key/value store. The
+method names mirror `redis-py` where the semantics line up, so porting small
+amounts of application code is usually one import change.
+
+Example:
+
+    from rustyant import Client
+
+    c = Client("wss://abc123.execute-api.us-east-1.amazonaws.com/prod")
+    c.set("hello", "world")
+    assert c.get("hello") == b"world"
+    c.hset("profile", "name", "alice", "age", "30")
+    assert c.hget("profile", "name") == b"alice"
+    c.close()
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Union
+
+import hiredis
+import websocket
+
+
+class RustyAntError(Exception):
+    """Raised when the server returns a RESP `-ERR` reply."""
+
+
+_Arg = Union[str, bytes, int, float, bool]
+
+
+def _encode_command(*args: _Arg) -> bytes:
+    """Serialize a command tuple into a RESP2 array frame."""
+    crlf = b"\r\n"
+    parts = [b"*" + str(len(args)).encode() + crlf]
+    for arg in args:
+        if isinstance(arg, bytes):
+            value = arg
+        elif isinstance(arg, bool):
+            # Match redis-py: True→b"1", False→b"0".
+            value = b"1" if arg else b"0"
+        elif isinstance(arg, (int, float)):
+            value = repr(arg).encode()
+        else:
+            value = str(arg).encode("utf-8")
+        parts.append(b"$" + str(len(value)).encode() + crlf + value + crlf)
+    return b"".join(parts)
+
+
+class Client:
+    """Blocking rustyant client. Thread-unsafe — one Client per thread."""
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        timeout: float = 10.0,
+        auto_connect: bool = True,
+    ) -> None:
+        if not url.startswith(("ws://", "wss://")):
+            raise ValueError(f"expected ws:// or wss:// URL, got {url!r}")
+        self._url = url
+        self._timeout = timeout
+        self._ws: websocket.WebSocket | None = None
+        self._reader: hiredis.Reader = hiredis.Reader()
+        if auto_connect:
+            self._connect()
+
+    # ---- connection management -----------------------------------------
+
+    def _connect(self) -> None:
+        self._ws = websocket.create_connection(self._url, timeout=self._timeout)
+
+    def close(self) -> None:
+        if self._ws is not None:
+            try:
+                self._ws.close()
+            finally:
+                self._ws = None
+
+    def __enter__(self) -> "Client":
+        if self._ws is None:
+            self._connect()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+    # ---- low-level dispatch --------------------------------------------
+
+    def _call(self, *args: _Arg) -> Any:
+        if self._ws is None:
+            self._connect()
+        assert self._ws is not None  # help the type-checker
+
+        packed = _encode_command(*args)
+        self._ws.send_binary(packed)
+
+        # Drain until a full reply is parsed. API Gateway delivers each
+        # `post_to_connection` payload as a single WS frame, so one recv
+        # normally suffices — but we loop defensively.
+        while True:
+            reply = self._reader.gets()
+            if reply is not False:
+                break
+            raw = self._ws.recv()
+            if isinstance(raw, str):
+                raw = raw.encode()
+            if not raw:
+                raise RustyAntError("connection closed while awaiting reply")
+            self._reader.feed(raw)
+
+        if isinstance(reply, hiredis.ReplyError):
+            raise RustyAntError(str(reply))
+        return reply
+
+    # ---- Redis-style command surface -----------------------------------
+
+    def ping(self) -> bytes:
+        return self._call("PING")
+
+    def set(
+        self,
+        key: _Arg,
+        value: _Arg,
+        *,
+        ex: int | None = None,
+        px: int | None = None,
+    ) -> bytes:
+        args: list[_Arg] = ["SET", key, value]
+        if ex is not None:
+            args += ["EX", ex]
+        if px is not None:
+            args += ["PX", px]
+        return self._call(*args)
+
+    def get(self, key: _Arg) -> bytes | None:
+        return self._call("GET", key)
+
+    def delete(self, *keys: _Arg) -> int:
+        return self._call("DEL", *keys)
+
+    def exists(self, *keys: _Arg) -> int:
+        return self._call("EXISTS", *keys)
+
+    def expire(self, key: _Arg, seconds: int) -> int:
+        return self._call("EXPIRE", key, seconds)
+
+    def ttl(self, key: _Arg) -> int:
+        return self._call("TTL", key)
+
+    def incr(self, key: _Arg) -> int:
+        return self._call("INCR", key)
+
+    def incrby(self, key: _Arg, delta: int) -> int:
+        return self._call("INCRBY", key, delta)
+
+    def hset(self, key: _Arg, *field_value_pairs: _Arg) -> int:
+        if len(field_value_pairs) < 2 or len(field_value_pairs) % 2 != 0:
+            raise ValueError("hset requires an even number of field/value args")
+        return self._call("HSET", key, *field_value_pairs)
+
+    def hget(self, key: _Arg, field: _Arg) -> bytes | None:
+        return self._call("HGET", key, field)
+
+    def hdel(self, key: _Arg, *fields: _Arg) -> int:
+        return self._call("HDEL", key, *fields)
+
+    def hgetall(self, key: _Arg) -> dict[bytes, bytes]:
+        flat: list[bytes] = self._call("HGETALL", key) or []
+        return dict(zip(flat[0::2], flat[1::2]))
+
+    def lpush(self, key: _Arg, *values: _Arg) -> int:
+        return self._call("LPUSH", key, *values)
+
+    def rpush(self, key: _Arg, *values: _Arg) -> int:
+        return self._call("RPUSH", key, *values)
+
+    def lpop(self, key: _Arg, count: int | None = None) -> Any:
+        if count is None:
+            return self._call("LPOP", key)
+        return self._call("LPOP", key, count)
+
+    def rpop(self, key: _Arg, count: int | None = None) -> Any:
+        if count is None:
+            return self._call("RPOP", key)
+        return self._call("RPOP", key, count)
+
+    def lrange(self, key: _Arg, start: int, stop: int) -> list[bytes]:
+        return self._call("LRANGE", key, start, stop)
+
+    def sadd(self, key: _Arg, *members: _Arg) -> int:
+        return self._call("SADD", key, *members)
+
+    def zadd(self, key: _Arg, mapping: dict[str, float] | Iterable[tuple[float, str]]) -> int:
+        """Accept either {member: score} or an iterable of (score, member) tuples."""
+        flat: list[_Arg] = []
+        if isinstance(mapping, dict):
+            for member, score in mapping.items():
+                flat += [score, member]
+        else:
+            for score, member in mapping:
+                flat += [score, member]
+        if not flat:
+            raise ValueError("zadd requires at least one score/member pair")
+        return self._call("ZADD", key, *flat)
+
+    def zrange(self, key: _Arg, start: int, stop: int) -> list[bytes]:
+        return self._call("ZRANGE", key, start, stop)

--- a/clients/python/tests/test_encoder.py
+++ b/clients/python/tests/test_encoder.py
@@ -1,0 +1,42 @@
+"""Encoder tests — byte-level wire-format compatibility checks.
+
+These tests have zero network dependencies and zero floci dependencies.
+They assert that `_encode_command` produces the exact RESP2 bytes the
+rustyant handler's integration tests are known to accept.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rustyant.client import _encode_command
+
+
+@pytest.mark.parametrize(
+    ("args", "expected"),
+    [
+        (("PING",), b"*1\r\n$4\r\nPING\r\n"),
+        (("SET", "hello", "world"),
+         b"*3\r\n$3\r\nSET\r\n$5\r\nhello\r\n$5\r\nworld\r\n"),
+        (("SET", "k", "v", "EX", 60),
+         b"*5\r\n$3\r\nSET\r\n$1\r\nk\r\n$1\r\nv\r\n$2\r\nEX\r\n$2\r\n60\r\n"),
+        (("HSET", "h", "f1", "v1", "f2", "v2"),
+         b"*6\r\n$4\r\nHSET\r\n$1\r\nh\r\n$2\r\nf1\r\n$2\r\nv1\r\n$2\r\nf2\r\n$2\r\nv2\r\n"),
+        (("LPUSH", "l", "a", "b", "c"),
+         b"*5\r\n$5\r\nLPUSH\r\n$1\r\nl\r\n$1\r\na\r\n$1\r\nb\r\n$1\r\nc\r\n"),
+        (("INCRBY", "counter", 10),
+         b"*3\r\n$6\r\nINCRBY\r\n$7\r\ncounter\r\n$2\r\n10\r\n"),
+    ],
+)
+def test_encode_matches_rustyant_wire_format(args: tuple[object, ...], expected: bytes) -> None:
+    assert _encode_command(*args) == expected
+
+
+def test_bytes_args_pass_through_unchanged() -> None:
+    packed = _encode_command("SET", b"\xff\x00\xaa", b"\x01\x02")
+    assert packed == b"*3\r\n$3\r\nSET\r\n$3\r\n\xff\x00\xaa\r\n$2\r\n\x01\x02\r\n"
+
+
+def test_bool_encodes_as_one_or_zero() -> None:
+    assert _encode_command("SET", "k", True) == b"*3\r\n$3\r\nSET\r\n$1\r\nk\r\n$1\r\n1\r\n"
+    assert _encode_command("SET", "k", False) == b"*3\r\n$3\r\nSET\r\n$1\r\nk\r\n$1\r\n0\r\n"

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -1,0 +1,176 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: rustyant — WebSocket transport (API Gateway WS → Lambda → S3)
+
+# Deploys:
+#   * S3 bucket for KV storage
+#   * rustyant-ws Lambda (Rust, arm64) built by sam+cargo-lambda
+#   * API Gateway WebSocket API with $connect / $disconnect / $default routes
+#   * IAM policy granting the Lambda execute-api:ManageConnections (so it can
+#     reply via @connections) plus S3 CRUD on the bucket
+#
+# The HTTP variant (Lambda URL) is not provisioned here — deploy it via
+# `just lambda-deploy` against the existing `rustyant` binary.
+
+Parameters:
+  BucketName:
+    Type: String
+    Description: S3 bucket holding the KV objects. Will be created by this stack.
+    AllowedPattern: ^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$
+
+  KeyPrefix:
+    Type: String
+    Description: Prefix prepended to every Redis key in S3.
+    Default: rustyant/
+
+  StageName:
+    Type: String
+    Description: API Gateway WebSocket stage name.
+    Default: prod
+
+  LogLevel:
+    Type: String
+    Description: tracing env-filter for the Lambda.
+    Default: info
+    AllowedValues: [trace, debug, info, warn, error]
+
+Globals:
+  Function:
+    Runtime: provided.al2023
+    Architectures: [arm64]
+    MemorySize: 256
+    Timeout: 10
+    Environment:
+      Variables:
+        BUCKET: !Ref BucketName
+        KEY_PREFIX: !Ref KeyPrefix
+        LOG_LEVEL: !Ref LogLevel
+        RUST_LOG: !Ref LogLevel
+
+Resources:
+  # --- Storage ------------------------------------------------------------
+  Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref BucketName
+      VersioningConfiguration:
+        Status: Enabled
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+
+  # --- WebSocket API ------------------------------------------------------
+  # $request.body.action is API Gateway's conventional selection expression.
+  # RESP frames are binary and contain no JSON `action` field, so the
+  # expression never resolves to a defined route key and traffic falls
+  # through to $default — which is exactly what we want.
+  WebSocketApi:
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: !Sub '${AWS::StackName}-ws'
+      ProtocolType: WEBSOCKET
+      RouteSelectionExpression: $request.body.action
+
+  # --- Lambda -------------------------------------------------------------
+  WsFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: rust-cargolambda
+      BuildProperties:
+        Binary: rustyant-ws
+    Properties:
+      FunctionName: !Sub '${AWS::StackName}-ws'
+      CodeUri: ../
+      Handler: bootstrap
+      Policies:
+        - S3CrudPolicy:
+            BucketName: !Ref BucketName
+        - Statement:
+            - Effect: Allow
+              Action:
+                - execute-api:ManageConnections
+              Resource:
+                - !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${WebSocketApi}/${StageName}/POST/@connections/*'
+
+  WsLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref WsFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${WebSocketApi}/*'
+
+  # --- Routes + Integration ----------------------------------------------
+  WsIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref WebSocketApi
+      IntegrationType: AWS_PROXY
+      IntegrationUri:
+        !Sub 'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${WsFunction.Arn}/invocations'
+
+  ConnectRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref WebSocketApi
+      RouteKey: $connect
+      AuthorizationType: NONE
+      Target: !Sub 'integrations/${WsIntegration}'
+
+  DisconnectRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref WebSocketApi
+      RouteKey: $disconnect
+      AuthorizationType: NONE
+      Target: !Sub 'integrations/${WsIntegration}'
+
+  DefaultRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref WebSocketApi
+      RouteKey: $default
+      AuthorizationType: NONE
+      Target: !Sub 'integrations/${WsIntegration}'
+
+  # --- Deployment + Stage ------------------------------------------------
+  WsDeployment:
+    Type: AWS::ApiGatewayV2::Deployment
+    DependsOn:
+      - ConnectRoute
+      - DisconnectRoute
+      - DefaultRoute
+    Properties:
+      ApiId: !Ref WebSocketApi
+
+  WsStage:
+    Type: AWS::ApiGatewayV2::Stage
+    Properties:
+      ApiId: !Ref WebSocketApi
+      StageName: !Ref StageName
+      DeploymentId: !Ref WsDeployment
+      DefaultRouteSettings:
+        DataTraceEnabled: false
+        DetailedMetricsEnabled: true
+        LoggingLevel: INFO
+
+Outputs:
+  WebSocketUrl:
+    Description: WebSocket URL to pass to the rustyant Python client.
+    Value: !Sub 'wss://${WebSocketApi}.execute-api.${AWS::Region}.amazonaws.com/${StageName}'
+    Export:
+      Name: !Sub '${AWS::StackName}-ws-url'
+
+  WsFunctionArn:
+    Description: ARN of the rustyant-ws Lambda.
+    Value: !GetAtt WsFunction.Arn
+
+  BucketName:
+    Description: S3 bucket backing KV storage.
+    Value: !Ref Bucket

--- a/justfile
+++ b/justfile
@@ -107,3 +107,28 @@ lambda-watch:
 
 lambda-deploy FUNCTION="rant-rustyant":
     cargo lambda deploy {{FUNCTION}}
+
+# ---- SAM / CloudFormation (WebSocket transport) ----
+# Requires the `sam` CLI (https://docs.aws.amazon.com/serverless-application-model/).
+# Uses the rust-cargolambda BuildMethod, which needs `--beta-features`.
+
+# Validate the template — catches syntax + IAM/reference errors without deploying.
+ws-template-validate:
+    sam validate --template-file infra/template.yaml --lint
+
+# Build the rustyant-ws Lambda artifact (runs cargo-lambda under the hood).
+ws-template-build:
+    sam build --template-file infra/template.yaml --beta-features
+
+# Deploy the WebSocket stack. Pass BUCKET=<globally-unique-name> on first use.
+# STACK defaults match the dev account convention (`rant-*`).
+ws-template-deploy STACK="rant-rustyant-ws" BUCKET="":
+    sam deploy --template-file .aws-sam/build/template.yaml \
+        --stack-name {{STACK}} \
+        --capabilities CAPABILITY_IAM \
+        --resolve-s3 \
+        --parameter-overrides BucketName={{BUCKET}}
+
+# Remove the deployed stack (destructive — empties the bucket first).
+ws-template-destroy STACK="rant-rustyant-ws":
+    sam delete --stack-name {{STACK}} --no-prompts

--- a/src/bin/ws.rs
+++ b/src/bin/ws.rs
@@ -1,0 +1,74 @@
+//! Lambda entry point for the API Gateway WebSocket transport.
+//!
+//! Wraps `rustyant::ws::handle` with:
+//!   * the AWS SDK client for the API Gateway Management API (to post
+//!     replies back on the same WebSocket connection), and
+//!   * the Lambda runtime bridge that deserializes events.
+
+use aws_lambda_events::apigw::{ApiGatewayProxyResponse, ApiGatewayWebsocketProxyRequest};
+use aws_sdk_apigatewaymanagement::Client as MgmtClient;
+use aws_sdk_apigatewaymanagement::primitives::Blob;
+use lambda_runtime::{Error, LambdaEvent, service_fn};
+use tracing::{error, warn};
+
+use rustyant::State;
+use rustyant::ws::{WsOutcome, handle};
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    rustyant::init_tracing();
+    let state = State::from_env().await?;
+    let aws_config = aws_config::load_from_env().await;
+
+    lambda_runtime::run(service_fn(move |ev: LambdaEvent<ApiGatewayWebsocketProxyRequest>| {
+        let state = state.clone();
+        let aws_config = aws_config.clone();
+        async move { handle_event(state, aws_config, ev.payload).await }
+    }))
+    .await
+}
+
+#[allow(clippy::similar_names)] // `state` vs `stage` is unavoidable here
+async fn handle_event(
+    state: State,
+    aws_config: aws_config::SdkConfig,
+    event: ApiGatewayWebsocketProxyRequest,
+) -> Result<ApiGatewayProxyResponse, Error> {
+    let domain_name = event.request_context.domain_name.clone();
+    let stage = event.request_context.stage.clone();
+
+    let outcome = match handle(&state, event).await {
+        Ok(o) => o,
+        Err(e) => {
+            error!(error = %e, "ws handler transport error");
+            return Ok(response(500));
+        }
+    };
+
+    if let WsOutcome::Reply { connection_id, data } = outcome {
+        let Some(domain) = domain_name else {
+            warn!("reply requested but no domain_name in context");
+            return Ok(response(500));
+        };
+        let Some(stage) = stage else {
+            warn!("reply requested but no stage in context");
+            return Ok(response(500));
+        };
+        let endpoint = format!("https://{domain}/{stage}");
+
+        let mgmt_config =
+            aws_sdk_apigatewaymanagement::config::Builder::from(&aws_config).endpoint_url(endpoint).build();
+        let mgmt = MgmtClient::from_conf(mgmt_config);
+
+        if let Err(e) = mgmt.post_to_connection().connection_id(connection_id).data(Blob::new(data)).send().await {
+            error!(error = %e, "post_to_connection failed");
+            return Ok(response(500));
+        }
+    }
+
+    Ok(response(200))
+}
+
+fn response(status: i64) -> ApiGatewayProxyResponse {
+    ApiGatewayProxyResponse { status_code: status, ..ApiGatewayProxyResponse::default() }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod resp;
 pub mod settings;
 pub mod state;
 pub mod storage;
+pub mod ws;
 
 pub use error::{Result, RustyAntError};
 pub use settings::Settings;

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -1,0 +1,202 @@
+//! API Gateway WebSocket event handler.
+//!
+//! Each inbound WS frame arrives here as an `ApiGatewayWebsocketProxyRequest`.
+//! This module is transport-pure: it returns a [`WsOutcome`] describing what
+//! the Lambda should do next. The binary (`src/bin/ws.rs`) owns the AWS SDK
+//! client that actually posts replies back via the API Gateway Management API
+//! — keeping this module testable without network calls.
+
+use aws_lambda_events::apigw::ApiGatewayWebsocketProxyRequest;
+use base64::Engine;
+
+use crate::commands;
+use crate::resp;
+use crate::state::State;
+
+/// What the caller should do with the result of handling one event.
+#[derive(Debug)]
+pub enum WsOutcome {
+    /// Control-plane event ($connect, $disconnect) — nothing to send back.
+    Empty,
+    /// Data-plane event — post `data` back to `connection_id` via the
+    /// API Gateway Management API.
+    Reply { connection_id: String, data: Vec<u8> },
+}
+
+/// Route-key classification. API Gateway sets the route for $connect,
+/// $disconnect, and $default (messages). Anything else is treated as a
+/// message for forward compatibility.
+fn is_control_route(route_key: Option<&str>) -> bool {
+    matches!(route_key, Some("$connect" | "$disconnect"))
+}
+
+fn decode_body(body: Option<String>, is_base64: bool) -> Result<Vec<u8>, String> {
+    let body = body.unwrap_or_default();
+    if is_base64 {
+        base64::engine::general_purpose::STANDARD.decode(body).map_err(|e| format!("base64 decode: {e}"))
+    } else {
+        Ok(body.into_bytes())
+    }
+}
+
+/// Handle one WebSocket event.
+///
+/// Never returns an error for command-level failures — those are returned to
+/// the client as a RESP `-ERR` reply. Only transport/infrastructure failures
+/// (missing `connection_id`, invalid base64 body) produce `Err`, which the
+/// binary converts to a 500 response.
+pub async fn handle(state: &State, event: ApiGatewayWebsocketProxyRequest) -> Result<WsOutcome, String> {
+    let ctx = event.request_context;
+
+    if is_control_route(ctx.route_key.as_deref()) {
+        return Ok(WsOutcome::Empty);
+    }
+
+    let connection_id = ctx.connection_id.ok_or_else(|| "missing connection_id in request context".to_string())?;
+
+    let bytes = decode_body(event.body, event.is_base64_encoded)?;
+
+    let reply = match resp::parse_command(&bytes) {
+        Ok(argv) => commands::dispatch(state, argv).await,
+        Err(e) => resp::RespReply::err(format!("PARSE {e}")),
+    };
+
+    let encoded = reply.encode().map_err(|e| format!("encode reply: {e}"))?;
+
+    Ok(WsOutcome::Reply { connection_id, data: encoded.to_vec() })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use aws_lambda_events::apigw::ApiGatewayWebsocketProxyRequestContext;
+
+    use super::*;
+    use crate::Settings;
+    use crate::storage::InMemoryStorage;
+
+    fn test_state() -> State {
+        let settings = Settings {
+            bucket: "test".to_string(),
+            key_prefix: "t/".to_string(),
+            aws_region: None,
+            aws_endpoint_url: None,
+        };
+        State::with_storage(settings, Arc::new(InMemoryStorage::new()))
+    }
+
+    fn ws_event(route: &str, body: Option<&str>, is_base64: bool) -> ApiGatewayWebsocketProxyRequest {
+        let ctx = ApiGatewayWebsocketProxyRequestContext {
+            route_key: Some(route.to_string()),
+            connection_id: Some("conn-1".to_string()),
+            domain_name: Some("example.execute-api.us-east-1.amazonaws.com".to_string()),
+            stage: Some("prod".to_string()),
+            ..ApiGatewayWebsocketProxyRequestContext::default()
+        };
+        ApiGatewayWebsocketProxyRequest {
+            request_context: ctx,
+            body: body.map(String::from),
+            is_base64_encoded: is_base64,
+            ..ApiGatewayWebsocketProxyRequest::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn connect_route_returns_empty() {
+        let state = test_state();
+        let ev = ws_event("$connect", None, false);
+        let out = handle(&state, ev).await.expect("ok");
+        assert!(matches!(out, WsOutcome::Empty));
+    }
+
+    #[tokio::test]
+    async fn disconnect_route_returns_empty() {
+        let state = test_state();
+        let ev = ws_event("$disconnect", None, false);
+        let out = handle(&state, ev).await.expect("ok");
+        assert!(matches!(out, WsOutcome::Empty));
+    }
+
+    #[tokio::test]
+    async fn ping_yields_pong_reply() {
+        let state = test_state();
+        let ev = ws_event("$default", Some("*1\r\n$4\r\nPING\r\n"), false);
+        let out = handle(&state, ev).await.expect("ok");
+        match out {
+            WsOutcome::Reply { connection_id, data } => {
+                assert_eq!(connection_id, "conn-1");
+                assert_eq!(&data, b"+PONG\r\n");
+            }
+            WsOutcome::Empty => panic!("expected reply"),
+        }
+    }
+
+    #[tokio::test]
+    async fn set_and_get_roundtrip_through_ws() {
+        let state = test_state();
+
+        let set_body = "*3\r\n$3\r\nSET\r\n$1\r\nk\r\n$1\r\nv\r\n";
+        let set_out = handle(&state, ws_event("$default", Some(set_body), false)).await.expect("set ok");
+        match set_out {
+            WsOutcome::Reply { data, .. } => assert_eq!(&data, b"+OK\r\n"),
+            WsOutcome::Empty => panic!("expected reply"),
+        }
+
+        let get_body = "*2\r\n$3\r\nGET\r\n$1\r\nk\r\n";
+        let get_out = handle(&state, ws_event("$default", Some(get_body), false)).await.expect("get ok");
+        match get_out {
+            WsOutcome::Reply { data, .. } => assert_eq!(&data, b"$1\r\nv\r\n"),
+            WsOutcome::Empty => panic!("expected reply"),
+        }
+    }
+
+    #[tokio::test]
+    async fn base64_body_is_decoded() {
+        let state = test_state();
+        // base64 of "*1\r\n$4\r\nPING\r\n"
+        let b64 = base64::engine::general_purpose::STANDARD.encode(b"*1\r\n$4\r\nPING\r\n");
+        let out = handle(&state, ws_event("$default", Some(&b64), true)).await.expect("ok");
+        match out {
+            WsOutcome::Reply { data, .. } => assert_eq!(&data, b"+PONG\r\n"),
+            WsOutcome::Empty => panic!("expected reply"),
+        }
+    }
+
+    #[tokio::test]
+    async fn malformed_body_returns_resp_error_not_http_failure() {
+        let state = test_state();
+        let out = handle(&state, ws_event("$default", Some("garbage"), false))
+            .await
+            .expect("should succeed at transport level");
+        match out {
+            WsOutcome::Reply { data, .. } => {
+                assert!(data.starts_with(b"-"), "expected RESP error, got {:?}", String::from_utf8_lossy(&data));
+            }
+            WsOutcome::Empty => panic!("expected reply"),
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_command_returns_resp_error() {
+        let state = test_state();
+        let body = "*1\r\n$4\r\nNOPE\r\n";
+        let out = handle(&state, ws_event("$default", Some(body), false)).await.expect("ok");
+        match out {
+            WsOutcome::Reply { data, .. } => {
+                assert!(data.starts_with(b"-"));
+                assert!(data.windows(3).any(|w| w == b"ERR"));
+            }
+            WsOutcome::Empty => panic!("expected reply"),
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_connection_id_is_transport_error() {
+        let state = test_state();
+        let mut ev = ws_event("$default", Some("*1\r\n$4\r\nPING\r\n"), false);
+        ev.request_context.connection_id = None;
+        let err = handle(&state, ev).await.expect_err("should fail");
+        assert!(err.contains("connection_id"));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `infra/template.yaml` — a SAM/CloudFormation template that deploys the full WebSocket stack (API Gateway WS, rustyant-ws Lambda, S3 bucket, IAM). Validated with `sam validate --lint`.
- Adds `just ws-template-{validate,build,deploy,destroy}` recipes.
- Bumps `actions/checkout@v4 → v5` and `actions/upload-artifact@v4 → v5` in the CI workflow to clear the Node.js 20 deprecation annotations.

## Depends on

Stacked on top of [#2](https://github.com/monkut/rustyant/pull/2) (the `rustyant-ws` binary). Merging this before #2 will leave the template referencing a binary that doesn't yet exist on main. Recommend merging #2 first, then this.

## What the template provisions

- `AWS::ApiGatewayV2::Api` (WebSocket protocol) with routes `$connect`, `$disconnect`, `$default` — all pointing at the single `rustyant-ws` Lambda
- `AWS::Serverless::Function` (Rust, arm64, provided.al2023) built by the `rust-cargolambda` BuildMethod
- `AWS::S3::Bucket` with AES256 encryption, versioning, and the public-access block
- IAM policy granting `execute-api:ManageConnections` (needed by the Lambda to send replies back via `@connections`) plus S3 CRUD via the `S3CrudPolicy` managed policy

Route selection expression is `\$request.body.action`. Since RESP frames carry no JSON `action` key, the expression never resolves to a defined route and traffic always falls through to `\$default`. That is what we want for a binary protocol.

Outputs: `WebSocketUrl` (ready to pass to the Python client), `WsFunctionArn`, `BucketName`.

## Test plan

- [x] `sam validate --template-file infra/template.yaml --lint` — template is valid
- [x] `cargo check --all-targets` — repo still compiles
- [ ] CI green on this PR
- [ ] Deferred: `sam build` + `sam deploy` against the dev account (manual; needs aws-vault profile)

## Not in scope

- No CI job running `sam validate` on every PR — easy to add (`aws-actions/setup-sam@v2` + one validate step) but I left it out to keep this PR focused.
- HTTP variant (Lambda URL) not included; deploy via `just lambda-deploy` against the existing `rustyant` binary as before.