### PR TITLE
:sparkles: CloudWatch EMF metrics on command dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ just test                 # cargo-nextest
 - `BUCKET` (required) — S3 bucket holding the key objects.
 - `KEY_PREFIX` (default `rustyant/`) — prefix prepended to every key.
 - `AWS_REGION`, `AWS_ENDPOINT_URL` — standard AWS env; `AWS_ENDPOINT_URL` points at a local S3 emulator.
+- `RUSTYANT_EMF_NAMESPACE` (optional) — when set, each dispatched command emits a CloudWatch Embedded Metric Format line to stdout with `DispatchCount` and `DispatchLatency` under the given namespace, dimensioned by `{Command, Outcome}`. Unset in local dev so the terminal stays clean; the SAM template sets it to `rustyant` for deployed Lambdas.
 
 ### Local S3 (floci)
 

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -46,6 +46,7 @@ Globals:
         KEY_PREFIX: !Ref KeyPrefix
         LOG_LEVEL: !Ref LogLevel
         RUST_LOG: !Ref LogLevel
+        RUSTYANT_EMF_NAMESPACE: rustyant
 
 Resources:
   # --- Storage ------------------------------------------------------------

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4,6 +4,7 @@ use bytes::Bytes;
 use tracing::info;
 
 use crate::error::RustyAntError;
+use crate::metrics;
 use crate::resp::RespReply;
 use crate::state::State;
 use crate::storage::{ScoreBound, TtlResult, now_ms};
@@ -77,6 +78,9 @@ pub async fn dispatch(state: &State, command_tokens: Vec<Bytes>) -> RespReply {
         duration_ms,
         "command dispatched",
     );
