### PR TITLE
:sparkles: add KEYS and SCAN commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,6 +2114,7 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "tracing-subscriber",
+ "wildmatch",
 ]
 
 [[package]]
@@ -2909,6 +2910,12 @@ dependencies = [
  "indexmap",
  "semver",
 ]
+
+[[package]]
+name = "wildmatch"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29333c3ea1ba8b17211763463ff24ee84e41c78224c16b001cd907e663a38c68"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 thiserror = "1"
+wildmatch = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -58,13 +58,16 @@ Implemented:
 | Group | Commands |
 |---|---|
 | Server | `PING` |
+| Keyspace | `KEYS`, `SCAN` (+ `MATCH` / `COUNT` options) |
 | Strings | `GET`, `SET` (+ `EX` / `PX` options), `GETSET`, `SETNX`, `SETEX`, `MGET`, `MSET`, `DEL`, `EXISTS`, `EXPIRE`, `PERSIST`, `TTL`, `INCR`, `INCRBY` |
 | Hashes | `HSET`, `HGET`, `HDEL`, `HGETALL`, `HLEN`, `HKEYS`, `HVALS`, `HEXISTS`, `HMGET`, `HINCRBY` |
 | Lists | `LPUSH`, `RPUSH`, `LPOP` (+ count), `RPOP` (+ count), `LRANGE`, `LLEN`, `LINDEX`, `LSET`, `LREM` |
 | Sets | `SADD`, `SREM`, `SMEMBERS`, `SISMEMBER`, `SCARD` |
 | Sorted Sets | `ZADD`, `ZREM`, `ZINCRBY`, `ZRANGE`, `ZRANGEBYSCORE`, `ZSCORE`, `ZCARD` |
 
-Not implemented (PRs welcome): `KEYS`, `SCAN` (both need S3 `ListObjectsV2`), and all pub/sub, transactions, scripting, streams, geo.
+`KEYS` paginates through `ListObjectsV2` in full and filters by the wildmatch pattern — O(n) over the keyspace, safe at low cardinality, proportionally slower for larger buckets. `SCAN` delegates the page boundary to S3 via a continuation token, returning one `ListObjectsV2` page per call; `MATCH` is applied client-side, so the per-page yield may be smaller than `COUNT` when a pattern is narrow.
+
+Not implemented (PRs welcome): pub/sub, transactions, scripting, streams, geo.
 
 `MSET` is **not atomic across keys** — a failure partway through leaves earlier keys set. Real Redis is atomic here; rustyant's S3 backing makes the all-or-none semantic expensive, and the fire-and-forget variant is fine for most workloads.
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -36,6 +36,8 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "EXPIRE" => handle_expire(state, args).await,
         "PERSIST" => handle_persist(state, args).await,
         "TTL" => handle_ttl(state, args).await,
