### PR TITLE
chore: CI install redis-py so compat tests actually run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,13 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install redis-py for the compat tests
+        # tests/redis_py_compat.rs shells out to `python3 -c "import redis; ..."`;
+        # without this step the tests skip gracefully but produce no coverage.
+        run: python -m pip install redis
       - name: Seed floci bucket
         run: |
           aws --endpoint-url=http://localhost:4566 --region us-east-1 \


### PR DESCRIPTION
## Summary

Closes the loop on #11 — the 11 redis-py compat tests were added in that PR but have been skipping in CI because the runner doesn't have the \`redis\` Python package installed. This PR adds \`actions/setup-python@v5\` + \`pip install redis\` to the \`test\` job so the suite actually runs.

## Why

\`tests/redis_py_compat.rs\` shells out to \`python3 -c \"import redis; r = redis.Redis(...)\"\` to exercise real redis-py against rustyant's dispatch. When \`import redis\` fails, each test prints \`SKIP\` and returns — so on the runner these tests were providing zero regression coverage, contrary to what the PR description claimed.

## What changes

\`\`\`yaml
- uses: actions/setup-python@v5
  with:
    python-version: "3.12"
- name: Install redis-py for the compat tests
  run: python -m pip install redis
\`\`\`

Inserted into the \`test\` job before the \`nextest\` step. \`actions/setup-python\` prepends its Python to \`PATH\`, so \`python3\` in the subprocess resolves to the one with \`redis\` installed.

## Test plan

- [x] YAML parses
- [ ] CI green on this PR, and specifically: the new redis-py compat tests should show 11 passes instead of 11 skips in the nextest output