### PR TITLE
feat: 11 new read-only Redis commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ Implemented:
 |---|---|
 | Server | `PING` |
 | Strings | `GET`, `SET` (+ `EX` / `PX` options), `DEL`, `EXISTS`, `EXPIRE`, `TTL`, `INCR`, `INCRBY` |
-| Hashes | `HSET`, `HGET`, `HDEL`, `HGETALL` |
-| Lists | `LPUSH`, `RPUSH`, `LPOP` (+ count), `RPOP` (+ count), `LRANGE` |
-| Sets | `SADD` |
-| Sorted Sets | `ZADD`, `ZRANGE` |
+| Hashes | `HSET`, `HGET`, `HDEL`, `HGETALL`, `HLEN`, `HKEYS`, `HVALS`, `HEXISTS`, `HMGET` |
+| Lists | `LPUSH`, `RPUSH`, `LPOP` (+ count), `RPOP` (+ count), `LRANGE`, `LLEN` |
+| Sets | `SADD`, `SMEMBERS`, `SISMEMBER`, `SCARD` |
+| Sorted Sets | `ZADD`, `ZRANGE`, `ZSCORE`, `ZCARD` |
 
-Not implemented (PRs welcome): `GETSET`, `MGET`, `MSET`, `SETNX`, `SETEX`, `PERSIST`, `KEYS`, `SCAN`, `HEXISTS`, `HKEYS`, `HVALS`, `HLEN`, `HINCRBY`, `LLEN`, `LINDEX`, `LSET`, `LREM`, `SREM`, `SMEMBERS`, `SISMEMBER`, `SCARD`, `ZREM`, `ZSCORE`, `ZINCRBY`, `ZRANGEBYSCORE`, `ZCARD`, and all pub/sub, transactions, scripting, streams, geo.
+Not implemented (PRs welcome): `GETSET`, `MGET`, `MSET`, `SETNX`, `SETEX`, `PERSIST`, `KEYS`, `SCAN`, `HINCRBY`, `LINDEX`, `LSET`, `LREM`, `SREM`, `ZREM`, `ZINCRBY`, `ZRANGEBYSCORE`, and all pub/sub, transactions, scripting, streams, geo.
 
 ### Concurrency
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -40,17 +40,28 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "HGET" => handle_hget(state, args).await,
         "HDEL" => handle_hdel(state, args).await,
         "HGETALL" => handle_hgetall(state, args).await,
+        "HLEN" => handle_hlen(state, args).await,
+        "HKEYS" => handle_hkeys(state, args).await,
+        "HVALS" => handle_hvals(state, args).await,
+        "HEXISTS" => handle_hexists(state, args).await,
+        "HMGET" => handle_hmget(state, args).await,
         // Lists
         "LPUSH" => handle_push(state, args, true).await,
         "RPUSH" => handle_push(state, args, false).await,
         "LPOP" => handle_pop(state, args, true).await,
         "RPOP" => handle_pop(state, args, false).await,
         "LRANGE" => handle_lrange(state, args).await,
+        "LLEN" => handle_llen(state, args).await,
         // Sets
         "SADD" => handle_sadd(state, args).await,
+        "SMEMBERS" => handle_smembers(state, args).await,
+        "SISMEMBER" => handle_sismember(state, args).await,
+        "SCARD" => handle_scard(state, args).await,
         // Sorted sets
         "ZADD" => handle_zadd(state, args).await,
         "ZRANGE" => handle_zrange(state, args).await,
+        "ZSCORE" => handle_zscore(state, args).await,
+        "ZCARD" => handle_zcard(state, args).await,
         other => Err(RustyAntError::UnknownCommand(other.to_string())),
     }
 }
@@ -299,4 +310,101 @@ async fn handle_zrange(state: &State, args: Vec<Bytes>) -> Result<RespReply, Rus
     Ok(RespReply::Array(
         members.into_iter().map(|m| RespReply::BulkString(Some(Bytes::from(m.into_bytes())))).collect(),
     ))