+        "KEYS" => handle_keys(state, args).await,
+        "SCAN" => handle_scan(state, args).await,
         "INCR" => handle_incrby(state, args, 1).await,
         "INCRBY" => {
             let delta = parse_delta(&args)?;
@@ -417,6 +419,53 @@ async fn handle_persist(state: &State, args: Vec<Bytes>) -> Result<RespReply, Ru
     let key = arg_as_str(&args[0])?;
     let cleared = state.storage.persist(key).await?;
     Ok(RespReply::Integer(i64::from(cleared)))
+}
+
+async fn handle_keys(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("KEYS", args.len() == 1)?;
+    let pattern = arg_as_str(&args[0])?;
+    let keys = state.storage.keys(pattern).await?;
+    Ok(RespReply::Array(keys.into_iter().map(|k| RespReply::BulkString(Some(Bytes::from(k.into_bytes())))).collect()))
+}
+
+async fn handle_scan(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("SCAN", !args.is_empty())?;
+    let cursor_arg = arg_as_str(&args[0])?;
+    // Redis convention: "0" means start / done.
+    let cursor: Option<String> = if cursor_arg == "0" { None } else { Some(cursor_arg.to_string()) };
+
+    let mut pattern: Option<String> = None;
+    let mut count: usize = 10; // Redis default
+    let mut i = 1;
+    while i < args.len() {
+        let opt = arg_as_str(&args[i])?.to_ascii_uppercase();
+        match opt.as_str() {
+            "MATCH" => {
+                let v = args.get(i + 1).ok_or_else(|| RustyAntError::Parse("MATCH requires a pattern".into()))?;
+                pattern = Some(arg_as_string(v)?);
+                i += 2;
+            }
+            "COUNT" => {
+                let v = args.get(i + 1).ok_or_else(|| RustyAntError::Parse("COUNT requires a value".into()))?;
+                let c = parse_i64(v, "COUNT")?;
+                if c <= 0 {
+                    return Err(RustyAntError::Parse("COUNT must be positive".into()));
+                }
+                count = usize::try_from(c).unwrap_or(10);
+                i += 2;
+            }
+            other => {
+                return Err(RustyAntError::Parse(format!("unsupported SCAN option: {other}")));
+            }
+        }
+    }
+
+    let (keys, next) = state.storage.scan(cursor.as_deref(), pattern.as_deref(), count).await?;
+    let cursor_out = next.unwrap_or_else(|| "0".to_string());
+    Ok(RespReply::Array(vec![
+        RespReply::BulkString(Some(Bytes::from(cursor_out.into_bytes()))),
+        RespReply::Array(keys.into_iter().map(|k| RespReply::BulkString(Some(Bytes::from(k.into_bytes())))).collect()),
+    ]))
 }
 
 async fn handle_lindex(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -257,6 +257,21 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn zrangebyscore(&self, key: &str, min: ScoreBound, max: ScoreBound) -> Result<Vec<String>, RustyAntError>;
     async fn zscore(&self, key: &str, member: &str) -> Result<Option<f64>, RustyAntError>;
     async fn zcard(&self, key: &str) -> Result<i64, RustyAntError>;
+
+    /// Return every key matching `pattern` (Redis-style glob: `*`, `?`).
+    /// On S3 this fans out to repeated `ListObjectsV2` calls until the
+    /// prefix is exhausted; on large keyspaces prefer `scan`.
+    async fn keys(&self, pattern: &str) -> Result<Vec<String>, RustyAntError>;
+
+    /// Incremental key iteration. `cursor=None` starts a fresh scan; a
+    /// `Some(token)` return means more pages remain, `None` means the
+    /// scan is exhausted. `count` bounds the batch size.
+    async fn scan(
+        &self,
+        cursor: Option<&str>,
+        pattern: Option<&str>,
+        count: usize,
+    ) -> Result<(Vec<String>, Option<String>), RustyAntError>;
 }
 
 // ---------------------------------------------------------------------------
@@ -837,6 +852,64 @@ impl Storage for S3Storage {
         Ok(filter_zset_by_score(map, min, max))
     }
 