+    if let Some(ns) = state.settings.emf_namespace.as_deref() {
+        metrics::emit_command_metrics(ns, &cmd_name, outcome.as_str(), duration_ms);
+    }
     match result {
         Ok(reply) => reply,
         Err(e) => RespReply::err(format!("ERR {e}")),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod commands;
 pub mod error;
 pub mod handler;
+pub mod metrics;
 pub mod resp;
 pub mod settings;
 pub mod state;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,69 @@
+//! `CloudWatch` Embedded Metric Format emission.
+//!
+//! Writing a JSON line in EMF shape to stdout lets `CloudWatch` Logs
+//! auto-extract metrics (`DispatchCount`, `DispatchLatency`) under the
+//! configured namespace with {Command, Outcome} dimensions. No AWS SDK call
+//! needed.
+//!
+//! Gated on `Settings::emf_namespace` being set — unset in local dev so the
+//! terminal stays clean.
+
+use serde_json::{Value, json};
+
+/// Build the EMF JSON value. Separated from the emit function so tests can
+/// assert the exact shape without intercepting stdout.
+pub fn build_emf(namespace: &str, command: &str, outcome: &str, duration_ms: u64, timestamp_ms: i64) -> Value {
+    json!({
+        "_aws": {
+            "Timestamp": timestamp_ms,
+            "CloudWatchMetrics": [{
+                "Namespace": namespace,
+                "Dimensions": [["Command", "Outcome"]],
+                "Metrics": [
+                    {"Name": "DispatchCount", "Unit": "Count"},
+                    {"Name": "DispatchLatency", "Unit": "Milliseconds"}
+                ]
+            }]
+        },
+        "Command": command,
+        "Outcome": outcome,
+        "DispatchCount": 1,
+        "DispatchLatency": duration_ms,
+    })
+}
+
+pub fn emit_command_metrics(namespace: &str, command: &str, outcome: &str, duration_ms: u64) {
+    let v = build_emf(namespace, command, outcome, duration_ms, crate::storage::now_ms());
+    println!("{v}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn emf_has_required_shape() {
+        let v = build_emf("rustyant", "GET", "ok", 12, 1_712_345_678_000);
+        assert_eq!(v["Command"], "GET");
+        assert_eq!(v["Outcome"], "ok");
+        assert_eq!(v["DispatchCount"], 1);
+        assert_eq!(v["DispatchLatency"], 12);
+        let aws = &v["_aws"];
+        assert_eq!(aws["Timestamp"], 1_712_345_678_000_i64);
+        let metric_block = &aws["CloudWatchMetrics"][0];
+        assert_eq!(metric_block["Namespace"], "rustyant");
+        assert_eq!(metric_block["Dimensions"][0][0], "Command");
+        assert_eq!(metric_block["Dimensions"][0][1], "Outcome");
+        let metric_names: Vec<&str> =
+            metric_block["Metrics"].as_array().unwrap().iter().map(|m| m["Name"].as_str().unwrap()).collect();
+        assert_eq!(metric_names, vec!["DispatchCount", "DispatchLatency"]);
+    }
+
+    #[test]
+    fn emf_serializes_to_valid_json() {
+        let v = build_emf("ns", "SET", "ok", 0, 0);
+        let s = v.to_string();
+        let reparsed: Value = serde_json::from_str(&s).expect("roundtrip");
+        assert_eq!(reparsed, v);
+    }
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -8,6 +8,9 @@ pub struct Settings {
     pub key_prefix: String,
     pub aws_region: Option<String>,
     pub aws_endpoint_url: Option<String>,
+    /// When set, each dispatched command emits a `CloudWatch` EMF line with
+    /// this namespace. Unset in local dev so we don't pollute terminal output.
+    pub emf_namespace: Option<String>,
 }
 
 impl Settings {
@@ -16,7 +19,8 @@ impl Settings {
         let key_prefix = env::var("KEY_PREFIX").unwrap_or_else(|_| "rustyant/".to_string());
         let aws_region = env::var("AWS_REGION").ok();
         let aws_endpoint_url = env::var("AWS_ENDPOINT_URL").ok();
+        let emf_namespace = env::var("RUSTYANT_EMF_NAMESPACE").ok().filter(|s| !s.is_empty());
 
-        Ok(Self { bucket, key_prefix, aws_region, aws_endpoint_url })
+        Ok(Self { bucket, key_prefix, aws_region, aws_endpoint_url, emf_namespace })
     }
 }

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -82,6 +82,7 @@ mod tests {
             key_prefix: "t/".to_string(),
             aws_region: None,
             aws_endpoint_url: None,
+            emf_namespace: None,
         };
         State::with_storage(settings, Arc::new(InMemoryStorage::new()))
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -23,6 +23,7 @@ fn test_state() -> State {
         key_prefix: "test/".to_string(),
         aws_region: None,
         aws_endpoint_url: None,
+        emf_namespace: None,
     };
     State::with_storage(settings, Arc::new(InMemoryStorage::new()))
 }

--- a/tests/redis_py_compat.rs
+++ b/tests/redis_py_compat.rs
@@ -42,6 +42,7 @@ fn test_state() -> State {
         key_prefix: "redis-py/".to_string(),
         aws_region: None,
         aws_endpoint_url: None,
+        emf_namespace: None,
     };
     State::with_storage(settings, Arc::new(InMemoryStorage::new()))
 }

--- a/tests/ws_e2e.rs
+++ b/tests/ws_e2e.rs
@@ -35,6 +35,7 @@ fn test_state() -> State {
         key_prefix: "e2e/".to_string(),
         aws_region: None,
         aws_endpoint_url: None,
+        emf_namespace: None,
     };
     State::with_storage(settings, Arc::new(InMemoryStorage::new()))
 }


### PR DESCRIPTION
## Summary

Follow-up to #17. When `RUSTYANT_EMF_NAMESPACE` is set, each dispatched command prints a [CloudWatch Embedded Metric Format](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html) line to stdout. CloudWatch Logs automatically extracts two metrics:

- `DispatchCount` (Count) — per-invocation counter
- `DispatchLatency` (Milliseconds) — wall-clock time through `dispatch`

both dimensioned by `{Command, Outcome}`, so dashboards can slice by command (GET, HSET, ...) and by outcome tag (ok, wrong_type, contention, s3, ...).

No AWS SDK dependency — EMF is just stdout JSON. The SAM template sets `RUSTYANT_EMF_NAMESPACE=rustyant` for deployed Lambdas; local dev leaves it unset so the terminal stays clean.

`build_emf` is a pure value builder, unit-tested separately from the stdout side effect.

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-targets` — 123 tests pass (2 new EMF shape/roundtrip unit tests)
- [ ] Deployment validation deferred to the follow-up AWS smoke-test PR