### PR TITLE
feat: add HINCRBY, SREM, ZREM, ZINCRBY

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ Implemented:
 |---|---|
 | Server | `PING` |
 | Strings | `GET`, `SET` (+ `EX` / `PX` options), `DEL`, `EXISTS`, `EXPIRE`, `TTL`, `INCR`, `INCRBY` |
-| Hashes | `HSET`, `HGET`, `HDEL`, `HGETALL`, `HLEN`, `HKEYS`, `HVALS`, `HEXISTS`, `HMGET` |
+| Hashes | `HSET`, `HGET`, `HDEL`, `HGETALL`, `HLEN`, `HKEYS`, `HVALS`, `HEXISTS`, `HMGET`, `HINCRBY` |
 | Lists | `LPUSH`, `RPUSH`, `LPOP` (+ count), `RPOP` (+ count), `LRANGE`, `LLEN` |
-| Sets | `SADD`, `SMEMBERS`, `SISMEMBER`, `SCARD` |
-| Sorted Sets | `ZADD`, `ZRANGE`, `ZSCORE`, `ZCARD` |
+| Sets | `SADD`, `SREM`, `SMEMBERS`, `SISMEMBER`, `SCARD` |
+| Sorted Sets | `ZADD`, `ZREM`, `ZINCRBY`, `ZRANGE`, `ZSCORE`, `ZCARD` |
 
-Not implemented (PRs welcome): `GETSET`, `MGET`, `MSET`, `SETNX`, `SETEX`, `PERSIST`, `KEYS`, `SCAN`, `HINCRBY`, `LINDEX`, `LSET`, `LREM`, `SREM`, `ZREM`, `ZINCRBY`, `ZRANGEBYSCORE`, and all pub/sub, transactions, scripting, streams, geo.
+Not implemented (PRs welcome): `GETSET`, `MGET`, `MSET`, `SETNX`, `SETEX`, `PERSIST`, `KEYS`, `SCAN`, `LINDEX`, `LSET`, `LREM`, `ZRANGEBYSCORE`, and all pub/sub, transactions, scripting, streams, geo.
 
 ### Concurrency
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -45,6 +45,7 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "HVALS" => handle_hvals(state, args).await,
         "HEXISTS" => handle_hexists(state, args).await,
         "HMGET" => handle_hmget(state, args).await,
+        "HINCRBY" => handle_hincrby(state, args).await,
         // Lists
         "LPUSH" => handle_push(state, args, true).await,
         "RPUSH" => handle_push(state, args, false).await,
@@ -54,11 +55,14 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "LLEN" => handle_llen(state, args).await,
         // Sets
         "SADD" => handle_sadd(state, args).await,
+        "SREM" => handle_srem(state, args).await,
         "SMEMBERS" => handle_smembers(state, args).await,
         "SISMEMBER" => handle_sismember(state, args).await,
         "SCARD" => handle_scard(state, args).await,
         // Sorted sets
         "ZADD" => handle_zadd(state, args).await,
+        "ZREM" => handle_zrem(state, args).await,
+        "ZINCRBY" => handle_zincrby(state, args).await,
         "ZRANGE" => handle_zrange(state, args).await,
         "ZSCORE" => handle_zscore(state, args).await,
         "ZCARD" => handle_zcard(state, args).await,
@@ -387,6 +391,42 @@ async fn handle_zcard(state: &State, args: Vec<Bytes>) -> Result<RespReply, Rust
     arity("ZCARD", args.len() == 1)?;
     let n = state.storage.zcard(arg_as_str(&args[0])?).await?;
     Ok(RespReply::Integer(n))
