### PR TITLE
feat: add MGET, MSET, SETNX, SETEX

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,15 @@ Implemented:
 | Group | Commands |
 |---|---|
 | Server | `PING` |
-| Strings | `GET`, `SET` (+ `EX` / `PX` options), `DEL`, `EXISTS`, `EXPIRE`, `TTL`, `INCR`, `INCRBY` |
+| Strings | `GET`, `SET` (+ `EX` / `PX` options), `SETNX`, `SETEX`, `MGET`, `MSET`, `DEL`, `EXISTS`, `EXPIRE`, `TTL`, `INCR`, `INCRBY` |
 | Hashes | `HSET`, `HGET`, `HDEL`, `HGETALL`, `HLEN`, `HKEYS`, `HVALS`, `HEXISTS`, `HMGET`, `HINCRBY` |
 | Lists | `LPUSH`, `RPUSH`, `LPOP` (+ count), `RPOP` (+ count), `LRANGE`, `LLEN` |
 | Sets | `SADD`, `SREM`, `SMEMBERS`, `SISMEMBER`, `SCARD` |
 | Sorted Sets | `ZADD`, `ZREM`, `ZINCRBY`, `ZRANGE`, `ZSCORE`, `ZCARD` |
 
-Not implemented (PRs welcome): `GETSET`, `MGET`, `MSET`, `SETNX`, `SETEX`, `PERSIST`, `KEYS`, `SCAN`, `LINDEX`, `LSET`, `LREM`, `ZRANGEBYSCORE`, and all pub/sub, transactions, scripting, streams, geo.
+Not implemented (PRs welcome): `GETSET`, `PERSIST`, `KEYS`, `SCAN`, `LINDEX`, `LSET`, `LREM`, `ZRANGEBYSCORE`, and all pub/sub, transactions, scripting, streams, geo.
+
+`MSET` is **not atomic across keys** — a failure partway through leaves earlier keys set. Real Redis is atomic here; rustyant's S3 backing makes the all-or-none semantic expensive, and the fire-and-forget variant is fine for most workloads.
 
 ### Concurrency
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -26,6 +26,10 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         // Strings
         "GET" => handle_get(state, args).await,
         "SET" => handle_set(state, args).await,
+        "SETNX" => handle_setnx(state, args).await,
+        "SETEX" => handle_setex(state, args).await,
+        "MGET" => handle_mget(state, args).await,
+        "MSET" => handle_mset(state, args).await,
         "DEL" => handle_del(state, args).await,
         "EXISTS" => handle_exists(state, args).await,
         "EXPIRE" => handle_expire(state, args).await,
@@ -391,6 +395,50 @@ async fn handle_zcard(state: &State, args: Vec<Bytes>) -> Result<RespReply, Rust
     arity("ZCARD", args.len() == 1)?;
     let n = state.storage.zcard(arg_as_str(&args[0])?).await?;
     Ok(RespReply::Integer(n))
+}
+
+// ---- String multi-key + NX/EX ---------------------------------------------
+
+async fn handle_setnx(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("SETNX", args.len() == 2)?;
+    let key = arg_as_str(&args[0])?;
+    let set = state.storage.set_string_nx(key, args[1].clone(), None).await?;
+    Ok(RespReply::Integer(i64::from(set)))
+}
+
+async fn handle_setex(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("SETEX", args.len() == 3)?;
+    let key = arg_as_str(&args[0])?;
+    let secs = parse_i64(&args[1], "seconds")?;
+    if secs <= 0 {
+        return Err(RustyAntError::Parse("SETEX seconds must be positive".into()));
+    }
+    let expires_at_ms = Some(now_ms() + secs * 1000);
+    state.storage.set_string(key, args[2].clone(), expires_at_ms).await?;
+    Ok(RespReply::ok())
+}
+
+async fn handle_mget(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("MGET", !args.is_empty())?;
+    let keys: Vec<String> = args.iter().map(arg_as_string).collect::<Result<_, _>>()?;
+    let vals = state.storage.mget(&keys).await?;
+    Ok(RespReply::Array(
+        vals.into_iter().map(|v| v.map_or(RespReply::Nil, |b| RespReply::BulkString(Some(b)))).collect(),
+    ))
+}
+
+async fn handle_mset(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    if args.is_empty() || args.len() % 2 != 0 {
+        return Err(RustyAntError::WrongArity { command: "MSET".into() });
+    }
+    let mut pairs: Vec<(String, Bytes)> = Vec::with_capacity(args.len() / 2);
+    let mut i = 0;
+    while i < args.len() {
+        pairs.push((arg_as_string(&args[i])?, args[i + 1].clone()));
+        i += 2;
+    }
+    state.storage.mset(pairs).await?;
+    Ok(RespReply::ok())
 }
 
 // ---- Additional mutating commands -----------------------------------------

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -116,7 +116,29 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
 
     async fn get_string(&self, key: &str) -> Result<Option<Bytes>, RustyAntError>;
     async fn set_string(&self, key: &str, value: Bytes, expires_at_ms: Option<i64>) -> Result<(), RustyAntError>;
