### PR TITLE
feat: add GETSET, PERSIST, LINDEX, LSET, LREM, ZRANGEBYSCORE

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ Implemented:
 | Group | Commands |
 |---|---|
 | Server | `PING` |
-| Strings | `GET`, `SET` (+ `EX` / `PX` options), `SETNX`, `SETEX`, `MGET`, `MSET`, `DEL`, `EXISTS`, `EXPIRE`, `TTL`, `INCR`, `INCRBY` |
+| Strings | `GET`, `SET` (+ `EX` / `PX` options), `GETSET`, `SETNX`, `SETEX`, `MGET`, `MSET`, `DEL`, `EXISTS`, `EXPIRE`, `PERSIST`, `TTL`, `INCR`, `INCRBY` |
 | Hashes | `HSET`, `HGET`, `HDEL`, `HGETALL`, `HLEN`, `HKEYS`, `HVALS`, `HEXISTS`, `HMGET`, `HINCRBY` |
-| Lists | `LPUSH`, `RPUSH`, `LPOP` (+ count), `RPOP` (+ count), `LRANGE`, `LLEN` |
+| Lists | `LPUSH`, `RPUSH`, `LPOP` (+ count), `RPOP` (+ count), `LRANGE`, `LLEN`, `LINDEX`, `LSET`, `LREM` |
 | Sets | `SADD`, `SREM`, `SMEMBERS`, `SISMEMBER`, `SCARD` |
-| Sorted Sets | `ZADD`, `ZREM`, `ZINCRBY`, `ZRANGE`, `ZSCORE`, `ZCARD` |
+| Sorted Sets | `ZADD`, `ZREM`, `ZINCRBY`, `ZRANGE`, `ZRANGEBYSCORE`, `ZSCORE`, `ZCARD` |
 
-Not implemented (PRs welcome): `GETSET`, `PERSIST`, `KEYS`, `SCAN`, `LINDEX`, `LSET`, `LREM`, `ZRANGEBYSCORE`, and all pub/sub, transactions, scripting, streams, geo.
+Not implemented (PRs welcome): `KEYS`, `SCAN` (both need S3 `ListObjectsV2`), and all pub/sub, transactions, scripting, streams, geo.
 
 `MSET` is **not atomic across keys** — a failure partway through leaves earlier keys set. Real Redis is atomic here; rustyant's S3 backing makes the all-or-none semantic expensive, and the fire-and-forget variant is fine for most workloads.
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -3,7 +3,7 @@ use bytes::Bytes;
 use crate::error::RustyAntError;
 use crate::resp::RespReply;
 use crate::state::State;
