### PR TITLE
:bug: conditional DeleteObject on empty-collection cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,10 @@ Not implemented (PRs welcome): pub/sub, transactions, scripting, streams, geo.
 
 ### Concurrency
 
-Read-modify-write commands (INCR, HSET, HDEL, LPUSH, RPUSH, LPOP, RPOP, SADD, ZADD, EXPIRE) use S3 conditional writes (`If-Match` on `ETag`) with bounded retry. Each `load → compute → save` goes through `If-Match: <etag>` on create-over-existing, or `If-None-Match: *` on first write. On HTTP 412 (precondition failed → concurrent modification) the operation backs off (10/20/40/80/160 ms) and re-reads; after 5 unsuccessful attempts the handler returns RESP `-ERR too much contention — retries exhausted`.
+Read-modify-write commands (INCR, HSET, HDEL, LPUSH, RPUSH, LPOP, RPOP, SADD, ZADD, EXPIRE) use S3 conditional writes (`If-Match` on `ETag`) with bounded retry. Each `load → compute → save` goes through `If-Match: <etag>` on create-over-existing, or `If-None-Match: *` on first write. When a mutation empties a collection (last field/element removed), the cleanup `DeleteObject` is also conditional on `If-Match: <etag>`, so a concurrent writer's new value isn't clobbered. On HTTP 412 (precondition failed → concurrent modification) the operation backs off (10/20/40/80/160 ms) and re-reads; after 5 unsuccessful attempts the handler returns RESP `-ERR too much contention — retries exhausted`.
 
 Known gaps:
-- When HDEL / LPOP / RPOP removes the last element and the key becomes empty, the underlying `DeleteObject` is unconditional (S3 doesn't support conditional delete). A narrow race window exists where a concurrent writer can be clobbered by the empty-collection cleanup.
-- The floci S3 emulator does **not** enforce conditional-write headers — it returns 200 on every PUT regardless of `If-Match`. The test `s3_concurrent_incr_converges` in `tests/floci.rs` is gated behind `RUSTYANT_S3_CAS=1` and only validates the retry loop against real AWS S3.
+- The floci S3 emulator does **not** enforce conditional-write headers — it returns 200 on every PUT/DELETE regardless of `If-Match`. The test `s3_concurrent_incr_converges` in `tests/floci.rs` is gated behind `RUSTYANT_S3_CAS=1` and only validates the retry loop against real AWS S3.
 
 ## Architecture
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -384,6 +384,25 @@ impl S3Storage {
         Ok(())
     }
 
+    /// Conditional DELETE. Returns `Err(Contention)` on HTTP 412, which the
+    /// CAS retry loop turns into another read-modify-write attempt. Used when
+    /// a mutation empties a collection (HDEL/LPOP/RPOP/SREM/ZREM of the last
+    /// member) so an unrelated concurrent writer's new value isn't clobbered.
+    async fn delete_if_match(&self, redis_key: &str, etag: &str) -> Result<(), RustyAntError> {
+        let res = self.client.delete_object().bucket(&self.bucket).key(self.key(redis_key)).if_match(etag).send().await;
+        match res {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                let is_412 = e.raw_response().is_some_and(|r| r.status().as_u16() == 412);
+                if is_412 {
+                    Err(RustyAntError::Contention)
+                } else {
+                    Err(RustyAntError::S3(e.into_service_error().to_string()))
+                }
+            }
+        }
+    }
+
     /// Read-modify-write helper: runs `modify` against the latest entry,
     /// writes the result back under ETag-based optimistic locking, retrying
     /// up to `MAX_CAS_RETRIES` times on contention.
@@ -400,12 +419,14 @@ impl S3Storage {
             };
             match modify(existing)? {
                 CasAction::NoOp(r) => return Ok(r),
-                CasAction::Delete(r) => {
-                    if etag.is_some() {
-                        self.delete_raw(redis_key).await?;
-                    }
-                    return Ok(r);
-                }
+                CasAction::Delete(r) => match etag {
+                    Some(e) => match self.delete_if_match(redis_key, &e).await {
+                        Ok(()) => return Ok(r),
+                        Err(RustyAntError::Contention) => (),
+                        Err(err) => return Err(err),
+                    },
+                    None => return Ok(r),
+                },
                 CasAction::Write(new_entry, r) => {
                     let cond = etag.map_or(CasCondition::CreateOnly, CasCondition::IfMatch);
                     match self.save_cas(redis_key, &new_entry, cond).await {


### PR DESCRIPTION
## Summary

Closes the "narrow race on empty-collection cleanup" documented under Known gaps in the README concurrency section.

When a read-modify-write empties a collection (last field removed via `HDEL`, last element via `LPOP`/`RPOP`, last member via `SREM`/`ZREM`), rustyant must delete the S3 object so the key reports as nonexistent. The old code called `DeleteObject` unconditionally — a concurrent writer that raced in between our `GetObject` (with its ETag) and the `DeleteObject` would have its new value wiped.

S3 added conditional `If-Match` support on `DeleteObject` in November 2024, and aws-sdk-s3 1.96 exposes it via a builder method. The CAS loop's `Delete` branch now calls `delete_if_match(key, etag)`; on HTTP 412 the loop falls through to the next iteration, which re-reads and re-evaluates the modify closure against the new state.

Non-CAS `delete_raw` is retained for non-CAS callers (the `DEL` command path, expired-key cleanup in the load path).

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-targets` — 123 tests pass
- [ ] CAS-on-delete path is guarded only by real S3: floci emulator returns 200 on every DELETE regardless of `If-Match` (same limitation noted for PUT). No new test added since `s3_concurrent_incr_converges` already covers the CAS retry loop semantics against real AWS under `RUSTYANT_S3_CAS=1`.