+}
+
+// ---- Additional mutating commands -----------------------------------------
+
+async fn handle_hincrby(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("HINCRBY", args.len() == 3)?;
+    let key = arg_as_str(&args[0])?;
+    let field = arg_as_str(&args[1])?;
+    let delta = parse_i64(&args[2], "increment")?;
+    let new_val = state.storage.hincr_by(key, field, delta).await?;
+    Ok(RespReply::Integer(new_val))
+}
+
+async fn handle_srem(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("SREM", args.len() >= 2)?;
+    let key = arg_as_str(&args[0])?;
+    let members: Vec<String> = args.iter().skip(1).map(arg_as_string).collect::<Result<_, _>>()?;
+    let removed = state.storage.srem(key, &members).await?;
+    Ok(RespReply::Integer(removed))
+}
+
+async fn handle_zrem(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("ZREM", args.len() >= 2)?;
+    let key = arg_as_str(&args[0])?;
+    let members: Vec<String> = args.iter().skip(1).map(arg_as_string).collect::<Result<_, _>>()?;
+    let removed = state.storage.zrem(key, &members).await?;
+    Ok(RespReply::Integer(removed))
+}
+
+async fn handle_zincrby(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("ZINCRBY", args.len() == 3)?;
+    let key = arg_as_str(&args[0])?;
+    let delta = parse_f64(&args[1], "increment")?;
+    let member = arg_as_str(&args[2])?;
+    let new_score = state.storage.zincr_by(key, member, delta).await?;
+    Ok(RespReply::BulkString(Some(Bytes::from(format_score(new_score).into_bytes()))))
 }
 
 /// Match Redis's score formatting: integers as `"42"`, finite floats via

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -127,6 +127,7 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn hvals(&self, key: &str) -> Result<Vec<Bytes>, RustyAntError>;
     async fn hexists(&self, key: &str, field: &str) -> Result<bool, RustyAntError>;
     async fn hmget(&self, key: &str, fields: &[String]) -> Result<Vec<Option<Bytes>>, RustyAntError>;
+    async fn hincr_by(&self, key: &str, field: &str, delta: i64) -> Result<i64, RustyAntError>;
 
     async fn list_push(&self, key: &str, values: Vec<Bytes>, left: bool) -> Result<i64, RustyAntError>;
     async fn list_pop(&self, key: &str, count: usize, left: bool) -> Result<Vec<Bytes>, RustyAntError>;
@@ -134,11 +135,14 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn llen(&self, key: &str) -> Result<i64, RustyAntError>;
 
     async fn sadd(&self, key: &str, members: Vec<String>) -> Result<i64, RustyAntError>;
+    async fn srem(&self, key: &str, members: &[String]) -> Result<i64, RustyAntError>;
     async fn smembers(&self, key: &str) -> Result<Vec<String>, RustyAntError>;
     async fn sismember(&self, key: &str, member: &str) -> Result<bool, RustyAntError>;
     async fn scard(&self, key: &str) -> Result<i64, RustyAntError>;
 
     async fn zadd(&self, key: &str, pairs: Vec<(f64, String)>) -> Result<i64, RustyAntError>;
+    async fn zrem(&self, key: &str, members: &[String]) -> Result<i64, RustyAntError>;
+    async fn zincr_by(&self, key: &str, member: &str, delta: f64) -> Result<f64, RustyAntError>;
     async fn zrange(&self, key: &str, start: i64, stop: i64) -> Result<Vec<String>, RustyAntError>;
     async fn zscore(&self, key: &str, member: &str) -> Result<Option<f64>, RustyAntError>;
     async fn zcard(&self, key: &str) -> Result<i64, RustyAntError>;
@@ -619,6 +623,100 @@ impl Storage for S3Storage {
             None => Ok(0),
         }
     }