-use crate::storage::{TtlResult, now_ms};
+use crate::storage::{ScoreBound, TtlResult, now_ms};
 
 pub async fn dispatch(state: &State, command_tokens: Vec<Bytes>) -> RespReply {
     match run(state, command_tokens).await {
@@ -25,6 +25,7 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "PING" => Ok(RespReply::SimpleString("PONG".into())),
         // Strings
         "GET" => handle_get(state, args).await,
+        "GETSET" => handle_getset(state, args).await,
         "SET" => handle_set(state, args).await,
         "SETNX" => handle_setnx(state, args).await,
         "SETEX" => handle_setex(state, args).await,
@@ -33,6 +34,7 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "DEL" => handle_del(state, args).await,
         "EXISTS" => handle_exists(state, args).await,
         "EXPIRE" => handle_expire(state, args).await,
+        "PERSIST" => handle_persist(state, args).await,
         "TTL" => handle_ttl(state, args).await,
         "INCR" => handle_incrby(state, args, 1).await,
         "INCRBY" => {
@@ -57,6 +59,9 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "RPOP" => handle_pop(state, args, false).await,
         "LRANGE" => handle_lrange(state, args).await,
         "LLEN" => handle_llen(state, args).await,
+        "LINDEX" => handle_lindex(state, args).await,
+        "LSET" => handle_lset(state, args).await,
+        "LREM" => handle_lrem(state, args).await,
         // Sets
         "SADD" => handle_sadd(state, args).await,
         "SREM" => handle_srem(state, args).await,
@@ -68,6 +73,7 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "ZREM" => handle_zrem(state, args).await,
         "ZINCRBY" => handle_zincrby(state, args).await,
         "ZRANGE" => handle_zrange(state, args).await,
+        "ZRANGEBYSCORE" => handle_zrangebyscore(state, args).await,
         "ZSCORE" => handle_zscore(state, args).await,
         "ZCARD" => handle_zcard(state, args).await,
         other => Err(RustyAntError::UnknownCommand(other.to_string())),
@@ -397,7 +403,57 @@ async fn handle_zcard(state: &State, args: Vec<Bytes>) -> Result<RespReply, Rust
     Ok(RespReply::Integer(n))
 }
 
-// ---- String multi-key + NX/EX ---------------------------------------------
+// ---- String multi-key + NX/EX + GETSET + PERSIST --------------------------
+
+async fn handle_getset(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("GETSET", args.len() == 2)?;
+    let key = arg_as_str(&args[0])?;
+    let old = state.storage.getset(key, args[1].clone()).await?;
+    Ok(old.map_or(RespReply::Nil, |v| RespReply::BulkString(Some(v))))
+}
+
+async fn handle_persist(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("PERSIST", args.len() == 1)?;
+    let key = arg_as_str(&args[0])?;
+    let cleared = state.storage.persist(key).await?;
+    Ok(RespReply::Integer(i64::from(cleared)))
+}
+
+async fn handle_lindex(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("LINDEX", args.len() == 2)?;
+    let key = arg_as_str(&args[0])?;
+    let index = parse_i64(&args[1], "index")?;
+    let elem = state.storage.lindex(key, index).await?;
+    Ok(elem.map_or(RespReply::Nil, |v| RespReply::BulkString(Some(v))))
+}
+
+async fn handle_lset(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("LSET", args.len() == 3)?;
+    let key = arg_as_str(&args[0])?;
+    let index = parse_i64(&args[1], "index")?;
+    state.storage.lset(key, index, args[2].clone()).await?;
+    Ok(RespReply::ok())
+}
+
+async fn handle_lrem(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("LREM", args.len() == 3)?;
+    let key = arg_as_str(&args[0])?;
+    let count = parse_i64(&args[1], "count")?;
+    let value = args[2].clone();
+    let removed = state.storage.lrem(key, count, value).await?;
+    Ok(RespReply::Integer(removed))
+}
+
+async fn handle_zrangebyscore(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("ZRANGEBYSCORE", args.len() == 3)?;
+    let key = arg_as_str(&args[0])?;
+    let min = ScoreBound::parse(arg_as_str(&args[1])?)?;
+    let max = ScoreBound::parse(arg_as_str(&args[2])?)?;
+    let members = state.storage.zrangebyscore(key, min, max).await?;
+    Ok(RespReply::Array(
+        members.into_iter().map(|m| RespReply::BulkString(Some(Bytes::from(m.into_bytes())))).collect(),
+    ))
+}
 
 async fn handle_setnx(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
     arity("SETNX", args.len() == 2)?;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -35,6 +35,51 @@ pub enum TtlResult {
     Ms(i64),
 }
 
+/// Score-bound for `ZRANGEBYSCORE` matching Redis's syntax: bare number is
+/// inclusive, `(N` is exclusive, `+inf` / `-inf` are the extremes.
+#[derive(Debug, Clone, Copy)]
+pub enum ScoreBound {
+    Inclusive(f64),
+    Exclusive(f64),
+    MinusInf,
+    PlusInf,
+}
+
+impl ScoreBound {
+    pub fn parse(s: &str) -> Result<Self, RustyAntError> {
+        if s == "-inf" {
+            return Ok(Self::MinusInf);
+        }
+        if s == "+inf" || s == "inf" {
+            return Ok(Self::PlusInf);
+        }
+        if let Some(rest) = s.strip_prefix('(') {
+            let v: f64 = rest.parse().map_err(|_| RustyAntError::Parse("score is not a float".into()))?;
+            return Ok(Self::Exclusive(v));
+        }
+        let v: f64 = s.parse().map_err(|_| RustyAntError::Parse("score is not a float".into()))?;
+        Ok(Self::Inclusive(v))
+    }
+
+    fn ge_min(self, score: f64) -> bool {
+        match self {
+            Self::Inclusive(v) => score >= v,
+            Self::Exclusive(v) => score > v,
+            Self::MinusInf => true,
+            Self::PlusInf => false,
+        }
+    }
+
+    fn le_max(self, score: f64) -> bool {
+        match self {
+            Self::Inclusive(v) => score <= v,
+            Self::Exclusive(v) => score < v,
+            Self::MinusInf => false,
+            Self::PlusInf => true,
+        }
+    }
+}
+
 pub fn now_ms() -> i64 {
     SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
 }
@@ -58,6 +103,44 @@ fn resolve_range(len: i64, start: i64, stop: i64) -> Option<(usize, usize)> {
 
 fn wrong_type(key: &str) -> RustyAntError {
     RustyAntError::WrongType { key: key.to_string() }
+}
+
+/// Remove up to `count` occurrences of `target` from `list`. Redis semantics:
+/// count > 0 removes from head, count < 0 removes from tail, count == 0
+/// removes all. Returns the number of elements removed.
+fn remove_list_occurrences(list: &mut Vec<Vec<u8>>, target: &[u8], count: i64) -> i64 {
+    let mut removed: i64 = 0;
+    if count >= 0 {
+        let max = if count == 0 { i64::MAX } else { count };
+        let mut i = 0;
+        while i < list.len() && removed < max {
+            if list[i].as_slice() == target {
+                list.remove(i);
+                removed += 1;
+            } else {
+                i += 1;
+            }
+        }
+    } else {
+        let max = -count;
+        let mut i = list.len();
+        while i > 0 && removed < max {
+            i -= 1;
+            if list[i].as_slice() == target {
+                list.remove(i);
+                removed += 1;
+            }
+        }
+    }
+    removed
+}
+
+/// Sort a `ZSet` by (score asc, member asc), then filter by the min/max
+/// bounds. Shared between `S3Storage` and `InMemoryStorage`.
+fn filter_zset_by_score(map: BTreeMap<String, f64>, min: ScoreBound, max: ScoreBound) -> Vec<String> {
+    let mut sorted: Vec<(String, f64)> = map.into_iter().collect();
+    sorted.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal).then_with(|| a.0.cmp(&b.0)));
+    sorted.into_iter().filter(|(_, s)| min.ge_min(*s) && max.le_max(*s)).map(|(m, _)| m).collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -117,7 +200,9 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn get_string(&self, key: &str) -> Result<Option<Bytes>, RustyAntError>;
     async fn set_string(&self, key: &str, value: Bytes, expires_at_ms: Option<i64>) -> Result<(), RustyAntError>;
     async fn set_string_nx(&self, key: &str, value: Bytes, expires_at_ms: Option<i64>) -> Result<bool, RustyAntError>;
+    async fn getset(&self, key: &str, value: Bytes) -> Result<Option<Bytes>, RustyAntError>;
     async fn incr_by(&self, key: &str, delta: i64) -> Result<i64, RustyAntError>;
+    async fn persist(&self, key: &str) -> Result<bool, RustyAntError>;
 
     /// Default: sequential `get_string` per key. Impls may override with a
     /// batched S3 request.
@@ -155,6 +240,9 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn list_pop(&self, key: &str, count: usize, left: bool) -> Result<Vec<Bytes>, RustyAntError>;
     async fn lrange(&self, key: &str, start: i64, stop: i64) -> Result<Vec<Bytes>, RustyAntError>;
     async fn llen(&self, key: &str) -> Result<i64, RustyAntError>;
+    async fn lindex(&self, key: &str, index: i64) -> Result<Option<Bytes>, RustyAntError>;
+    async fn lset(&self, key: &str, index: i64, value: Bytes) -> Result<(), RustyAntError>;
+    async fn lrem(&self, key: &str, count: i64, value: Bytes) -> Result<i64, RustyAntError>;
 
     async fn sadd(&self, key: &str, members: Vec<String>) -> Result<i64, RustyAntError>;
     async fn srem(&self, key: &str, members: &[String]) -> Result<i64, RustyAntError>;
@@ -166,6 +254,7 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn zrem(&self, key: &str, members: &[String]) -> Result<i64, RustyAntError>;
     async fn zincr_by(&self, key: &str, member: &str, delta: f64) -> Result<f64, RustyAntError>;
     async fn zrange(&self, key: &str, start: i64, stop: i64) -> Result<Vec<String>, RustyAntError>;
+    async fn zrangebyscore(&self, key: &str, min: ScoreBound, max: ScoreBound) -> Result<Vec<String>, RustyAntError>;
     async fn zscore(&self, key: &str, member: &str) -> Result<Option<f64>, RustyAntError>;
     async fn zcard(&self, key: &str) -> Result<i64, RustyAntError>;
 }
@@ -658,6 +747,96 @@ impl Storage for S3Storage {
         }
     }
 
+    async fn getset(&self, key: &str, value: Bytes) -> Result<Option<Bytes>, RustyAntError> {
+        self.cas(key, move |entry| {
+            let old = match entry {
+                Some(StoredValue { value: Value::String(data), .. }) => Some(Bytes::from(data.clone())),
+                Some(_) => return Err(wrong_type(key)),
+                None => None,
+            };
+            // Redis: GETSET clears any existing TTL (matches SET semantics).
+            let new_entry = StoredValue { expires_at_ms: None, value: Value::String(value.to_vec()) };
+            Ok(CasAction::Write(new_entry, old))
+        })
+        .await
+    }
+
+    async fn persist(&self, key: &str) -> Result<bool, RustyAntError> {
+        self.cas(key, move |entry| match entry {
+            Some(existing) if existing.expires_at_ms.is_some() => {
+                let mut new_entry = existing.clone();
+                new_entry.expires_at_ms = None;
+                Ok(CasAction::Write(new_entry, true))
+            }
+            _ => Ok(CasAction::NoOp(false)),
+        })
+        .await
+    }
+
+    async fn lindex(&self, key: &str, index: i64) -> Result<Option<Bytes>, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::List(l), .. }) => {
+                let len = i64::try_from(l.len()).unwrap_or(i64::MAX);
+                let actual = if index < 0 { len + index } else { index };
+                if actual < 0 || actual >= len {
+                    return Ok(None);
+                }
+                let i = usize::try_from(actual).unwrap_or(0);
+                Ok(Some(Bytes::from(l[i].clone())))
+            }
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(None),
+        }
+    }
+
+    async fn lset(&self, key: &str, index: i64, value: Bytes) -> Result<(), RustyAntError> {
+        self.cas(key, move |entry| {
+            let (mut list, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::List(l), expires_at_ms }) => (l.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => return Err(RustyAntError::Parse("no such key".into())),
+            };
+            let len = i64::try_from(list.len()).unwrap_or(i64::MAX);
+            let actual = if index < 0 { len + index } else { index };
+            if actual < 0 || actual >= len {
+                return Err(RustyAntError::Parse("index out of range".into()));
+            }
+            let i = usize::try_from(actual).unwrap_or(0);
+            list[i] = value.to_vec();
+            let new_entry = StoredValue { expires_at_ms, value: Value::List(list) };
+            Ok(CasAction::Write(new_entry, ()))
+        })
+        .await
+    }
+
+    async fn lrem(&self, key: &str, count: i64, value: Bytes) -> Result<i64, RustyAntError> {
+        self.cas(key, move |entry| {
+            let (mut list, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::List(l), expires_at_ms }) => (l.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => return Ok(CasAction::NoOp(0)),
+            };
+            let target = value.as_ref();
+            let removed = remove_list_occurrences(&mut list, target, count);
+            if list.is_empty() {
+                Ok(CasAction::Delete(removed))
+            } else {
+                let new_entry = StoredValue { expires_at_ms, value: Value::List(list) };
+                Ok(CasAction::Write(new_entry, removed))
+            }
+        })
+        .await
+    }
+
+    async fn zrangebyscore(&self, key: &str, min: ScoreBound, max: ScoreBound) -> Result<Vec<String>, RustyAntError> {
+        let map = match self.load(key).await? {
+            Some(StoredValue { value: Value::ZSet(m), .. }) => m,
+            Some(_) => return Err(wrong_type(key)),
+            None => return Ok(Vec::new()),
+        };
+        Ok(filter_zset_by_score(map, min, max))
+    }
+
     async fn hincr_by(&self, key: &str, field: &str, delta: i64) -> Result<i64, RustyAntError> {
         let field = field.to_string();
         self.cas(key, move |entry| {
@@ -1139,6 +1318,102 @@ impl Storage for InMemoryStorage {
             Some(_) => Err(wrong_type(key)),
             None => Ok(0),
         }
+    }
+
+    async fn getset(&self, key: &str, value: Bytes) -> Result<Option<Bytes>, RustyAntError> {
+        let old = match self.load(key) {
+            Some(StoredValue { value: Value::String(data), .. }) => Some(Bytes::from(data)),
+            Some(_) => return Err(wrong_type(key)),
+            None => None,
+        };
+        let entry = StoredValue { expires_at_ms: None, value: Value::String(value.to_vec()) };
+        self.with_entry_mut(|store| {
+            store.insert(key.to_string(), entry);
+        });
+        Ok(old)
+    }
+
+    async fn persist(&self, key: &str) -> Result<bool, RustyAntError> {
+        // Evict expired keys first so we don't "persist" a zombie.
+        if self.load(key).is_none() {
+            return Ok(false);
+        }
+        Ok(self.with_entry_mut(|map| {
+            let Some(entry) = map.get_mut(key) else {
+                return false;
+            };
+            if entry.expires_at_ms.is_some() {
+                entry.expires_at_ms = None;
+                true
+            } else {
+                false
+            }
+        }))
+    }
+
+    async fn lindex(&self, key: &str, index: i64) -> Result<Option<Bytes>, RustyAntError> {
+        match self.load(key) {
+            Some(StoredValue { value: Value::List(l), .. }) => {
+                let len = i64::try_from(l.len()).unwrap_or(i64::MAX);
+                let actual = if index < 0 { len + index } else { index };
+                if actual < 0 || actual >= len {
+                    return Ok(None);
+                }
+                let i = usize::try_from(actual).unwrap_or(0);
+                Ok(Some(Bytes::from(l[i].clone())))
+            }
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(None),
+        }
+    }
+
+    async fn lset(&self, key: &str, index: i64, value: Bytes) -> Result<(), RustyAntError> {
+        let (mut list, expires_at_ms) = match self.load(key) {
+            Some(StoredValue { value: Value::List(l), expires_at_ms }) => (l, expires_at_ms),
+            Some(_) => return Err(wrong_type(key)),
+            None => return Err(RustyAntError::Parse("no such key".into())),
+        };
+        let len = i64::try_from(list.len()).unwrap_or(i64::MAX);
+        let actual = if index < 0 { len + index } else { index };
+        if actual < 0 || actual >= len {
+            return Err(RustyAntError::Parse("index out of range".into()));
+        }
+        let i = usize::try_from(actual).unwrap_or(0);
+        list[i] = value.to_vec();
+        let entry = StoredValue { expires_at_ms, value: Value::List(list) };
+        self.with_entry_mut(|store| {
+            store.insert(key.to_string(), entry);
+        });
+        Ok(())
+    }
+
+    async fn lrem(&self, key: &str, count: i64, value: Bytes) -> Result<i64, RustyAntError> {
+        let (mut list, expires_at_ms) = match self.load(key) {
+            Some(StoredValue { value: Value::List(l), expires_at_ms }) => (l, expires_at_ms),
+            Some(_) => return Err(wrong_type(key)),
+            None => return Ok(0),
+        };
+        let removed = remove_list_occurrences(&mut list, value.as_ref(), count);
+        if list.is_empty() {
+            self.with_entry_mut(|store| {
+                store.remove(key);
+            });
+        } else {
+            let entry = StoredValue { expires_at_ms, value: Value::List(list) };
+            self.with_entry_mut(|store| {
+                store.insert(key.to_string(), entry);
+            });
+        }
+        Ok(removed)
+    }
+
+    async fn zrangebyscore(&self, key: &str, min: ScoreBound, max: ScoreBound) -> Result<Vec<String>, RustyAntError> {
+        let map = match self.load(key) {
+            Some(StoredValue { value: Value::ZSet(m), .. }) => m,
+            Some(_) => return Err(wrong_type(key)),
+            None => return Ok(Vec::new()),
+        };
+        Ok(filter_zset_by_score(map, min, max))
     }
 
     async fn hincr_by(&self, key: &str, field: &str, delta: i64) -> Result<i64, RustyAntError> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -673,6 +673,161 @@ async fn new_read_commands_all_error_on_wrong_type() {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Additional commands: GETSET, PERSIST, LINDEX, LSET, LREM, ZRANGEBYSCORE
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn getset_returns_old_and_clears_ttl() {
+    let state = test_state();
+    // No prior value → GETSET returns nil.
+    call(&state, &[b"GETSET", b"k", b"v1"]).await.expect_nil();
+    call(&state, &[b"GET", b"k"]).await.expect_bulk(b"v1");
+    // Second GETSET returns the prior value.
+    call(&state, &[b"GETSET", b"k", b"v2"]).await.expect_bulk(b"v1");
+    call(&state, &[b"GET", b"k"]).await.expect_bulk(b"v2");
+}
+
+#[tokio::test]
+async fn getset_clears_existing_ttl() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v", b"EX", b"120"]).await;
+    call(&state, &[b"GETSET", b"k", b"new"]).await.expect_bulk(b"v");
+    // TTL cleared — GETSET matches SET's overwrite semantics.
+    call(&state, &[b"TTL", b"k"]).await.expect_integer(-1);
+}
+
+#[tokio::test]
+async fn persist_removes_ttl() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v", b"EX", b"60"]).await;
+    call(&state, &[b"PERSIST", b"k"]).await.expect_integer(1);
+    call(&state, &[b"TTL", b"k"]).await.expect_integer(-1);
+}
+
+#[tokio::test]
+async fn persist_returns_zero_when_no_ttl_or_missing() {
+    let state = test_state();
+    call(&state, &[b"PERSIST", b"missing"]).await.expect_integer(0);
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"PERSIST", b"k"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn lindex_positive_and_negative() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"l", b"a", b"b", b"c", b"d"]).await;
+    call(&state, &[b"LINDEX", b"l", b"0"]).await.expect_bulk(b"a");
+    call(&state, &[b"LINDEX", b"l", b"3"]).await.expect_bulk(b"d");
+    call(&state, &[b"LINDEX", b"l", b"-1"]).await.expect_bulk(b"d");
+    call(&state, &[b"LINDEX", b"l", b"-4"]).await.expect_bulk(b"a");
+    // Out of range → nil.
+    call(&state, &[b"LINDEX", b"l", b"4"]).await.expect_nil();
+    call(&state, &[b"LINDEX", b"l", b"-5"]).await.expect_nil();
+    // Missing key → nil.
+    call(&state, &[b"LINDEX", b"missing", b"0"]).await.expect_nil();
+}
+
+#[tokio::test]
+async fn lset_updates_element() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"l", b"a", b"b", b"c"]).await;
+    call(&state, &[b"LSET", b"l", b"1", b"B"]).await.expect_simple("OK");
+    let items = call(&state, &[b"LRANGE", b"l", b"0", b"-1"]).await.into_bulk_array();
+    assert_eq!(items[0].as_ref(), b"a");
+    assert_eq!(items[1].as_ref(), b"B");
+    assert_eq!(items[2].as_ref(), b"c");
+    // Negative index.
+    call(&state, &[b"LSET", b"l", b"-1", b"C"]).await.expect_simple("OK");
+    let items = call(&state, &[b"LRANGE", b"l", b"0", b"-1"]).await.into_bulk_array();
+    assert_eq!(items[2].as_ref(), b"C");
+}
+
+#[tokio::test]
+async fn lset_errors_on_missing_key_or_bad_index() {
+    let state = test_state();
+    call(&state, &[b"LSET", b"missing", b"0", b"x"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"RPUSH", b"l", b"a"]).await;
+    call(&state, &[b"LSET", b"l", b"5", b"x"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"LSET", b"l", b"-5", b"x"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn lrem_positive_count_removes_from_head() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"l", b"a", b"b", b"a", b"c", b"a"]).await;
+    call(&state, &[b"LREM", b"l", b"2", b"a"]).await.expect_integer(2);
+    let items = call(&state, &[b"LRANGE", b"l", b"0", b"-1"]).await.into_bulk_array();
+    assert_eq!(items[0].as_ref(), b"b");
+    assert_eq!(items[1].as_ref(), b"c");
+    assert_eq!(items[2].as_ref(), b"a"); // third occurrence survives
+}
+
+#[tokio::test]
+async fn lrem_negative_count_removes_from_tail() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"l", b"a", b"b", b"a", b"c", b"a"]).await;
+    call(&state, &[b"LREM", b"l", b"-2", b"a"]).await.expect_integer(2);
+    let items = call(&state, &[b"LRANGE", b"l", b"0", b"-1"]).await.into_bulk_array();
+    assert_eq!(items[0].as_ref(), b"a"); // first survives (removed last two)
+    assert_eq!(items[1].as_ref(), b"b");
+    assert_eq!(items[2].as_ref(), b"c");
+}
+
+#[tokio::test]
+async fn lrem_zero_count_removes_all() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"l", b"a", b"b", b"a", b"a"]).await;
+    call(&state, &[b"LREM", b"l", b"0", b"a"]).await.expect_integer(3);
+    let items = call(&state, &[b"LRANGE", b"l", b"0", b"-1"]).await.into_bulk_array();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].as_ref(), b"b");
+}
+
+#[tokio::test]
+async fn lrem_empties_and_deletes_key() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"l", b"a", b"a"]).await;
+    call(&state, &[b"LREM", b"l", b"0", b"a"]).await.expect_integer(2);
+    call(&state, &[b"EXISTS", b"l"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn zrangebyscore_inclusive_bounds() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"a", b"2", b"b", b"3", b"c", b"4", b"d"]).await;
+    let m = call(&state, &[b"ZRANGEBYSCORE", b"z", b"2", b"3"]).await.into_bulk_array();
+    assert_eq!(m.len(), 2);
+    assert_eq!(m[0].as_ref(), b"b");
+    assert_eq!(m[1].as_ref(), b"c");
+}
+
+#[tokio::test]
+async fn zrangebyscore_exclusive_bounds() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"a", b"2", b"b", b"3", b"c"]).await;
+    // (1 3 means score > 1 and score <= 3.
+    let m = call(&state, &[b"ZRANGEBYSCORE", b"z", b"(1", b"3"]).await.into_bulk_array();
+    assert_eq!(m.len(), 2);
+    assert_eq!(m[0].as_ref(), b"b");
+    assert_eq!(m[1].as_ref(), b"c");
+    // Fully exclusive.
+    let m = call(&state, &[b"ZRANGEBYSCORE", b"z", b"(1", b"(3"]).await.into_bulk_array();
+    assert_eq!(m.len(), 1);
+    assert_eq!(m[0].as_ref(), b"b");
+}
+
+#[tokio::test]
+async fn zrangebyscore_infinity_bounds() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"a", b"2", b"b", b"3", b"c"]).await;
+    let m = call(&state, &[b"ZRANGEBYSCORE", b"z", b"-inf", b"+inf"]).await.into_bulk_array();
+    assert_eq!(m.len(), 3);
+    let m = call(&state, &[b"ZRANGEBYSCORE", b"z", b"-inf", b"2"]).await.into_bulk_array();
+    assert_eq!(m.len(), 2);
+    assert_eq!(m[1].as_ref(), b"b");
+}
+
 // Use RespReply publicly to check the crate re-export surface compiles.
 #[test]
 fn reply_encode_simple_works_from_tests() {


### PR DESCRIPTION
## Summary

Six more commands, closing most of the remaining gaps in the Redis surface.

| Command | Notes |
|---|---|
| \`GETSET\` | Atomic swap; returns old value, clears TTL (matches SET semantics) |
| \`PERSIST\` | Removes TTL from a key; \`1\` on success, \`0\` if no TTL or no key |
| \`LINDEX\` | List element by index; negative = from end; nil on out-of-range |
| \`LSET\` | Set list element at index; errors on missing key or out-of-range |
| \`LREM\` | Remove value from list; \`count > 0\` from head, \`< 0\` from tail, \`= 0\` all; deletes key when list becomes empty |
| \`ZRANGEBYSCORE\` | ZSet range by score; full Redis syntax — inclusive, \`(N\` exclusive, \`-inf\`/\`+inf\` |

All writes ride the existing \`self.cas\` helper, so S3 conditional-write semantics come for free.

## Implementation notes

- New \`ScoreBound\` enum in \`storage.rs\` parses the ZRANGEBYSCORE arg syntax (\`-inf\`, \`+inf\`, bare number = inclusive, \`(N\` = exclusive).
- \`remove_list_occurrences\` and \`filter_zset_by_score\` extracted as shared free functions so \`S3Storage\` and \`InMemoryStorage\` share the same LREM and ZRANGEBYSCORE logic.
- \`LSET\` returns \`-ERR no such key\` / \`-ERR index out of range\` to match Redis's error messages exactly.

## After this PR

Remaining unimplemented commands: \`KEYS\` and \`SCAN\` (both need \`ListObjectsV2\` against the S3 bucket — different code path from the current one-object-per-key flow), plus pub/sub, transactions (\`MULTI\`/\`EXEC\`, \`WATCH\`), scripting (\`EVAL\`), streams, and geo.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo test --all-targets\` — 115 pass (up from 101)
- [x] 14 new integration tests: GETSET returns old / clears TTL, PERSIST success/no-op paths, LINDEX positive + negative indices + out-of-range, LSET success + missing-key + bad-index, LREM count-positive/negative/zero + empty-collection cleanup, ZRANGEBYSCORE inclusive/exclusive bounds + infinity bounds
- [ ] CI green