### PR TITLE
feat: Python HttpClient + shared command-surface base

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ from rustyant import Client
 with Client("wss://abc.execute-api.us-east-1.amazonaws.com/prod") as c:
     c.set("k", "v"); c.get("k")  # b"v"
 
-# HTTP — one POST per command, simpler deploy
+# HTTP — one POST per command, Lambda Function URL works
 from rustyant import HttpClient
 with HttpClient("https://abc.lambda-url.us-east-1.on.aws") as c:
     c.set("k", "v"); c.get("k")  # b"v"

--- a/README.md
+++ b/README.md
@@ -35,13 +35,18 @@ Content-Type: application/resp
 
 API Gateway WS API routes `$connect` / `$disconnect` / `$default` events to the `rustyant-ws` Lambda. Each inbound WebSocket frame carries one RESP2 command; the Lambda posts the reply back on the same connection via the API Gateway Management API. Persistent connection → no per-command HTTP handshake, pipelining works, lower tail latency.
 
-Use the [Python client](clients/python/README.md) for a `redis-py`-shaped API:
+Use the [Python client](clients/python/README.md) for a `redis-py`-shaped API. Two transport classes share one method surface:
 
 ```python
+# WebSocket — persistent connection, pipelining
 from rustyant import Client
-c = Client("wss://abc.execute-api.us-east-1.amazonaws.com/prod")
-c.set("k", "v")
-c.get("k")  # b"v"
+with Client("wss://abc.execute-api.us-east-1.amazonaws.com/prod") as c:
+    c.set("k", "v"); c.get("k")  # b"v"
+
+# HTTP — one POST per command, simpler deploy
+from rustyant import HttpClient
+with HttpClient("https://abc.lambda-url.us-east-1.on.aws") as c:
+    c.set("k", "v"); c.get("k")  # b"v"
 ```
 
 Neither transport supports `MULTI`/`EXEC`, `SUBSCRIBE`/`PUBLISH`, or streams.

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -12,12 +12,14 @@ uv pip install rustyant
 
 ## Transports
 
-| Class | Transport | When to use |
+| Class | Transport | Server side |
 |---|---|---|
