### PR TITLE
chore: CI — add sam-validate + python-client jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,3 +110,31 @@ jobs:
           toolchain: ${{ steps.msrv.outputs.msrv }}
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --all-features --all-targets
+
+  sam-validate:
+    name: SAM template validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
+      - run: sam validate --template-file infra/template.yaml --lint
+
+  python-client:
+    name: Python client tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: clients/python
+    steps:
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      - name: Install python 3.12
+        run: uv python install 3.12
+      - name: Install package + dev deps
+        run: uv pip install --system -e '.[dev]'
+      - name: Run pytest
+        run: pytest tests/ -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,9 +132,9 @@ jobs:
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
-      - name: Install python 3.12
-        run: uv python install 3.12
-      - name: Install package + dev deps
-        run: uv pip install --system -e '.[dev]'
+      - name: Create venv + install package with dev extras
+        run: |
+          uv venv --python 3.12
+          uv pip install -e '.[dev]'
       - name: Run pytest
-        run: pytest tests/ -q
+        run: uv run pytest tests/ -q


### PR DESCRIPTION
## Summary

Two new CI jobs, both independent of the existing Rust matrix:

| Job | Does | Runtime |
|---|---|---|
| `sam-validate` | installs the SAM CLI via \`aws-actions/setup-sam@v2\` and runs \`sam validate --lint\` on \`infra/template.yaml\` | ~15s |
| \`python-client\` | installs \`clients/python/\` with dev extras via \`astral-sh/setup-uv@v6\` and runs \`pytest tests/\` | ~20s |

Catches template regressions and Python-client encoder regressions on every PR.

## Test plan

- [x] YAML parses (\`python -c \"import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))\"\`)
- [x] Local \`sam validate --lint infra/template.yaml\` passes
- [x] Local \`pytest tests/ -q\` in \`clients/python/\` passes (8/8)
- [ ] Both jobs green in this PR's CI run