+}
+
+// ---- Additional read-only commands ----------------------------------------
+
+async fn handle_hlen(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("HLEN", args.len() == 1)?;
+    let n = state.storage.hlen(arg_as_str(&args[0])?).await?;
+    Ok(RespReply::Integer(n))
+}
+
+async fn handle_hkeys(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("HKEYS", args.len() == 1)?;
+    let keys = state.storage.hkeys(arg_as_str(&args[0])?).await?;
+    Ok(RespReply::Array(keys.into_iter().map(|k| RespReply::BulkString(Some(Bytes::from(k.into_bytes())))).collect()))
+}
+
+async fn handle_hvals(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("HVALS", args.len() == 1)?;
+    let vals = state.storage.hvals(arg_as_str(&args[0])?).await?;
+    Ok(RespReply::Array(vals.into_iter().map(|v| RespReply::BulkString(Some(v))).collect()))
+}
+
+async fn handle_hexists(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("HEXISTS", args.len() == 2)?;
+    let present = state.storage.hexists(arg_as_str(&args[0])?, arg_as_str(&args[1])?).await?;
+    Ok(RespReply::Integer(i64::from(present)))
+}
+
+async fn handle_hmget(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("HMGET", args.len() >= 2)?;
+    let key = arg_as_str(&args[0])?;
+    let fields: Vec<String> = args.iter().skip(1).map(arg_as_string).collect::<Result<_, _>>()?;
+    let vals = state.storage.hmget(key, &fields).await?;
+    Ok(RespReply::Array(
+        vals.into_iter().map(|v| v.map_or(RespReply::Nil, |b| RespReply::BulkString(Some(b)))).collect(),
+    ))
+}
+
+async fn handle_llen(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("LLEN", args.len() == 1)?;
+    let n = state.storage.llen(arg_as_str(&args[0])?).await?;
+    Ok(RespReply::Integer(n))
+}
+
+async fn handle_smembers(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("SMEMBERS", args.len() == 1)?;
+    let members = state.storage.smembers(arg_as_str(&args[0])?).await?;
+    Ok(RespReply::Array(
+        members.into_iter().map(|m| RespReply::BulkString(Some(Bytes::from(m.into_bytes())))).collect(),
+    ))
+}
+
+async fn handle_sismember(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("SISMEMBER", args.len() == 2)?;
+    let present = state.storage.sismember(arg_as_str(&args[0])?, arg_as_str(&args[1])?).await?;
+    Ok(RespReply::Integer(i64::from(present)))
+}
+
+async fn handle_scard(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("SCARD", args.len() == 1)?;
+    let n = state.storage.scard(arg_as_str(&args[0])?).await?;
+    Ok(RespReply::Integer(n))
+}
+
+async fn handle_zscore(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("ZSCORE", args.len() == 2)?;
+    let score = state.storage.zscore(arg_as_str(&args[0])?, arg_as_str(&args[1])?).await?;
+    Ok(score.map_or(RespReply::Nil, |s| {
+        // Redis returns scores as bulk strings using the canonical float format.
+        RespReply::BulkString(Some(Bytes::from(format_score(s).into_bytes())))
+    }))
+}
+
+async fn handle_zcard(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("ZCARD", args.len() == 1)?;
+    let n = state.storage.zcard(arg_as_str(&args[0])?).await?;
+    Ok(RespReply::Integer(n))
+}
+
+/// Match Redis's score formatting: integers as `"42"`, finite floats via
+/// their shortest round-trippable decimal, special values spelled out.
+fn format_score(s: f64) -> String {
+    if s.is_nan() {
+        return "nan".to_string();
+    }
+    if s.is_infinite() {
+        return (if s > 0.0 { "inf" } else { "-inf" }).to_string();
+    }
+    // Integer-valued scores inside i64 range → render without a decimal point.
+    // Casting through the safe integer window first keeps clippy's truncation
+    // lint satisfied.
+    if s.fract() == 0.0 && s.abs() < 9.007_199_254_740_992e15 {
+        #[allow(clippy::cast_possible_truncation)] // fract==0 && range checked
+        let as_int = s as i64;
+        return as_int.to_string();
+    }
+    format!("{s}")
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -122,15 +122,26 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn hget(&self, key: &str, field: &str) -> Result<Option<Bytes>, RustyAntError>;
     async fn hdel(&self, key: &str, fields: &[String]) -> Result<i64, RustyAntError>;
     async fn hgetall(&self, key: &str) -> Result<Vec<(String, Bytes)>, RustyAntError>;
+    async fn hlen(&self, key: &str) -> Result<i64, RustyAntError>;
+    async fn hkeys(&self, key: &str) -> Result<Vec<String>, RustyAntError>;
+    async fn hvals(&self, key: &str) -> Result<Vec<Bytes>, RustyAntError>;
+    async fn hexists(&self, key: &str, field: &str) -> Result<bool, RustyAntError>;
+    async fn hmget(&self, key: &str, fields: &[String]) -> Result<Vec<Option<Bytes>>, RustyAntError>;
 
     async fn list_push(&self, key: &str, values: Vec<Bytes>, left: bool) -> Result<i64, RustyAntError>;
     async fn list_pop(&self, key: &str, count: usize, left: bool) -> Result<Vec<Bytes>, RustyAntError>;
     async fn lrange(&self, key: &str, start: i64, stop: i64) -> Result<Vec<Bytes>, RustyAntError>;
+    async fn llen(&self, key: &str) -> Result<i64, RustyAntError>;
 
     async fn sadd(&self, key: &str, members: Vec<String>) -> Result<i64, RustyAntError>;
+    async fn smembers(&self, key: &str) -> Result<Vec<String>, RustyAntError>;
+    async fn sismember(&self, key: &str, member: &str) -> Result<bool, RustyAntError>;
+    async fn scard(&self, key: &str) -> Result<i64, RustyAntError>;
 
     async fn zadd(&self, key: &str, pairs: Vec<(f64, String)>) -> Result<i64, RustyAntError>;
     async fn zrange(&self, key: &str, start: i64, stop: i64) -> Result<Vec<String>, RustyAntError>;
+    async fn zscore(&self, key: &str, member: &str) -> Result<Option<f64>, RustyAntError>;
+    async fn zcard(&self, key: &str) -> Result<i64, RustyAntError>;
 }
 
 // ---------------------------------------------------------------------------
