### PR TITLE
feat: E2E WebSocket integration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,6 +776,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2096,14 +2102,16 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "bytes-utils",
+ "futures-util",
  "lambda_http",
  "lambda_runtime",
  "redis-protocol",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
+ "tokio-tungstenite",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2407,7 +2415,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2415,6 +2432,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2526,6 +2554,18 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -2660,6 +2700,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2700,6 +2757,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ thiserror = "1"
 
 [dev-dependencies]
 tempfile = "3"
+tokio-tungstenite = "0.28"
+futures-util = "0.3"
 
 # ----------------------------------------------------------------------------
 # Lints — rustc + clippy, surfaced in Cargo.toml (RFC 3389, stable since 1.74).

--- a/tests/ws_e2e.rs
+++ b/tests/ws_e2e.rs
@@ -1,0 +1,243 @@
+//! End-to-end WebSocket integration tests.
+//!
+//! Spawns a local TCP WebSocket server that stands in for API Gateway's
+//! WebSocket front-door: for each incoming WS frame it builds a synthetic
+//! `ApiGatewayWebsocketProxyRequest`, runs `rustyant::ws::handle` against
+//! shared state, and sends the reply back on the same connection. Uses
+//! `InMemoryStorage` so the tests are hermetic — no AWS, no floci.
+//!
+//! This closes the transport-level coverage gap left by `src/ws.rs::tests`:
+//! those tests call `handle` directly with hand-constructed events; here we
+//! round-trip real WebSocket frames over a TCP socket, which is what a
+//! redis-py-style client (or any `tokio-tungstenite`-based caller) actually
+//! does in production.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use aws_lambda_events::apigw::{ApiGatewayWebsocketProxyRequest, ApiGatewayWebsocketProxyRequestContext};
+use base64::Engine;
+use futures_util::{SinkExt, StreamExt};
+use rustyant::State;
+use rustyant::storage::InMemoryStorage;
+use rustyant::ws::{WsOutcome, handle};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{WebSocketStream, accept_async, connect_async};
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+fn test_state() -> State {
+    let settings = rustyant::Settings {
+        bucket: "test".to_string(),
+        key_prefix: "e2e/".to_string(),
+        aws_region: None,
+        aws_endpoint_url: None,
+    };
+    State::with_storage(settings, Arc::new(InMemoryStorage::new()))
+}
+
+/// Spin up a local WS server that mimics API Gateway. Returns the
+/// `ws://127.0.0.1:PORT` URL a test client should connect to.
+async fn spawn_ws_server(state: State) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr: SocketAddr = listener.local_addr().expect("local_addr");
+
+    tokio::spawn(async move {
+        let mut conn_counter: u64 = 0;
+        while let Ok((stream, _)) = listener.accept().await {
+            conn_counter += 1;
+            let conn_id = format!("sim-{conn_counter}");
+            let state = state.clone();
+            tokio::spawn(async move {
+                if let Ok(ws) = accept_async(stream).await {
+                    serve_connection(state, ws, conn_id).await;
+                }
+            });
+        }
+    });
+
+    format!("ws://{addr}")
+}
+
+async fn serve_connection(state: State, ws: WebSocketStream<TcpStream>, connection_id: String) {
+    let (mut sender, mut receiver) = ws.split();
+    while let Some(msg) = receiver.next().await {
+        let Ok(msg) = msg else { break };
+        let bytes = match msg {
+            Message::Binary(b) => b.to_vec(),
+            Message::Text(s) => s.as_str().as_bytes().to_vec(),
+            Message::Close(_) => break,
+            _ => continue,
+        };
+
+        let event = build_default_event(&connection_id, &bytes);
+        match handle(&state, event).await {
+            Ok(WsOutcome::Reply { data, .. }) => {
+                if sender.send(Message::Binary(data.into())).await.is_err() {
+                    break;
+                }
+            }
+            Ok(WsOutcome::Empty) => {}
+            Err(_) => break,
+        }
+    }
+}
+
+fn build_default_event(connection_id: &str, body: &[u8]) -> ApiGatewayWebsocketProxyRequest {
+    // API Gateway delivers binary WS frames as base64-encoded strings with
+    // is_base64_encoded=true. Mirror that here so the handler's decode path
+    // is exercised the same way as in production.
+    let b64 = base64::engine::general_purpose::STANDARD.encode(body);
+    let ctx = ApiGatewayWebsocketProxyRequestContext {
+        route_key: Some("$default".to_string()),
+        connection_id: Some(connection_id.to_string()),
+        domain_name: Some("sim.local".to_string()),
+        stage: Some("test".to_string()),
+        ..ApiGatewayWebsocketProxyRequestContext::default()
+    };
+    ApiGatewayWebsocketProxyRequest {
+        request_context: ctx,
+        body: Some(b64),
+        is_base64_encoded: true,
+        ..ApiGatewayWebsocketProxyRequest::default()
+    }
+}
+
+/// Connect to the simulator and return (sink, stream) halves.
+async fn connect(url: &str) -> WebSocketStream<tokio_tungstenite::MaybeTlsStream<TcpStream>> {
+    let (ws, _) = connect_async(url).await.expect("ws connect");
+    ws
+}
+
+/// Send one RESP command and receive one reply as raw bytes.
+async fn roundtrip(url: &str, command: &[u8]) -> Vec<u8> {
+    let mut ws = connect(url).await;
+    ws.send(Message::Binary(command.to_vec().into())).await.expect("send");
+    let msg = ws.next().await.expect("recv some").expect("recv ok");
+    match msg {
+        Message::Binary(b) => b.to_vec(),
+        Message::Text(s) => s.as_str().as_bytes().to_vec(),
+        other => panic!("unexpected frame: {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn ws_ping_returns_pong() {
+    let state = test_state();
+    let url = spawn_ws_server(state).await;
+    let reply = roundtrip(&url, b"*1\r\n$4\r\nPING\r\n").await;
+    assert_eq!(&reply, b"+PONG\r\n");
+}
+
+#[tokio::test]
+async fn ws_set_then_get_persists_across_frames() {
+    let state = test_state();
+    let url = spawn_ws_server(state).await;
+
+    // Two separate WS connections would break persistence because each
+    // connection gets a fresh dispatch chain — but the InMemoryStorage
+    // is shared through `state`, so state survives across connections.
+    let set = roundtrip(&url, b"*3\r\n$3\r\nSET\r\n$5\r\nhello\r\n$5\r\nworld\r\n").await;
+    assert_eq!(&set, b"+OK\r\n");
+
+    let got = roundtrip(&url, b"*2\r\n$3\r\nGET\r\n$5\r\nhello\r\n").await;
+    assert_eq!(&got, b"$5\r\nworld\r\n");
+}
+
+#[tokio::test]
+async fn ws_pipeline_three_commands_on_one_connection() {
+    let state = test_state();
+    let url = spawn_ws_server(state).await;
+    let mut ws = connect(&url).await;
+
+    let commands: &[&[u8]] = &[
+        b"*3\r\n$3\r\nSET\r\n$1\r\nk\r\n$1\r\n1\r\n",
+        b"*2\r\n$4\r\nINCR\r\n$1\r\nk\r\n",
+        b"*2\r\n$3\r\nGET\r\n$1\r\nk\r\n",
+    ];
+    for cmd in commands {
+        ws.send(Message::Binary(cmd.to_vec().into())).await.expect("send");
+    }
+
+    // Replies arrive in order on the same connection.
+    let expected: &[&[u8]] = &[b"+OK\r\n", b":2\r\n", b"$1\r\n2\r\n"];
+    for want in expected {
+        let msg = ws.next().await.expect("frame").expect("frame ok");
+        let bytes = match msg {
+            Message::Binary(b) => b.to_vec(),
+            other => panic!("unexpected: {other:?}"),
+        };
+        assert_eq!(&bytes, want);
+    }
+}
+
+#[tokio::test]
+async fn ws_hash_roundtrip() {
+    let state = test_state();
+    let url = spawn_ws_server(state).await;
+
+    let hset = roundtrip(&url, b"*6\r\n$4\r\nHSET\r\n$1\r\nh\r\n$1\r\na\r\n$2\r\nv1\r\n$1\r\nb\r\n$2\r\nv2\r\n").await;
+    assert_eq!(&hset, b":2\r\n");
+
+    let hgetall = roundtrip(&url, b"*2\r\n$7\r\nHGETALL\r\n$1\r\nh\r\n").await;
+    // BTreeMap → keys ascending: a, b.
+    assert_eq!(&hgetall, b"*4\r\n$1\r\na\r\n$2\r\nv1\r\n$1\r\nb\r\n$2\r\nv2\r\n");
+}
+
+#[tokio::test]
+async fn ws_preserves_binary_bytes_in_values() {
+    let state = test_state();
+    let url = spawn_ws_server(state).await;
+
+    // Value contains a NUL byte and a high byte — must survive the round trip
+    // intact (base64 transport handles non-UTF-8).
+    let binary_value = b"\x00\xff\x7f";
+    let mut cmd = Vec::new();
+    cmd.extend_from_slice(b"*3\r\n$3\r\nSET\r\n$1\r\nk\r\n$");
+    cmd.extend_from_slice(binary_value.len().to_string().as_bytes());
+    cmd.extend_from_slice(b"\r\n");
+    cmd.extend_from_slice(binary_value);
+    cmd.extend_from_slice(b"\r\n");
+    let set = roundtrip(&url, &cmd).await;
+    assert_eq!(&set, b"+OK\r\n");
+
+    let got = roundtrip(&url, b"*2\r\n$3\r\nGET\r\n$1\r\nk\r\n").await;
+    let mut expected = Vec::new();
+    expected.extend_from_slice(b"$");
+    expected.extend_from_slice(binary_value.len().to_string().as_bytes());
+    expected.extend_from_slice(b"\r\n");
+    expected.extend_from_slice(binary_value);
+    expected.extend_from_slice(b"\r\n");
+    assert_eq!(got, expected);
+}
+
+#[tokio::test]
+async fn ws_unknown_command_returns_resp_error_not_connection_close() {
+    let state = test_state();
+    let url = spawn_ws_server(state).await;
+    let mut ws = connect(&url).await;
+
+    ws.send(Message::Binary(b"*1\r\n$4\r\nNOPE\r\n".to_vec().into())).await.expect("send");
+    let first = ws.next().await.expect("frame").expect("ok");
+    let bytes = match first {
+        Message::Binary(b) => b.to_vec(),
+        other => panic!("unexpected: {other:?}"),
+    };
+    assert!(bytes.starts_with(b"-"), "expected RESP error, got {:?}", String::from_utf8_lossy(&bytes));
+
+    // Connection must still be usable afterwards.
+    ws.send(Message::Binary(b"*1\r\n$4\r\nPING\r\n".to_vec().into())).await.expect("send ping");
+    let pong = ws.next().await.expect("frame").expect("ok");
+    let pong_bytes = match pong {
+        Message::Binary(b) => b.to_vec(),
+        other => panic!("unexpected: {other:?}"),
+    };
+    assert_eq!(&pong_bytes, b"+PONG\r\n");
+}


### PR DESCRIPTION
## Summary

Adds a new test suite \`tests/ws_e2e.rs\` (6 tests) that drives RESP frames through a real WebSocket handshake and a real TCP socket rather than calling \`ws::handle\` with hand-built events.

## Harness

\`spawn_ws_server(state)\` binds an ephemeral TCP port and accepts WebSocket connections with \`tokio-tungstenite\`. For each inbound frame it constructs a synthetic \`ApiGatewayWebsocketProxyRequest\` with a base64-encoded body (matching what API Gateway actually delivers in production — \`is_base64_encoded: true\`) and runs it through the same \`ws::handle\` the Lambda binary uses. When \`handle\` returns \`WsOutcome::Reply\`, the bytes go back on the same WebSocket connection.

This closes the transport-level gap left by the unit tests — those construct events in-memory, these round-trip through real WS frames on a real socket, which is what any \`tokio-tungstenite\` (or \`redis-py\` via the WS client) caller does in production.

## Coverage

- \`ws_ping_returns_pong\` — smoke test
- \`ws_set_then_get_persists_across_frames\` — cross-connection state
- \`ws_pipeline_three_commands_on_one_connection\` — pipelining (SET + INCR + GET on one WS)
- \`ws_hash_roundtrip\` — multi-field HSET + HGETALL
- \`ws_preserves_binary_bytes_in_values\` — NUL + 0xFF bytes survive the base64 round trip
- \`ws_unknown_command_returns_resp_error_not_connection_close\` — connection stays usable after RESP \`-ERR\`

All backed by \`InMemoryStorage\` — hermetic, no floci, no AWS.

## Test plan

- [x] \`cargo test --test ws_e2e\` — 6 pass
- [x] \`cargo test --all-targets\` — 62 pass (16 lib units + 34 integration + 6 floci-gated + 6 new WS E2E)
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [ ] CI green on this PR

## Deps

\`tokio-tungstenite 0.28\` and \`futures-util 0.3\` added to \`[dev-dependencies]\`. Neither is linked into the production binaries.