+    async fn set_string_nx(&self, key: &str, value: Bytes, expires_at_ms: Option<i64>) -> Result<bool, RustyAntError>;
     async fn incr_by(&self, key: &str, delta: i64) -> Result<i64, RustyAntError>;
+
+    /// Default: sequential `get_string` per key. Impls may override with a
+    /// batched S3 request.
+    async fn mget(&self, keys: &[String]) -> Result<Vec<Option<Bytes>>, RustyAntError> {
+        let mut out = Vec::with_capacity(keys.len());
+        for k in keys {
+            out.push(self.get_string(k).await?);
+        }
+        Ok(out)
+    }
+
+    /// Default: sequential `set_string` per pair. Not atomic across keys —
+    /// a failure midway leaves some keys set. Real Redis is atomic; that
+    /// semantic isn't worth emulating over S3 without a dedicated transaction
+    /// log, and the S3 backing makes the fire-and-forget variant fast enough.
+    async fn mset(&self, pairs: Vec<(String, Bytes)>) -> Result<(), RustyAntError> {
+        for (k, v) in pairs {
+            self.set_string(&k, v, None).await?;
+        }
+        Ok(())
+    }
 
     async fn hset(&self, key: &str, pairs: Vec<(String, Bytes)>) -> Result<i64, RustyAntError>;
     async fn hget(&self, key: &str, field: &str) -> Result<Option<Bytes>, RustyAntError>;
@@ -336,6 +358,18 @@ impl Storage for S3Storage {
 
     async fn set_string(&self, key: &str, value: Bytes, expires_at_ms: Option<i64>) -> Result<(), RustyAntError> {
         self.save(key, &StoredValue { expires_at_ms, value: Value::String(value.to_vec()) }).await
+    }
+
+    async fn set_string_nx(&self, key: &str, value: Bytes, expires_at_ms: Option<i64>) -> Result<bool, RustyAntError> {
+        // Surface any expired entry so `If-None-Match: *` doesn't reject
+        // a legitimate create because the zombie object hasn't been swept yet.
+        let _ = self.load_with_etag(key).await?;
+        let entry = StoredValue { expires_at_ms, value: Value::String(value.to_vec()) };
+        match self.save_cas(key, &entry, CasCondition::CreateOnly).await {
+            Ok(()) => Ok(true),
+            Err(RustyAntError::Contention) => Ok(false),
+            Err(e) => Err(e),
+        }
     }
 
     async fn incr_by(&self, key: &str, delta: i64) -> Result<i64, RustyAntError> {
@@ -801,6 +835,22 @@ impl Storage for InMemoryStorage {
             map.insert(key.to_string(), entry);
         });
         Ok(())
+    }
+
+    async fn set_string_nx(&self, key: &str, value: Bytes, expires_at_ms: Option<i64>) -> Result<bool, RustyAntError> {
+        let entry = StoredValue { expires_at_ms, value: Value::String(value.to_vec()) };
+        Ok(self.with_entry_mut(|map| {
+            // Evict any expired occupant; then the emptiness check is honest.
+            if let Some(existing) = map.get(key) {
+                if is_expired(existing) {
+                    map.remove(key);
+                } else {
+                    return false;
+                }
+            }
+            map.insert(key.to_string(), entry);
+            true
+        }))
     }
 
     async fn incr_by(&self, key: &str, delta: i64) -> Result<i64, RustyAntError> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -418,6 +418,64 @@ async fn zadd_odd_args_errors() {
 }
 
 // ---------------------------------------------------------------------------