-| `Client` | WebSocket (wss://) | Persistent connection, no per-command handshake, pipelining |
-| `HttpClient` | HTTPS (https://) | One POST per command; simpler deploy — Lambda Function URL works |
+| `Client` | WebSocket (wss://) | API Gateway WebSocket API → Lambda; persistent connection, pipelining |
+| `HttpClient` | HTTPS (https://) | Lambda Function URL or API Gateway HTTP API; one POST per command |
 
-Both expose the same `redis-py`-shaped method surface (`get`/`set`/`hset`/…) via a shared base class.
+Both server-side options are VPC-less with roughly the same footprint. The HTTP path is one Lambda behind one HTTPS route; the WebSocket path adds three routes (`$connect`/`$disconnect`/`$default`) plus the `execute-api:ManageConnections` IAM grant so the Lambda can reply via the management API. HTTP pays a per-command TLS handshake; WebSocket pays it once per connection.
+
+Both clients expose the same `redis-py`-shaped method surface (`get`/`set`/`hset`/…) via a shared base class.
 
 ## Usage — WebSocket
 

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -1,6 +1,6 @@
 # rustyant — Python client
 
-Python client for [rustyant](https://github.com/monkut/rustyant) — a Redis-compatible key-value store served over AWS API Gateway WebSocket + Lambda + S3.
+Python client for [rustyant](https://github.com/monkut/rustyant) — a Redis-compatible key-value store served over AWS Lambda + S3. Two transports, one API.
 
 ## Install
 
@@ -10,7 +10,16 @@ pip install rustyant
 uv pip install rustyant
 ```
 
-## Usage
+## Transports
+
+| Class | Transport | When to use |
+|---|---|---|
+| `Client` | WebSocket (wss://) | Persistent connection, no per-command handshake, pipelining |
+| `HttpClient` | HTTPS (https://) | One POST per command; simpler deploy — Lambda Function URL works |
+
+Both expose the same `redis-py`-shaped method surface (`get`/`set`/`hset`/…) via a shared base class.
+
+## Usage — WebSocket
 
 ```python
 from rustyant import Client
@@ -39,6 +48,26 @@ Context-manager form auto-closes the WebSocket:
 with Client("wss://…") as c:
     c.set("k", "v")
 ```
+
+## Usage — HTTP
+
+```python
+from rustyant import HttpClient
+
+# Point at a Lambda Function URL or API Gateway HTTP API
+c = HttpClient("https://abc123.lambda-url.us-east-1.on.aws")
+
+c.set("hello", "world")
+assert c.get("hello") == b"world"
+
+# Everything else is identical:
+c.hset("profile", "name", "alice")
+c.zadd("scores", {"alice": 10, "bob": 5})
+
+c.close()
+```
+
+`HttpClient` re-uses a `requests.Session` internally, so keep-alive and connection pooling work against long-lived handles. Pass `session=...` to inject a pre-configured session (custom adapters, retry policies, auth headers). Any session you pass is not closed by `HttpClient.close()`.
 
 ## Command surface
 

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rustyant"
-version = "0.1.0"
+version = "0.2.0"
 description = "Python client for rustyant — Redis-compatible key-value store on AWS Lambda + S3"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -8,6 +8,7 @@ license = { text = "LicenseRef-KICONIAWORKS-Customers" }
 authors = [{ name = "monkut" }]
 dependencies = [
     "hiredis>=2.0",
+    "requests>=2.31",
     "websocket-client>=1.7",
 ]
 

--- a/clients/python/rustyant/__init__.py
+++ b/clients/python/rustyant/__init__.py
@@ -1,6 +1,8 @@
 """Python client for rustyant (Redis-compatible KV over AWS Lambda + S3)."""
 
-from rustyant.client import Client, RustyAntError
+from rustyant._base import RustyAntError
+from rustyant.client import Client
+from rustyant.http_client import HttpClient
 
-__all__ = ["Client", "RustyAntError"]
-__version__ = "0.1.0"
+__all__ = ["Client", "HttpClient", "RustyAntError"]
+__version__ = "0.2.0"

--- a/clients/python/rustyant/_base.py
+++ b/clients/python/rustyant/_base.py
@@ -1,0 +1,216 @@
+"""
+Shared redis-py-shaped API surface used by both transports.
+
+Subclasses implement `_call(*args) -> Any` (and connection lifecycle);
+this base handles argument packing and the Redis-style command methods.
+Keeping the command surface in one place means the WebSocket and HTTP
+clients can't drift in what they expose.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Union
+
+_Arg = Union[str, bytes, int, float, bool]
+
+
+class RustyAntError(Exception):
+    """Raised when the server returns a RESP `-ERR` reply, or the transport
+    closes unexpectedly mid-command."""
+
+
+def _encode_command(*args: _Arg) -> bytes:
+    """Serialize a command tuple into a RESP2 array frame."""
+    crlf = b"\r\n"
+    parts = [b"*" + str(len(args)).encode() + crlf]
+    for arg in args:
+        if isinstance(arg, bytes):
+            value = arg
+        elif isinstance(arg, bool):
+            value = b"1" if arg else b"0"
+        elif isinstance(arg, (int, float)):
+            value = repr(arg).encode()
+        else:
+            value = str(arg).encode("utf-8")
+        parts.append(b"$" + str(len(value)).encode() + crlf + value + crlf)
+    return b"".join(parts)
+
+
+class _RedisShapedClient:
+    """Mixin providing the redis-py-shaped command surface.
+
+    Subclasses must implement `_call(*args) -> Any` which serializes the
+    command via `_encode_command`, ships the bytes over the wire, and
+    returns the parsed RESP reply (raising `RustyAntError` on server-side
+    `-ERR` replies).
+    """
+
+    def _call(self, *args: _Arg) -> Any:  # noqa: D401
+        raise NotImplementedError
+
+    # ---- Server --------------------------------------------------------
+
+    def ping(self) -> bytes:
+        return self._call("PING")
+
+    # ---- Strings -------------------------------------------------------
+
+    def set(
+        self,
+        key: _Arg,
+        value: _Arg,
+        *,
+        ex: int | None = None,
+        px: int | None = None,
+    ) -> bytes:
+        args: list[_Arg] = ["SET", key, value]
+        if ex is not None:
+            args += ["EX", ex]
+        if px is not None:
+            args += ["PX", px]
+        return self._call(*args)
+
+    def setnx(self, key: _Arg, value: _Arg) -> int:
+        return self._call("SETNX", key, value)
+
+    def setex(self, key: _Arg, seconds: int, value: _Arg) -> bytes:
+        return self._call("SETEX", key, seconds, value)
+
+    def get(self, key: _Arg) -> bytes | None:
+        return self._call("GET", key)
+
+    def mget(self, *keys: _Arg) -> list[bytes | None]:
+        return self._call("MGET", *keys)
+
+    def mset(self, *key_value_pairs: _Arg) -> bytes:
+        if len(key_value_pairs) < 2 or len(key_value_pairs) % 2 != 0:
+            raise ValueError("mset requires an even number of key/value args")
+        return self._call("MSET", *key_value_pairs)
+
+    def delete(self, *keys: _Arg) -> int:
+        return self._call("DEL", *keys)
+
+    def exists(self, *keys: _Arg) -> int:
+        return self._call("EXISTS", *keys)
+
+    def expire(self, key: _Arg, seconds: int) -> int:
+        return self._call("EXPIRE", key, seconds)
+
+    def ttl(self, key: _Arg) -> int:
+        return self._call("TTL", key)
+
+    def incr(self, key: _Arg) -> int:
+        return self._call("INCR", key)
+
+    def incrby(self, key: _Arg, delta: int) -> int:
+        return self._call("INCRBY", key, delta)
+
+    # ---- Hashes --------------------------------------------------------
+
+    def hset(self, key: _Arg, *field_value_pairs: _Arg) -> int:
+        if len(field_value_pairs) < 2 or len(field_value_pairs) % 2 != 0:
+            raise ValueError("hset requires an even number of field/value args")
+        return self._call("HSET", key, *field_value_pairs)
+
+    def hget(self, key: _Arg, field: _Arg) -> bytes | None:
+        return self._call("HGET", key, field)
+
+    def hdel(self, key: _Arg, *fields: _Arg) -> int:
+        return self._call("HDEL", key, *fields)
+
+    def hgetall(self, key: _Arg) -> dict[bytes, bytes]:
+        flat: list[bytes] = self._call("HGETALL", key) or []
+        return dict(zip(flat[0::2], flat[1::2]))
+
+    def hlen(self, key: _Arg) -> int:
+        return self._call("HLEN", key)
+
+    def hkeys(self, key: _Arg) -> list[bytes]:
+        return self._call("HKEYS", key)
+
+    def hvals(self, key: _Arg) -> list[bytes]:
+        return self._call("HVALS", key)
+
+    def hexists(self, key: _Arg, field: _Arg) -> int:
+        return self._call("HEXISTS", key, field)
+
+    def hmget(self, key: _Arg, *fields: _Arg) -> list[bytes | None]:
+        return self._call("HMGET", key, *fields)
+
+    def hincrby(self, key: _Arg, field: _Arg, delta: int) -> int:
+        return self._call("HINCRBY", key, field, delta)
+
+    # ---- Lists ---------------------------------------------------------
+
+    def lpush(self, key: _Arg, *values: _Arg) -> int:
+        return self._call("LPUSH", key, *values)
+
+    def rpush(self, key: _Arg, *values: _Arg) -> int:
+        return self._call("RPUSH", key, *values)
+
+    def lpop(self, key: _Arg, count: int | None = None) -> Any:
+        if count is None:
+            return self._call("LPOP", key)
+        return self._call("LPOP", key, count)
+
+    def rpop(self, key: _Arg, count: int | None = None) -> Any:
+        if count is None:
+            return self._call("RPOP", key)
+        return self._call("RPOP", key, count)
+
+    def lrange(self, key: _Arg, start: int, stop: int) -> list[bytes]:
+        return self._call("LRANGE", key, start, stop)
+
+    def llen(self, key: _Arg) -> int:
+        return self._call("LLEN", key)
+
+    # ---- Sets ----------------------------------------------------------
+
+    def sadd(self, key: _Arg, *members: _Arg) -> int:
+        return self._call("SADD", key, *members)
+
+    def srem(self, key: _Arg, *members: _Arg) -> int:
+        return self._call("SREM", key, *members)
+
+    def smembers(self, key: _Arg) -> list[bytes]:
+        return self._call("SMEMBERS", key)
+
+    def sismember(self, key: _Arg, member: _Arg) -> int:
+        return self._call("SISMEMBER", key, member)
+
+    def scard(self, key: _Arg) -> int:
+        return self._call("SCARD", key)
+
+    # ---- Sorted sets ---------------------------------------------------
+
+    def zadd(
+        self,
+        key: _Arg,
+        mapping: dict[str, float] | Iterable[tuple[float, str]],
+    ) -> int:
+        """Accept either {member: score} or an iterable of (score, member) tuples."""
+        flat: list[_Arg] = []
+        if isinstance(mapping, dict):
+            for member, score in mapping.items():
+                flat += [score, member]
+        else:
+            for score, member in mapping:
+                flat += [score, member]
+        if not flat:
+            raise ValueError("zadd requires at least one score/member pair")
+        return self._call("ZADD", key, *flat)
+
+    def zrem(self, key: _Arg, *members: _Arg) -> int:
+        return self._call("ZREM", key, *members)
+
+    def zincrby(self, key: _Arg, delta: float, member: _Arg) -> bytes:
+        return self._call("ZINCRBY", key, delta, member)
+
+    def zrange(self, key: _Arg, start: int, stop: int) -> list[bytes]:
+        return self._call("ZRANGE", key, start, stop)
+
+    def zscore(self, key: _Arg, member: _Arg) -> bytes | None:
+        return self._call("ZSCORE", key, member)
+
+    def zcard(self, key: _Arg) -> int:
+        return self._call("ZCARD", key)

--- a/clients/python/rustyant/client.py
+++ b/clients/python/rustyant/client.py
@@ -1,10 +1,8 @@
 """
-Rustyant client — WebSocket transport, RESP2 wire format.
+Rustyant WebSocket client — persistent connection, RESP2 framing over WS.
 
-Connects to an API Gateway WebSocket endpoint fronting the rustyant Lambda
-and issues Redis-style commands against the S3-backed key/value store. The
-method names mirror `redis-py` where the semantics line up, so porting small
-amounts of application code is usually one import change.
+Connects to an API Gateway WebSocket endpoint fronting the rustyant-ws Lambda
+and issues Redis-style commands against the S3-backed key/value store.
 
 Example:
 
@@ -13,46 +11,21 @@ Example:
     c = Client("wss://abc123.execute-api.us-east-1.amazonaws.com/prod")
     c.set("hello", "world")
     assert c.get("hello") == b"world"
-    c.hset("profile", "name", "alice", "age", "30")
-    assert c.hget("profile", "name") == b"alice"
     c.close()
 """
 
 from __future__ import annotations
 
-from typing import Any, Iterable, Union
+from typing import Any
 
 import hiredis
 import websocket
 
-
-class RustyAntError(Exception):
-    """Raised when the server returns a RESP `-ERR` reply."""
+from rustyant._base import RustyAntError, _Arg, _RedisShapedClient, _encode_command
 
 
-_Arg = Union[str, bytes, int, float, bool]
-
-
-def _encode_command(*args: _Arg) -> bytes:
-    """Serialize a command tuple into a RESP2 array frame."""
-    crlf = b"\r\n"
-    parts = [b"*" + str(len(args)).encode() + crlf]
-    for arg in args:
-        if isinstance(arg, bytes):
-            value = arg
-        elif isinstance(arg, bool):
-            # Match redis-py: True→b"1", False→b"0".
-            value = b"1" if arg else b"0"
-        elif isinstance(arg, (int, float)):
-            value = repr(arg).encode()
-        else:
-            value = str(arg).encode("utf-8")
-        parts.append(b"$" + str(len(value)).encode() + crlf + value + crlf)
-    return b"".join(parts)
-
-
-class Client:
-    """Blocking rustyant client. Thread-unsafe — one Client per thread."""
+class Client(_RedisShapedClient):
+    """Blocking rustyant WebSocket client. Thread-unsafe — one Client per thread."""
 
     def __init__(
         self,
@@ -90,7 +63,7 @@ class Client:
     def __exit__(self, *_exc: object) -> None:
         self.close()
 
-    # ---- low-level dispatch --------------------------------------------
+    # ---- transport -----------------------------------------------------
 
     def _call(self, *args: _Arg) -> Any:
         if self._ws is None:
@@ -117,97 +90,3 @@ class Client:
         if isinstance(reply, hiredis.ReplyError):
             raise RustyAntError(str(reply))
         return reply
-
-    # ---- Redis-style command surface -----------------------------------
-
-    def ping(self) -> bytes:
-        return self._call("PING")
-
-    def set(
-        self,
-        key: _Arg,
-        value: _Arg,
-        *,
-        ex: int | None = None,
-        px: int | None = None,
-    ) -> bytes:
-        args: list[_Arg] = ["SET", key, value]
-        if ex is not None:
-            args += ["EX", ex]
-        if px is not None:
-            args += ["PX", px]
-        return self._call(*args)
-
-    def get(self, key: _Arg) -> bytes | None:
-        return self._call("GET", key)
-
-    def delete(self, *keys: _Arg) -> int:
-        return self._call("DEL", *keys)
-
-    def exists(self, *keys: _Arg) -> int:
-        return self._call("EXISTS", *keys)
-
-    def expire(self, key: _Arg, seconds: int) -> int:
-        return self._call("EXPIRE", key, seconds)
-
-    def ttl(self, key: _Arg) -> int:
-        return self._call("TTL", key)
-
-    def incr(self, key: _Arg) -> int:
-        return self._call("INCR", key)
-
-    def incrby(self, key: _Arg, delta: int) -> int:
-        return self._call("INCRBY", key, delta)
-
-    def hset(self, key: _Arg, *field_value_pairs: _Arg) -> int:
-        if len(field_value_pairs) < 2 or len(field_value_pairs) % 2 != 0:
-            raise ValueError("hset requires an even number of field/value args")
-        return self._call("HSET", key, *field_value_pairs)
-
-    def hget(self, key: _Arg, field: _Arg) -> bytes | None:
-        return self._call("HGET", key, field)
-
-    def hdel(self, key: _Arg, *fields: _Arg) -> int:
-        return self._call("HDEL", key, *fields)
-
-    def hgetall(self, key: _Arg) -> dict[bytes, bytes]:
-        flat: list[bytes] = self._call("HGETALL", key) or []
-        return dict(zip(flat[0::2], flat[1::2]))
-
-    def lpush(self, key: _Arg, *values: _Arg) -> int:
-        return self._call("LPUSH", key, *values)
-
-    def rpush(self, key: _Arg, *values: _Arg) -> int:
-        return self._call("RPUSH", key, *values)
-
-    def lpop(self, key: _Arg, count: int | None = None) -> Any:
-        if count is None:
-            return self._call("LPOP", key)
-        return self._call("LPOP", key, count)
-
-    def rpop(self, key: _Arg, count: int | None = None) -> Any:
-        if count is None:
-            return self._call("RPOP", key)
-        return self._call("RPOP", key, count)
-
-    def lrange(self, key: _Arg, start: int, stop: int) -> list[bytes]:
-        return self._call("LRANGE", key, start, stop)
-
-    def sadd(self, key: _Arg, *members: _Arg) -> int:
-        return self._call("SADD", key, *members)
-
-    def zadd(self, key: _Arg, mapping: dict[str, float] | Iterable[tuple[float, str]]) -> int:
-        """Accept either {member: score} or an iterable of (score, member) tuples."""
-        flat: list[_Arg] = []
-        if isinstance(mapping, dict):
-            for member, score in mapping.items():
-                flat += [score, member]
-        else:
-            for score, member in mapping:
-                flat += [score, member]
-        if not flat:
-            raise ValueError("zadd requires at least one score/member pair")
-        return self._call("ZADD", key, *flat)
-
-    def zrange(self, key: _Arg, start: int, stop: int) -> list[bytes]:
-        return self._call("ZRANGE", key, start, stop)

--- a/clients/python/rustyant/http_client.py
+++ b/clients/python/rustyant/http_client.py
@@ -1,0 +1,78 @@
+"""
+Rustyant HTTP client — one POST per command, RESP2 in body/response.
+
+Alternative to the WebSocket `Client` when the rustyant Lambda is fronted by
+an HTTP endpoint (Lambda Function URL, API Gateway HTTP API, or the legacy
+REST API). Simpler to deploy — no WebSocket API infrastructure — at the cost
+of per-command HTTP + TLS handshake.
+
+Example:
+
+    from rustyant import HttpClient
+
+    c = HttpClient("https://abc123.lambda-url.us-east-1.on.aws")
+    c.set("hello", "world")
+    assert c.get("hello") == b"world"
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import hiredis
+import requests
+
+from rustyant._base import RustyAntError, _Arg, _RedisShapedClient, _encode_command
+
+
+class HttpClient(_RedisShapedClient):
+    """Blocking rustyant HTTP client. Thread-unsafe — one HttpClient per thread."""
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        timeout: float = 10.0,
+        session: requests.Session | None = None,
+    ) -> None:
+        if not url.startswith(("http://", "https://")):
+            raise ValueError(f"expected http:// or https:// URL, got {url!r}")
+        self._url = url
+        self._timeout = timeout
+        self._session = session or requests.Session()
+        self._owns_session = session is None
+
+    def close(self) -> None:
+        if self._owns_session:
+            self._session.close()
+
+    def __enter__(self) -> "HttpClient":
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+    # ---- transport -----------------------------------------------------
+
+    def _call(self, *args: _Arg) -> Any:
+        packed = _encode_command(*args)
+        resp = self._session.post(
+            self._url,
+            data=packed,
+            headers={"Content-Type": "application/resp"},
+            timeout=self._timeout,
+        )
+        body = resp.content
+        if not body:
+            raise RustyAntError(f"empty response from {self._url} (status {resp.status_code})")
+
+        # One POST = one RESP reply; use a fresh parser per call so a prior
+        # short read can't corrupt the next one.
+        reader = hiredis.Reader()
+        reader.feed(body)
+        reply = reader.gets()
+        if reply is False:
+            raise RustyAntError(f"incomplete RESP reply from {self._url}")
+        if isinstance(reply, hiredis.ReplyError):
+            raise RustyAntError(str(reply))
+        return reply

--- a/clients/python/rustyant/http_client.py
+++ b/clients/python/rustyant/http_client.py
@@ -3,8 +3,13 @@ Rustyant HTTP client — one POST per command, RESP2 in body/response.
 
 Alternative to the WebSocket `Client` when the rustyant Lambda is fronted by
 an HTTP endpoint (Lambda Function URL, API Gateway HTTP API, or the legacy
-REST API). Simpler to deploy — no WebSocket API infrastructure — at the cost
-of per-command HTTP + TLS handshake.
+REST API). Both HTTP and WebSocket deployments are VPC-less and have
+equivalent infrastructure footprint — the distinction is developer-facing:
+the HTTP path is one Lambda behind one HTTPS route, while the WebSocket path
+needs `$connect`/`$disconnect`/`$default` routes and the
+`execute-api:ManageConnections` IAM grant so the Lambda can reply via the
+management API. Trade-off: HTTP pays a per-command TLS handshake; WebSocket
+pays the handshake once per connection.
 
 Example:
 

--- a/clients/python/tests/test_encoder.py
+++ b/clients/python/tests/test_encoder.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import pytest
 
-from rustyant.client import _encode_command
+from rustyant._base import _encode_command
 
 
 @pytest.mark.parametrize(

--- a/clients/python/tests/test_http_client.py
+++ b/clients/python/tests/test_http_client.py
@@ -1,0 +1,133 @@
+"""Tests for the HTTP transport client.
+
+No network — a fake `requests.Session` intercepts POSTs and returns
+canned RESP replies. Combined with the encoder tests, this proves the
+HTTP client produces the bytes the rustyant handler accepts and parses
+the bytes the handler returns.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from rustyant import HttpClient, RustyAntError
+
+
+@dataclass
+class _FakeResponse:
+    content: bytes
+    status_code: int = 200
+
+
+class _FakeSession:
+    """Captures POSTs and plays back a programmed queue of replies."""
+
+    def __init__(self, replies: list[bytes]) -> None:
+        self._replies = list(replies)
+        self.sent: list[bytes] = []
+
+    def post(self, url: str, *, data: bytes, headers: dict[str, str], timeout: float) -> _FakeResponse:
+        assert url == "https://example/"
+        assert headers["Content-Type"] == "application/resp"
+        assert timeout > 0
+        self.sent.append(data)
+        if not self._replies:
+            raise AssertionError("no more canned replies")
+        return _FakeResponse(self._replies.pop(0))
+
+    def close(self) -> None:
+        pass
+
+
+def _client(replies: list[bytes]) -> tuple[HttpClient, _FakeSession]:
+    sess = _FakeSession(replies)
+    return HttpClient("https://example/", session=sess), sess  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# URL validation
+# ---------------------------------------------------------------------------
+
+
+def test_http_client_rejects_non_http_url() -> None:
+    with pytest.raises(ValueError):
+        HttpClient("wss://example/")
+    with pytest.raises(ValueError):
+        HttpClient("redis://example/")
+
+
+# ---------------------------------------------------------------------------
+# Round trips — bytes sent match encoder, replies parse via hiredis
+# ---------------------------------------------------------------------------
+
+
+def test_ping_returns_pong() -> None:
+    c, sess = _client([b"+PONG\r\n"])
+    assert c.ping() == b"PONG"
+    assert sess.sent == [b"*1\r\n$4\r\nPING\r\n"]
+
+
+def test_set_and_get_roundtrip() -> None:
+    c, sess = _client([b"+OK\r\n", b"$5\r\nhello\r\n"])
+    assert c.set("k", "hello") == b"OK"
+    assert c.get("k") == b"hello"
+    assert sess.sent == [
+        b"*3\r\n$3\r\nSET\r\n$1\r\nk\r\n$5\r\nhello\r\n",
+        b"*2\r\n$3\r\nGET\r\n$1\r\nk\r\n",
+    ]
+
+
+def test_get_missing_returns_none() -> None:
+    c, _ = _client([b"$-1\r\n"])
+    assert c.get("missing") is None
+
+
+def test_incr_returns_int() -> None:
+    c, _ = _client([b":5\r\n"])
+    assert c.incr("counter") == 5
+
+
+def test_hgetall_returns_dict() -> None:
+    # HGETALL replies as a flat array which the base class zips into a dict.
+    c, _ = _client([b"*4\r\n$1\r\na\r\n$2\r\nv1\r\n$1\r\nb\r\n$2\r\nv2\r\n"])
+    assert c.hgetall("h") == {b"a": b"v1", b"b": b"v2"}
+
+
+def test_mget_returns_list_with_nil() -> None:
+    c, _ = _client([b"*3\r\n$1\r\n1\r\n$-1\r\n$1\r\n3\r\n"])
+    assert c.mget("a", "b", "c") == [b"1", None, b"3"]
+
+
+# ---------------------------------------------------------------------------
+# Error propagation
+# ---------------------------------------------------------------------------
+
+
+def test_server_error_reply_raises() -> None:
+    c, _ = _client([b"-WRONGTYPE oops\r\n"])
+    with pytest.raises(RustyAntError) as exc:
+        c.get("k")
+    assert "WRONGTYPE" in str(exc.value)
+
+
+def test_empty_body_raises() -> None:
+    c, _ = _client([b""])
+    with pytest.raises(RustyAntError):
+        c.ping()
+
+
+# ---------------------------------------------------------------------------
+# Resource management
+# ---------------------------------------------------------------------------
+
+
+def test_context_manager_closes_only_owned_session() -> None:
+    # Caller passed a session — close() must not close it.
+    sess = _FakeSession([b"+PONG\r\n"])
+    with HttpClient("https://example/", session=sess) as c:  # type: ignore[arg-type]
+        c.ping()
+    # Nothing broken if sess.close is called again explicitly:
+    sess.close()


### PR DESCRIPTION
## Summary

Adds \`rustyant.HttpClient\`, an HTTP-transport counterpart to the existing WebSocket \`Client\`. One HTTP POST per command, RESP2 in body and response. Targets rustyant deployments fronted by a Lambda Function URL or API Gateway HTTP API — simpler infra than the WebSocket path, at the cost of per-command handshake.

| Class | Transport | When to use |
|---|---|---|
| \`Client\` | WebSocket (\`wss://\`) | Persistent connection, pipelining, lower tail latency |
| \`HttpClient\` | HTTPS (\`https://\`) | One POST per command; Lambda Function URL works out of the box |

## Implementation

Refactors the redis-py-shaped command surface (~30 methods: ping, get, set, hset, lpush, zadd, …) into \`rustyant/_base.py\` as a \`_RedisShapedClient\` base class. Both \`Client\` and \`HttpClient\` extend it and override \`_call\` with their transport-specific payload shipping. The two transports can't drift in what they expose because the methods are defined exactly once.

\`HttpClient\` reuses a \`requests.Session\` for keep-alive; callers can inject their own pre-configured session (custom adapters, retries, auth). A caller-supplied session is **not** closed by \`HttpClient.close()\`.

## Test plan

- [x] 10 new tests in \`tests/test_http_client.py\` drive the client through a fake \`requests.Session\` that intercepts POSTs and plays back canned RESP bytes. Covers URL validation, ping, set/get round trip, nil GET, INCR, HGETALL → dict, MGET with nil, server \`-ERR\` raises, empty-body raises, and context-manager session ownership
- [x] Existing 8 encoder tests still pass
- [x] Rust side unchanged — 90 tests still pass
- [ ] CI green on this PR

## Package changes

- Version bumped from \`0.1.0\` → \`0.2.0\`
- \`requests>=2.31\` added as a dependency
- \`HttpClient\` exported from the package root