+
+    async fn hincr_by(&self, key: &str, field: &str, delta: i64) -> Result<i64, RustyAntError> {
+        let field = field.to_string();
+        self.cas(key, move |entry| {
+            let (mut map, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::Hash(m), expires_at_ms }) => (m.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => (BTreeMap::new(), None),
+            };
+            let current: i64 = map
+                .get(&field)
+                .map(|v| {
+                    let s = std::str::from_utf8(v)
+                        .map_err(|_| RustyAntError::Parse("hash value is not an integer".into()))?;
+                    s.parse::<i64>().map_err(|_| RustyAntError::Parse("hash value is not an integer".into()))
+                })
+                .transpose()?
+                .unwrap_or(0);
+            let new_val =
+                current.checked_add(delta).ok_or_else(|| RustyAntError::Parse("increment overflow".into()))?;
+            map.insert(field.clone(), new_val.to_string().into_bytes());
+            let new_entry = StoredValue { expires_at_ms, value: Value::Hash(map) };
+            Ok(CasAction::Write(new_entry, new_val))
+        })
+        .await
+    }
+
+    async fn srem(&self, key: &str, members: &[String]) -> Result<i64, RustyAntError> {
+        let members = members.to_vec();
+        self.cas(key, move |entry| {
+            let (mut set, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::Set(s), expires_at_ms }) => (s.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => return Ok(CasAction::NoOp(0)),
+            };
+            let mut removed: i64 = 0;
+            for m in &members {
+                if set.remove(m) {
+                    removed += 1;
+                }
+            }
+            if set.is_empty() {
+                Ok(CasAction::Delete(removed))
+            } else {
+                let new_entry = StoredValue { expires_at_ms, value: Value::Set(set) };
+                Ok(CasAction::Write(new_entry, removed))
+            }
+        })
+        .await
+    }
+
+    async fn zrem(&self, key: &str, members: &[String]) -> Result<i64, RustyAntError> {
+        let members = members.to_vec();
+        self.cas(key, move |entry| {
+            let (mut map, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::ZSet(m), expires_at_ms }) => (m.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => return Ok(CasAction::NoOp(0)),
+            };
+            let mut removed: i64 = 0;
+            for m in &members {
+                if map.remove(m).is_some() {
+                    removed += 1;
+                }
+            }
+            if map.is_empty() {
+                Ok(CasAction::Delete(removed))
+            } else {
+                let new_entry = StoredValue { expires_at_ms, value: Value::ZSet(map) };
+                Ok(CasAction::Write(new_entry, removed))
+            }
+        })
+        .await
+    }
+
+    async fn zincr_by(&self, key: &str, member: &str, delta: f64) -> Result<f64, RustyAntError> {
+        let member = member.to_string();
+        self.cas(key, move |entry| {
+            let (mut map, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::ZSet(m), expires_at_ms }) => (m.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => (BTreeMap::new(), None),
+            };
+            let current = map.get(&member).copied().unwrap_or(0.0);
+            let new_score = current + delta;
+            if new_score.is_nan() {
+                return Err(RustyAntError::Parse("resulting score is NaN".into()));
+            }
+            map.insert(member.clone(), new_score);
+            let new_entry = StoredValue { expires_at_ms, value: Value::ZSet(map) };
+            Ok(CasAction::Write(new_entry, new_score))
+        })
+        .await
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -991,6 +1089,99 @@ impl Storage for InMemoryStorage {
             Some(_) => Err(wrong_type(key)),
             None => Ok(0),
         }