+// String multi-key + NX/EX (SETNX, SETEX, MGET, MSET)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn setnx_sets_missing_key() {
+    let state = test_state();
+    call(&state, &[b"SETNX", b"k", b"v1"]).await.expect_integer(1);
+    call(&state, &[b"GET", b"k"]).await.expect_bulk(b"v1");
+    // Second SETNX must not overwrite.
+    call(&state, &[b"SETNX", b"k", b"v2"]).await.expect_integer(0);
+    call(&state, &[b"GET", b"k"]).await.expect_bulk(b"v1");
+}
+
+#[tokio::test]
+async fn setex_sets_value_with_ttl() {
+    let state = test_state();
+    call(&state, &[b"SETEX", b"k", b"120", b"v"]).await.expect_simple("OK");
+    call(&state, &[b"GET", b"k"]).await.expect_bulk(b"v");
+    // TTL should be ~120s.
+    let reply = call(&state, &[b"TTL", b"k"]).await;
+    let raw = String::from_utf8_lossy(&reply.raw);
+    let n: i64 = raw.trim_start_matches(':').trim_end().parse().expect("int");
+    assert!((110..=120).contains(&n), "TTL out of range: {n}");
+}
+
+#[tokio::test]
+async fn setex_rejects_non_positive_seconds() {
+    let state = test_state();
+    call(&state, &[b"SETEX", b"k", b"0", b"v"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"SETEX", b"k", b"-5", b"v"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn mget_returns_nil_for_missing_keys() {
+    let state = test_state();
+    call(&state, &[b"SET", b"a", b"1"]).await;
+    call(&state, &[b"SET", b"c", b"3"]).await;
+    let raw = call(&state, &[b"MGET", b"a", b"b", b"c"]).await.raw;
+    // Array of 3: bulk "1", nil, bulk "3"
+    assert_eq!(&raw, b"*3\r\n$1\r\n1\r\n$-1\r\n$1\r\n3\r\n");
+}
+
+#[tokio::test]
+async fn mset_sets_all_pairs() {
+    let state = test_state();
+    call(&state, &[b"MSET", b"a", b"1", b"b", b"2", b"c", b"3"]).await.expect_simple("OK");
+    call(&state, &[b"GET", b"a"]).await.expect_bulk(b"1");
+    call(&state, &[b"GET", b"b"]).await.expect_bulk(b"2");
+    call(&state, &[b"GET", b"c"]).await.expect_bulk(b"3");
+}
+
+#[tokio::test]
+async fn mset_odd_args_errors() {
+    let state = test_state();
+    call(&state, &[b"MSET", b"a", b"1", b"b"]).await.expect_error_prefix("ERR");
+}
+
+// ---------------------------------------------------------------------------
 // Additional read-only commands (HLEN / HKEYS / HVALS / HEXISTS / HMGET,
 // LLEN, SMEMBERS / SISMEMBER / SCARD, ZSCORE / ZCARD)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Four string-family commands that are common enough to belong in the default surface:

| Command | Behavior |
|---|---|
| \`MGET\` | Batched GET. Returns a bulk string per key; nil for missing keys |
| \`MSET\` | Batched SET. **Not atomic across keys** — documented caveat |
| \`SETNX\` | Create-only SET. Returns 1 if created, 0 if the key existed |
| \`SETEX\` | \`SET key ... EX seconds\` alias; rejects non-positive seconds |

## Implementation

- \`SETNX\` rides the existing \`save_cas\` \`CreateOnly\` path. The handler catches \`Err(Contention)\` (= S3 returned 412, which \`save_cas\` classifies as contention for the CAS retry loop) and translates it to Redis's \`0\` return instead of surfacing an error.
- \`MGET\` / \`MSET\` default impls live on the \`Storage\` trait as sequential \`get_string\` / \`set_string\` loops — \`S3Storage\` and \`InMemoryStorage\` get them for free.
- \`SETEX\` is a thin alias around \`set_string\` with an EX argument; no new storage method needed.

## Atomicity note (in README)

Real Redis \`MSET\` is all-or-none. Over S3 that would need a dedicated transaction log; not worth it for this use case. \`MSET\` in rustyant fires sequentially, so a mid-sequence failure leaves earlier keys set. Documented explicitly.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo test --all-targets\` — 90 pass (up from 84)
- [x] 6 new tests: SETNX existing-vs-missing, SETEX TTL accuracy, SETEX rejects non-positive seconds, MGET nil-for-missing, MSET all-pairs, MSET odd-arg errors
- [ ] CI green

## Command surface status

After this: remaining unimplemented is \`GETSET\`, \`PERSIST\`, \`KEYS\`, \`SCAN\`, \`LINDEX\`, \`LSET\`, \`LREM\`, \`ZRANGEBYSCORE\`, plus pub/sub / transactions / scripting / streams / geo.