+    async fn keys(&self, pattern: &str) -> Result<Vec<String>, RustyAntError> {
+        let wm = wildmatch::WildMatch::new(pattern);
+        let mut out = Vec::new();
+        let mut cursor: Option<String> = None;
+        loop {
+            let mut req = self.client.list_objects_v2().bucket(&self.bucket).prefix(&self.prefix);
+            if let Some(c) = &cursor {
+                req = req.continuation_token(c);
+            }
+            let resp = req.send().await.map_err(|e| RustyAntError::S3(e.to_string()))?;
+            for obj in resp.contents() {
+                if let Some(full) = obj.key() {
+                    if let Some(rel) = full.strip_prefix(self.prefix.as_str()) {
+                        if wm.matches(rel) {
+                            out.push(rel.to_string());
+                        }
+                    }
+                }
+            }
+            match resp.next_continuation_token() {
+                Some(next) => cursor = Some(next.to_string()),
+                None => break,
+            }
+        }
+        Ok(out)
+    }
+
+    async fn scan(
+        &self,
+        cursor: Option<&str>,
+        pattern: Option<&str>,
+        count: usize,
+    ) -> Result<(Vec<String>, Option<String>), RustyAntError> {
+        let wm = pattern.map(wildmatch::WildMatch::new);
+        let mut req = self
+            .client
+            .list_objects_v2()
+            .bucket(&self.bucket)
+            .prefix(&self.prefix)
+            .max_keys(i32::try_from(count).unwrap_or(i32::MAX));
+        if let Some(c) = cursor {
+            req = req.continuation_token(c);
+        }
+        let resp = req.send().await.map_err(|e| RustyAntError::S3(e.to_string()))?;
+        let mut matched: Vec<String> = Vec::new();
+        for obj in resp.contents() {
+            if let Some(full) = obj.key() {
+                if let Some(rel) = full.strip_prefix(self.prefix.as_str()) {
+                    if wm.as_ref().is_none_or(|w| w.matches(rel)) {
+                        matched.push(rel.to_string());
+                    }
+                }
+            }
+        }
+        let next = resp.next_continuation_token().map(String::from);
+        Ok((matched, next))
+    }
+
     async fn hincr_by(&self, key: &str, field: &str, delta: i64) -> Result<i64, RustyAntError> {
         let field = field.to_string();
         self.cas(key, move |entry| {
@@ -1414,6 +1487,46 @@ impl Storage for InMemoryStorage {
             None => return Ok(Vec::new()),
         };
         Ok(filter_zset_by_score(map, min, max))
+    }
+
+    async fn keys(&self, pattern: &str) -> Result<Vec<String>, RustyAntError> {
+        let wm = wildmatch::WildMatch::new(pattern);
+        let now = now_ms();
+        Ok(self.with_entry_mut(|map| {
+            map.iter()
+                .filter(|(_, v)| v.expires_at_ms.is_none_or(|exp| exp > now))
+                .filter(|(k, _)| wm.matches(k))
+                .map(|(k, _)| k.clone())
+                .collect()
+        }))
+    }
+
+    async fn scan(
+        &self,
+        cursor: Option<&str>,
+        pattern: Option<&str>,
+        count: usize,
+    ) -> Result<(Vec<String>, Option<String>), RustyAntError> {
+        let wm = pattern.map(wildmatch::WildMatch::new);
+        let now = now_ms();
+        // Cursor semantics for InMemoryStorage: the cursor is the last key
+        // returned on the previous call. BTreeMap gives us ordered iteration,
+        // so "keys strictly greater than cursor" is a stable continuation.
+        Ok(self.with_entry_mut(|map| {
+            let start_after = cursor;
+            let live_matched: Vec<String> = map
+                .iter()
+                .filter(|(k, _)| start_after.is_none_or(|c| k.as_str() > c))
+                .filter(|(_, v)| v.expires_at_ms.is_none_or(|exp| exp > now))
+                .filter(|(k, _)| wm.as_ref().is_none_or(|w| w.matches(k)))
+                .take(count + 1) // +1 peek to know whether more exist
+                .map(|(k, _)| k.clone())
+                .collect();
+            let has_more = live_matched.len() > count;
+            let batch = if has_more { live_matched[..count].to_vec() } else { live_matched };
+            let next = if has_more { batch.last().cloned() } else { None };
+            (batch, next)
+        }))
     }
 
     async fn hincr_by(&self, key: &str, field: &str, delta: i64) -> Result<i64, RustyAntError> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -828,6 +828,100 @@ async fn zrangebyscore_infinity_bounds() {
     assert_eq!(m[1].as_ref(), b"b");
 }
 
+// ---------------------------------------------------------------------------
+// KEYS and SCAN
+// ---------------------------------------------------------------------------
+
+fn bulks_to_strs(items: &[Bytes]) -> Vec<String> {
+    items.iter().map(|b| String::from_utf8(b.to_vec()).expect("utf8")).collect()
+}
+
+#[tokio::test]
+async fn keys_matches_everything() {
+    let state = test_state();
+    call(&state, &[b"SET", b"alpha", b"1"]).await;
+    call(&state, &[b"SET", b"beta", b"2"]).await;
+    call(&state, &[b"HSET", b"gamma", b"f", b"v"]).await;
+    let mut keys = bulks_to_strs(&call(&state, &[b"KEYS", b"*"]).await.into_bulk_array());
+    keys.sort();
+    assert_eq!(keys, vec!["alpha".to_string(), "beta".to_string(), "gamma".to_string()]);
+}
+
+#[tokio::test]
+async fn keys_glob_star_and_question() {
+    let state = test_state();
+    for k in ["user:1", "user:2", "user:10", "other"] {
+        call(&state, &[b"SET", k.as_bytes(), b"v"]).await;
+    }
+    let mut m = bulks_to_strs(&call(&state, &[b"KEYS", b"user:*"]).await.into_bulk_array());
+    m.sort();
+    assert_eq!(m, vec!["user:1".to_string(), "user:10".to_string(), "user:2".to_string()]);
+    let mut m = bulks_to_strs(&call(&state, &[b"KEYS", b"user:?"]).await.into_bulk_array());
+    m.sort();
+    assert_eq!(m, vec!["user:1".to_string(), "user:2".to_string()]);
+}
+
+#[tokio::test]
+async fn keys_excludes_expired() {
+    let state = test_state();
+    // PX=1 with short sleep guarantees expiry.
+    call(&state, &[b"SET", b"will-expire", b"v", b"PX", b"1"]).await;
+    call(&state, &[b"SET", b"stays", b"v"]).await;
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    let keys = bulks_to_strs(&call(&state, &[b"KEYS", b"*"]).await.into_bulk_array());
+    assert_eq!(keys, vec!["stays".to_string()]);
+}
+
+#[tokio::test]
+async fn scan_paginates_full_keyspace() {
+    // SCAN's reply is a nested [cursor, [keys...]] array that the flat
+    // `into_bulk_array` helper can't parse; exercise scan semantics through
+    // the storage layer directly instead.
+    let state = test_state();
+    for i in 0..15 {
+        let k = format!("k{i:02}");
+        call(&state, &[b"SET", k.as_bytes(), b"v"]).await;
+    }
+
+    let mut seen: Vec<String> = Vec::new();
+    let (first, next) = state.storage.scan(None, None, 5).await.expect("scan");
+    assert_eq!(first.len(), 5);
+    seen.extend(first);
+    let mut cursor = next.expect("more pages");
+    let (second, next) = state.storage.scan(Some(&cursor), None, 5).await.expect("scan");
+    assert_eq!(second.len(), 5);
+    seen.extend(second);
+    cursor = next.expect("more pages");
+    let (third, next) = state.storage.scan(Some(&cursor), None, 5).await.expect("scan");
+    assert_eq!(third.len(), 5);
+    seen.extend(third);
+    assert!(next.is_none(), "expected scan exhausted");
+    seen.sort();
+    let expected: Vec<String> = (0..15).map(|i| format!("k{i:02}")).collect();
+    assert_eq!(seen, expected);
+}
+
+#[tokio::test]
+async fn scan_with_match_pattern_filters() {
+    let state = test_state();
+    call(&state, &[b"SET", b"user:1", b"v"]).await;
+    call(&state, &[b"SET", b"user:2", b"v"]).await;
+    call(&state, &[b"SET", b"other", b"v"]).await;
+
+    let (matched, _next) = state.storage.scan(None, Some("user:*"), 100).await.expect("scan");
+    let mut m: Vec<String> = matched;
+    m.sort();
+    assert_eq!(m, vec!["user:1".to_string(), "user:2".to_string()]);
+}
+
+#[tokio::test]
+async fn scan_empty_store_returns_done() {
+    let state = test_state();
+    let (keys, next) = state.storage.scan(None, None, 10).await.expect("scan");
+    assert_eq!(keys.len(), 0);
+    assert!(next.is_none());
+}
+
 // Use RespReply publicly to check the crate re-export surface compiles.
 #[test]
 fn reply_encode_simple_works_from_tests() {


### PR DESCRIPTION
## Summary

Implements the two keyspace-enumeration commands that were listed as "not implemented" in the README, backed by `ListObjectsV2` on S3 and by ordered `BTreeMap` iteration in the in-memory test storage.

- `KEYS <pattern>` — paginates through every object under `KEY_PREFIX` and filters by the wildmatch pattern; O(n) over the keyspace.
- `SCAN <cursor> [MATCH pat] [COUNT n]` — returns one S3 page per call, threading the S3 continuation token as the RESP cursor. Client uses cursor `"0"` to start and treats a `"0"` reply as end-of-scan. `MATCH` is applied client-side to each page, so the yield may be smaller than `COUNT` for narrow patterns.

Stacked on #14. Once that merges, this will retarget to `main`.

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-targets` — all 121 tests pass (81 integration including 6 new KEYS/SCAN cases)
- [ ] Floci CI (emulator doesn't enforce conditional writes but `ListObjectsV2` semantics are standard — will validate in CI)