+    }
+
+    async fn hincr_by(&self, key: &str, field: &str, delta: i64) -> Result<i64, RustyAntError> {
+        let (mut map, expires_at_ms) = match self.load(key) {
+            Some(StoredValue { value: Value::Hash(m), expires_at_ms }) => (m, expires_at_ms),
+            Some(_) => return Err(wrong_type(key)),
+            None => (BTreeMap::new(), None),
+        };
+        let current: i64 = map
+            .get(field)
+            .map(|v| {
+                let s =
+                    std::str::from_utf8(v).map_err(|_| RustyAntError::Parse("hash value is not an integer".into()))?;
+                s.parse::<i64>().map_err(|_| RustyAntError::Parse("hash value is not an integer".into()))
+            })
+            .transpose()?
+            .unwrap_or(0);
+        let new_val = current.checked_add(delta).ok_or_else(|| RustyAntError::Parse("increment overflow".into()))?;
+        map.insert(field.to_string(), new_val.to_string().into_bytes());
+        let entry = StoredValue { expires_at_ms, value: Value::Hash(map) };
+        self.with_entry_mut(|store| {
+            store.insert(key.to_string(), entry);
+        });
+        Ok(new_val)
+    }
+
+    async fn srem(&self, key: &str, members: &[String]) -> Result<i64, RustyAntError> {
+        let (mut set, expires_at_ms) = match self.load(key) {
+            Some(StoredValue { value: Value::Set(s), expires_at_ms }) => (s, expires_at_ms),
+            Some(_) => return Err(wrong_type(key)),
+            None => return Ok(0),
+        };
+        let mut removed: i64 = 0;
+        for m in members {
+            if set.remove(m) {
+                removed += 1;
+            }
+        }
+        if set.is_empty() {
+            self.with_entry_mut(|store| {
+                store.remove(key);
+            });
+        } else {
+            let entry = StoredValue { expires_at_ms, value: Value::Set(set) };
+            self.with_entry_mut(|store| {
+                store.insert(key.to_string(), entry);
+            });
+        }
+        Ok(removed)
+    }
+
+    async fn zrem(&self, key: &str, members: &[String]) -> Result<i64, RustyAntError> {
+        let (mut map, expires_at_ms) = match self.load(key) {
+            Some(StoredValue { value: Value::ZSet(m), expires_at_ms }) => (m, expires_at_ms),
+            Some(_) => return Err(wrong_type(key)),
+            None => return Ok(0),
+        };
+        let mut removed: i64 = 0;
+        for m in members {
+            if map.remove(m).is_some() {
+                removed += 1;
+            }
+        }
+        if map.is_empty() {
+            self.with_entry_mut(|store| {
+                store.remove(key);
+            });
+        } else {
+            let entry = StoredValue { expires_at_ms, value: Value::ZSet(map) };
+            self.with_entry_mut(|store| {
+                store.insert(key.to_string(), entry);
+            });
+        }
+        Ok(removed)
+    }
+
+    async fn zincr_by(&self, key: &str, member: &str, delta: f64) -> Result<f64, RustyAntError> {
+        let (mut map, expires_at_ms) = match self.load(key) {
+            Some(StoredValue { value: Value::ZSet(m), expires_at_ms }) => (m, expires_at_ms),
+            Some(_) => return Err(wrong_type(key)),
+            None => (BTreeMap::new(), None),
+        };
+        let current = map.get(member).copied().unwrap_or(0.0);
+        let new_score = current + delta;
+        if new_score.is_nan() {
+            return Err(RustyAntError::Parse("resulting score is NaN".into()));
+        }
+        map.insert(member.to_string(), new_score);
+        let entry = StoredValue { expires_at_ms, value: Value::ZSet(map) };
+        self.with_entry_mut(|store| {
+            store.insert(key.to_string(), entry);
+        });
+        Ok(new_score)
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -526,6 +526,86 @@ async fn zcard_counts_members() {
     call(&state, &[b"ZCARD", b"z"]).await.expect_integer(3);
 }
 
+// ---------------------------------------------------------------------------
+// Additional mutating commands (HINCRBY, SREM, ZREM, ZINCRBY)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn hincrby_creates_field_at_zero() {
+    let state = test_state();
+    call(&state, &[b"HINCRBY", b"h", b"counter", b"5"]).await.expect_integer(5);
+    call(&state, &[b"HINCRBY", b"h", b"counter", b"3"]).await.expect_integer(8);
+    call(&state, &[b"HINCRBY", b"h", b"counter", b"-10"]).await.expect_integer(-2);
+}
+
+#[tokio::test]
+async fn hincrby_on_non_integer_field_errors() {
+    let state = test_state();
+    call(&state, &[b"HSET", b"h", b"name", b"alice"]).await;
+    call(&state, &[b"HINCRBY", b"h", b"name", b"1"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn srem_returns_count_removed() {
+    let state = test_state();
+    call(&state, &[b"SADD", b"s", b"a", b"b", b"c"]).await;
+    call(&state, &[b"SREM", b"s", b"a", b"b", b"missing"]).await.expect_integer(2);
+    call(&state, &[b"SCARD", b"s"]).await.expect_integer(1);
+}
+
+#[tokio::test]
+async fn srem_empties_and_deletes_key() {
+    let state = test_state();
+    call(&state, &[b"SADD", b"s", b"x"]).await;
+    call(&state, &[b"SREM", b"s", b"x"]).await.expect_integer(1);
+    call(&state, &[b"EXISTS", b"s"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn zrem_returns_count_removed() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"a", b"2", b"b", b"3", b"c"]).await;
+    call(&state, &[b"ZREM", b"z", b"a", b"c", b"missing"]).await.expect_integer(2);
+    call(&state, &[b"ZCARD", b"z"]).await.expect_integer(1);
+}
+
+#[tokio::test]
+async fn zrem_empties_and_deletes_key() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"a"]).await;
+    call(&state, &[b"ZREM", b"z", b"a"]).await.expect_integer(1);
+    call(&state, &[b"EXISTS", b"z"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn zincrby_creates_member_at_zero() {
+    let state = test_state();
+    call(&state, &[b"ZINCRBY", b"z", b"5", b"member"]).await.expect_bulk(b"5");
+    call(&state, &[b"ZINCRBY", b"z", b"2.5", b"member"]).await.expect_bulk(b"7.5");
+    call(&state, &[b"ZSCORE", b"z", b"member"]).await.expect_bulk(b"7.5");
+}
+
+#[tokio::test]
+async fn zincrby_reorders_in_zrange() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"a", b"2", b"b"]).await;
+    // Push a past b by +10.
+    call(&state, &[b"ZINCRBY", b"z", b"10", b"a"]).await.expect_bulk(b"11");
+    let items = call(&state, &[b"ZRANGE", b"z", b"0", b"-1"]).await.into_bulk_array();
+    assert_eq!(items[0].as_ref(), b"b");
+    assert_eq!(items[1].as_ref(), b"a");
+}
+
+#[tokio::test]
+async fn new_write_commands_error_on_wrong_type() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"HINCRBY", b"k", b"f", b"1"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"SREM", b"k", b"x"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"ZREM", b"k", b"x"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"ZINCRBY", b"k", b"1", b"m"]).await.expect_error_prefix("ERR");
+}
+
 #[tokio::test]
 async fn new_read_commands_all_error_on_wrong_type() {
     let state = test_state();


### PR DESCRIPTION
## Summary

Four more mutating Redis commands, each a thin wrapper around the existing CAS retry loop:

| Command | Behavior |
|---|---|
| \`HINCRBY\` | Atomic integer increment on a hash field; creates the field at 0 if absent |
| \`SREM\` | Remove members from a set; deletes the key when empty |
| \`ZREM\` | Remove members from a sorted set; deletes when empty |
| \`ZINCRBY\` | Atomic float increment on a sorted-set member score; creates at 0 if absent |

## Implementation

Each storage method lives inside a \`self.cas\` closure, so the S3 \`If-Match\` / exponential-backoff retry semantics come for free. \`InMemoryStorage\` versions use the Mutex-guarded BTreeMap for atomicity — same pattern as the existing write commands.

\`SREM\` and \`ZREM\` emit \`CasAction::Delete\` when the last member is removed, preserving Redis's \"empty collection → key doesn't exist\" invariant (same convention as \`HDEL\` and \`LPOP\`/\`RPOP\`).

Error semantics match Redis:
- \`HINCRBY\` on a non-integer field → RESP \`-ERR\` with \"hash value is not an integer\"
- \`ZINCRBY\` producing NaN (e.g. \`+inf + -inf\`) → RESP \`-ERR\` with \"resulting score is NaN\"

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo test --all-targets\` — 84 pass (up from 75)
- [x] 9 new handler tests: HINCRBY create/increment/negative/non-integer, SREM count + empty-delete, ZREM count + empty-delete, ZINCRBY creates-and-reorders, batch WRONGTYPE
- [ ] CI green on this PR

## Command surface status

After this lands, the only commands remaining in the \"Not implemented\" list are: \`GETSET\`, \`MGET\`, \`MSET\`, \`SETNX\`, \`SETEX\`, \`PERSIST\`, \`KEYS\`, \`SCAN\`, \`LINDEX\`, \`LSET\`, \`LREM\`, \`ZRANGEBYSCORE\`, plus pub/sub, transactions, scripting, streams, and geo.