@@ -518,6 +529,96 @@ impl Storage for S3Storage {
         };
         Ok(sorted[s..=e].iter().map(|(m, _)| m.clone()).collect())
     }
+
+    async fn hlen(&self, key: &str) -> Result<i64, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::Hash(m), .. }) => Ok(i64::try_from(m.len()).unwrap_or(i64::MAX)),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(0),
+        }
+    }
+
+    async fn hkeys(&self, key: &str) -> Result<Vec<String>, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::Hash(m), .. }) => Ok(m.into_keys().collect()),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(Vec::new()),
+        }
+    }
+
+    async fn hvals(&self, key: &str) -> Result<Vec<Bytes>, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::Hash(m), .. }) => Ok(m.into_values().map(Bytes::from).collect()),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(Vec::new()),
+        }
+    }
+
+    async fn hexists(&self, key: &str, field: &str) -> Result<bool, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::Hash(m), .. }) => Ok(m.contains_key(field)),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(false),
+        }
+    }
+
+    async fn hmget(&self, key: &str, fields: &[String]) -> Result<Vec<Option<Bytes>>, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::Hash(m), .. }) => {
+                Ok(fields.iter().map(|f| m.get(f).map(|v| Bytes::from(v.clone()))).collect())
+            }
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(fields.iter().map(|_| None).collect()),
+        }
+    }
+
+    async fn llen(&self, key: &str) -> Result<i64, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::List(l), .. }) => Ok(i64::try_from(l.len()).unwrap_or(i64::MAX)),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(0),
+        }
+    }
+
+    async fn smembers(&self, key: &str) -> Result<Vec<String>, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::Set(s), .. }) => Ok(s.into_iter().collect()),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(Vec::new()),
+        }
+    }
+
+    async fn sismember(&self, key: &str, member: &str) -> Result<bool, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::Set(s), .. }) => Ok(s.contains(member)),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(false),
+        }
+    }
+
+    async fn scard(&self, key: &str) -> Result<i64, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::Set(s), .. }) => Ok(i64::try_from(s.len()).unwrap_or(i64::MAX)),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(0),
+        }
+    }
+
+    async fn zscore(&self, key: &str, member: &str) -> Result<Option<f64>, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::ZSet(m), .. }) => Ok(m.get(member).copied()),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(None),
+        }
+    }
+
+    async fn zcard(&self, key: &str) -> Result<i64, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::ZSet(m), .. }) => Ok(i64::try_from(m.len()).unwrap_or(i64::MAX)),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(0),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -800,6 +901,96 @@ impl Storage for InMemoryStorage {
             return Ok(Vec::new());
         };
         Ok(sorted[s..=e].iter().map(|(m, _)| m.clone()).collect())
