### PR TITLE
:sparkles: add TYPE command

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Implemented:
 | Group | Commands |
 |---|---|
 | Server | `PING` |
-| Keyspace | `KEYS`, `SCAN` (+ `MATCH` / `COUNT` options) |
+| Keyspace | `KEYS`, `SCAN` (+ `MATCH` / `COUNT` options), `TYPE` |
 | Strings | `GET`, `SET` (+ `EX` / `PX` options), `GETSET`, `SETNX`, `SETEX`, `MGET`, `MSET`, `DEL`, `EXISTS`, `EXPIRE`, `PERSIST`, `TTL`, `INCR`, `INCRBY` |
 | Hashes | `HSET`, `HGET`, `HDEL`, `HGETALL`, `HLEN`, `HKEYS`, `HVALS`, `HEXISTS`, `HMGET`, `HINCRBY` |
 | Lists | `LPUSH`, `RPUSH`, `LPOP` (+ count), `RPOP` (+ count), `LRANGE`, `LLEN`, `LINDEX`, `LSET`, `LREM` |

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -113,6 +113,7 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "TTL" => handle_ttl(state, args).await,
         "KEYS" => handle_keys(state, args).await,
         "SCAN" => handle_scan(state, args).await,
+        "TYPE" => handle_type(state, args).await,
         "INCR" => handle_incrby(state, args, 1).await,
         "INCRBY" => {
             let delta = parse_delta(&args)?;
@@ -501,6 +502,13 @@ async fn handle_keys(state: &State, args: Vec<Bytes>) -> Result<RespReply, Rusty
     let pattern = arg_as_str(&args[0])?;
     let keys = state.storage.keys(pattern).await?;
     Ok(RespReply::Array(keys.into_iter().map(|k| RespReply::BulkString(Some(Bytes::from(k.into_bytes())))).collect()))
+}
+
+async fn handle_type(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("TYPE", args.len() == 1)?;
+    let key = arg_as_str(&args[0])?;
+    let kind = state.storage.kind(key).await?.unwrap_or("none");
+    Ok(RespReply::SimpleString(kind.into()))
 }
 
 async fn handle_scan(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -105,6 +105,17 @@ fn wrong_type(key: &str) -> RustyAntError {
     RustyAntError::WrongType { key: key.to_string() }
 }
 
+/// Redis `TYPE` reply tag for a stored value.
+const fn value_kind(value: &Value) -> &'static str {
+    match value {
+        Value::String(_) => "string",
+        Value::Hash(_) => "hash",
+        Value::List(_) => "list",
+        Value::Set(_) => "set",
+        Value::ZSet(_) => "zset",
+    }
+}
+
 /// Remove up to `count` occurrences of `target` from `list`. Redis semantics:
 /// count > 0 removes from head, count < 0 removes from tail, count == 0
 /// removes all. Returns the number of elements removed.
@@ -196,6 +207,9 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn exists(&self, key: &str) -> Result<bool, RustyAntError>;
     async fn expire_at(&self, key: &str, expires_at_ms: i64) -> Result<bool, RustyAntError>;
     async fn ttl_ms(&self, key: &str) -> Result<TtlResult, RustyAntError>;
+    /// Redis `TYPE` — returns the value-kind tag (`"string"`, `"hash"`,
+    /// `"list"`, `"set"`, `"zset"`) or `None` when the key is missing/expired.
+    async fn kind(&self, key: &str) -> Result<Option<&'static str>, RustyAntError>;
 
     async fn get_string(&self, key: &str) -> Result<Option<Bytes>, RustyAntError>;
     async fn set_string(&self, key: &str, value: Bytes, expires_at_ms: Option<i64>) -> Result<(), RustyAntError>;
@@ -453,6 +467,10 @@ impl Storage for S3Storage {
 
     async fn exists(&self, key: &str) -> Result<bool, RustyAntError> {
         Ok(self.load(key).await?.is_some())
+    }
+
+    async fn kind(&self, key: &str) -> Result<Option<&'static str>, RustyAntError> {
+        Ok(self.load(key).await?.map(|v| value_kind(&v.value)))
     }
 
     async fn expire_at(&self, key: &str, expires_at_ms: i64) -> Result<bool, RustyAntError> {
@@ -1070,6 +1088,10 @@ impl Storage for InMemoryStorage {
 
     async fn exists(&self, key: &str) -> Result<bool, RustyAntError> {
         Ok(self.load(key).is_some())
+    }
+
+    async fn kind(&self, key: &str) -> Result<Option<&'static str>, RustyAntError> {
+        Ok(self.load(key).map(|v| value_kind(&v.value)))
     }
 
     async fn expire_at(&self, key: &str, expires_at_ms: i64) -> Result<bool, RustyAntError> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -923,6 +923,36 @@ async fn scan_empty_store_returns_done() {
     assert!(next.is_none());
 }
 
+#[tokio::test]
+async fn type_returns_none_for_missing_key() {
+    let state = test_state();
+    call(&state, &[b"TYPE", b"missing"]).await.expect_simple("none");
+}
+
+#[tokio::test]
+async fn type_reports_each_value_kind() {
+    let state = test_state();
+    call(&state, &[b"SET", b"s", b"v"]).await;
+    call(&state, &[b"HSET", b"h", b"f", b"v"]).await;
+    call(&state, &[b"LPUSH", b"l", b"x"]).await;
+    call(&state, &[b"SADD", b"set1", b"m"]).await;
+    call(&state, &[b"ZADD", b"z", b"1", b"m"]).await;
+
+    call(&state, &[b"TYPE", b"s"]).await.expect_simple("string");
+    call(&state, &[b"TYPE", b"h"]).await.expect_simple("hash");
+    call(&state, &[b"TYPE", b"l"]).await.expect_simple("list");
+    call(&state, &[b"TYPE", b"set1"]).await.expect_simple("set");
+    call(&state, &[b"TYPE", b"z"]).await.expect_simple("zset");
+}
+
+#[tokio::test]
+async fn type_returns_none_after_expiry() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v", b"PX", b"10"]).await;
+    tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+    call(&state, &[b"TYPE", b"k"]).await.expect_simple("none");
+}
+
 // Use RespReply publicly to check the crate re-export surface compiles.
 #[test]
 fn reply_encode_simple_works_from_tests() {


### PR DESCRIPTION
## Summary

Adds the `TYPE <key>` command, returning the Redis type tag as a RESP simple string:

- `string`, `hash`, `list`, `set`, `zset` for present keys of the respective kind
- `none` for missing or expired keys

Rounds out the keyspace group next to `KEYS` / `SCAN` — standard Redis clients frequently issue `TYPE` while iterating, so this removes a rough edge for mixed-type bucket usage.

Storage trait gains an `async fn kind(&self, key)`; both `S3Storage` and `InMemoryStorage` implement it via their existing `load` helper and a shared `value_kind(&Value)` match.

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-targets` — 126 pass (3 new TYPE tests covering each kind, missing key, and post-expiry)