+    }
+
+    async fn hlen(&self, key: &str) -> Result<i64, RustyAntError> {
+        match self.load(key) {
+            Some(StoredValue { value: Value::Hash(m), .. }) => Ok(i64::try_from(m.len()).unwrap_or(i64::MAX)),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(0),
+        }
+    }
+
+    async fn hkeys(&self, key: &str) -> Result<Vec<String>, RustyAntError> {
+        match self.load(key) {
+            Some(StoredValue { value: Value::Hash(m), .. }) => Ok(m.into_keys().collect()),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(Vec::new()),
+        }
+    }
+
+    async fn hvals(&self, key: &str) -> Result<Vec<Bytes>, RustyAntError> {
+        match self.load(key) {
+            Some(StoredValue { value: Value::Hash(m), .. }) => Ok(m.into_values().map(Bytes::from).collect()),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(Vec::new()),
+        }
+    }
+
+    async fn hexists(&self, key: &str, field: &str) -> Result<bool, RustyAntError> {
+        match self.load(key) {
+            Some(StoredValue { value: Value::Hash(m), .. }) => Ok(m.contains_key(field)),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(false),
+        }
+    }
+
+    async fn hmget(&self, key: &str, fields: &[String]) -> Result<Vec<Option<Bytes>>, RustyAntError> {
+        match self.load(key) {
+            Some(StoredValue { value: Value::Hash(m), .. }) => {
+                Ok(fields.iter().map(|f| m.get(f).map(|v| Bytes::from(v.clone()))).collect())
+            }
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(fields.iter().map(|_| None).collect()),
+        }
+    }
+
+    async fn llen(&self, key: &str) -> Result<i64, RustyAntError> {
+        match self.load(key) {
+            Some(StoredValue { value: Value::List(l), .. }) => Ok(i64::try_from(l.len()).unwrap_or(i64::MAX)),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(0),
+        }
+    }
+
+    async fn smembers(&self, key: &str) -> Result<Vec<String>, RustyAntError> {
+        match self.load(key) {
+            Some(StoredValue { value: Value::Set(s), .. }) => Ok(s.into_iter().collect()),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(Vec::new()),
+        }
+    }
+
+    async fn sismember(&self, key: &str, member: &str) -> Result<bool, RustyAntError> {
+        match self.load(key) {
+            Some(StoredValue { value: Value::Set(s), .. }) => Ok(s.contains(member)),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(false),
+        }
+    }
+
+    async fn scard(&self, key: &str) -> Result<i64, RustyAntError> {
+        match self.load(key) {
+            Some(StoredValue { value: Value::Set(s), .. }) => Ok(i64::try_from(s.len()).unwrap_or(i64::MAX)),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(0),
+        }
+    }
+
+    async fn zscore(&self, key: &str, member: &str) -> Result<Option<f64>, RustyAntError> {
+        match self.load(key) {
+            Some(StoredValue { value: Value::ZSet(m), .. }) => Ok(m.get(member).copied()),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(None),
+        }
+    }
+
+    async fn zcard(&self, key: &str) -> Result<i64, RustyAntError> {
+        match self.load(key) {
+            Some(StoredValue { value: Value::ZSet(m), .. }) => Ok(i64::try_from(m.len()).unwrap_or(i64::MAX)),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(0),
+        }
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -417,6 +417,124 @@ async fn zadd_odd_args_errors() {
     call(&state, &[b"ZADD", b"z", b"1"]).await.expect_error_prefix("ERR");
 }
 
+// ---------------------------------------------------------------------------
+// Additional read-only commands (HLEN / HKEYS / HVALS / HEXISTS / HMGET,
+// LLEN, SMEMBERS / SISMEMBER / SCARD, ZSCORE / ZCARD)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn hlen_counts_fields() {
+    let state = test_state();
+    call(&state, &[b"HLEN", b"missing"]).await.expect_integer(0);
+    call(&state, &[b"HSET", b"h", b"a", b"1", b"b", b"2", b"c", b"3"]).await;
+    call(&state, &[b"HLEN", b"h"]).await.expect_integer(3);
+}
+
+#[tokio::test]
+async fn hkeys_returns_field_names_sorted() {
+    let state = test_state();
+    call(&state, &[b"HSET", b"h", b"b", b"2", b"a", b"1"]).await;
+    let items = call(&state, &[b"HKEYS", b"h"]).await.into_bulk_array();
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0].as_ref(), b"a");
+    assert_eq!(items[1].as_ref(), b"b");
+}
+
+#[tokio::test]
+async fn hvals_returns_values() {
+    let state = test_state();
+    call(&state, &[b"HSET", b"h", b"a", b"x", b"b", b"y"]).await;
+    let items = call(&state, &[b"HVALS", b"h"]).await.into_bulk_array();
+    assert_eq!(items.len(), 2);
+    // Keys are BTreeMap-ordered (a, b); values follow the same order.
+    assert_eq!(items[0].as_ref(), b"x");
+    assert_eq!(items[1].as_ref(), b"y");
+}
+
+#[tokio::test]
+async fn hexists_returns_0_or_1() {
+    let state = test_state();
+    call(&state, &[b"HSET", b"h", b"name", b"alice"]).await;
+    call(&state, &[b"HEXISTS", b"h", b"name"]).await.expect_integer(1);
+    call(&state, &[b"HEXISTS", b"h", b"missing"]).await.expect_integer(0);
+    call(&state, &[b"HEXISTS", b"nope", b"field"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn hmget_returns_nil_for_missing_fields() {
+    let state = test_state();
+    call(&state, &[b"HSET", b"h", b"a", b"1", b"c", b"3"]).await;
+    let raw = call(&state, &[b"HMGET", b"h", b"a", b"b", b"c"]).await.raw;
+    // Array of 3: bulk "1", nil, bulk "3"
+    assert_eq!(&raw, b"*3\r\n$1\r\n1\r\n$-1\r\n$1\r\n3\r\n");
+}
+
+#[tokio::test]
+async fn llen_counts_elements() {
+    let state = test_state();
+    call(&state, &[b"LLEN", b"missing"]).await.expect_integer(0);
+    call(&state, &[b"RPUSH", b"l", b"a", b"b", b"c"]).await;
+    call(&state, &[b"LLEN", b"l"]).await.expect_integer(3);
+    call(&state, &[b"LPOP", b"l"]).await;
+    call(&state, &[b"LLEN", b"l"]).await.expect_integer(2);
+}
+
+#[tokio::test]
+async fn smembers_returns_all() {
+    let state = test_state();
+    call(&state, &[b"SADD", b"s", b"z", b"a", b"m"]).await;
+    let items = call(&state, &[b"SMEMBERS", b"s"]).await.into_bulk_array();
+    assert_eq!(items.len(), 3);
+    // BTreeSet ordering → alphabetical.
+    assert_eq!(items[0].as_ref(), b"a");
+    assert_eq!(items[1].as_ref(), b"m");
+    assert_eq!(items[2].as_ref(), b"z");
+}
+
+#[tokio::test]
+async fn sismember_returns_0_or_1() {
+    let state = test_state();
+    call(&state, &[b"SADD", b"s", b"alice", b"bob"]).await;
+    call(&state, &[b"SISMEMBER", b"s", b"alice"]).await.expect_integer(1);
+    call(&state, &[b"SISMEMBER", b"s", b"carol"]).await.expect_integer(0);
+    call(&state, &[b"SISMEMBER", b"nope", b"x"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn scard_counts_members() {
+    let state = test_state();
+    call(&state, &[b"SCARD", b"missing"]).await.expect_integer(0);
+    call(&state, &[b"SADD", b"s", b"a", b"b", b"c", b"a"]).await;
+    call(&state, &[b"SCARD", b"s"]).await.expect_integer(3);
+}
+
+#[tokio::test]
+async fn zscore_returns_score_or_nil() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"a", b"2.5", b"b"]).await;
+    call(&state, &[b"ZSCORE", b"z", b"a"]).await.expect_bulk(b"1");
+    call(&state, &[b"ZSCORE", b"z", b"b"]).await.expect_bulk(b"2.5");
+    call(&state, &[b"ZSCORE", b"z", b"missing"]).await.expect_nil();
+    call(&state, &[b"ZSCORE", b"nope", b"m"]).await.expect_nil();
+}
+
+#[tokio::test]
+async fn zcard_counts_members() {
+    let state = test_state();
+    call(&state, &[b"ZCARD", b"missing"]).await.expect_integer(0);
+    call(&state, &[b"ZADD", b"z", b"1", b"a", b"2", b"b", b"3", b"c"]).await;
+    call(&state, &[b"ZCARD", b"z"]).await.expect_integer(3);
+}
+
+#[tokio::test]
+async fn new_read_commands_all_error_on_wrong_type() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    for cmd in [b"HLEN" as &[u8], b"HKEYS", b"HVALS", b"LLEN", b"SMEMBERS", b"SCARD", b"ZCARD"] {
+        call(&state, &[cmd, b"k"]).await.expect_error_prefix("ERR");
+    }
+}
+
 // Use RespReply publicly to check the crate re-export surface compiles.
 #[test]
 fn reply_encode_simple_works_from_tests() {


### PR DESCRIPTION
## Summary

Adds eleven read-only commands to close the most-requested gaps in the command surface:

| Group | Commands added |
|---|---|
| Hashes | \`HLEN\`, \`HKEYS\`, \`HVALS\`, \`HEXISTS\`, \`HMGET\` |
| Lists | \`LLEN\` |
| Sets | \`SMEMBERS\`, \`SISMEMBER\`, \`SCARD\` |
| Sorted sets | \`ZSCORE\`, \`ZCARD\` |

All are pure reads — no CAS retry loop needed, no new race to reason about. Each method loads the entry, extracts what the command needs, and returns it (or the type-appropriate empty value for a missing key). WRONGTYPE errors on existing keys of the wrong kind behave identically to the existing read commands.

\`ZSCORE\` uses a Redis-matching score formatter: integer-valued scores render as \`\"42\"\`, finite floats use their shortest round-trippable decimal, and \`inf\` / \`-inf\` / \`nan\` are spelled out.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo test --all-targets\` — 75 pass (up from 63). 12 new handler tests in \`tests/integration.rs\` cover every new command plus a batch WRONGTYPE check
- [ ] CI green on this PR

## Follow-ups (not in this PR)

Mutating additions still missing: \`HINCRBY\`, \`SREM\`, \`ZREM\`, \`ZINCRBY\`. Each is one more \`self.cas\` call with a trivial closure. Can land in a single follow-up.