### PR TITLE
:sparkles: add EXPIREAT and PEXPIREAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Implemented:
 |---|---|
 | Server | `PING` |
 | Keyspace | `KEYS`, `SCAN` (+ `MATCH` / `COUNT` options), `TYPE` |
-| Strings | `GET`, `SET` (+ `EX` / `PX` options), `GETSET`, `SETNX`, `SETEX`, `MGET`, `MSET`, `DEL`, `EXISTS`, `EXPIRE`, `PERSIST`, `TTL`, `INCR`, `INCRBY` |
+| Strings | `GET`, `SET` (+ `EX` / `PX` options), `GETSET`, `SETNX`, `SETEX`, `MGET`, `MSET`, `DEL`, `EXISTS`, `EXPIRE`, `EXPIREAT`, `PEXPIREAT`, `PERSIST`, `TTL`, `INCR`, `INCRBY` |
 | Hashes | `HSET`, `HGET`, `HDEL`, `HGETALL`, `HLEN`, `HKEYS`, `HVALS`, `HEXISTS`, `HMGET`, `HINCRBY` |
 | Lists | `LPUSH`, `RPUSH`, `LPOP` (+ count), `RPOP` (+ count), `LRANGE`, `LLEN`, `LINDEX`, `LSET`, `LREM` |
 | Sets | `SADD`, `SREM`, `SMEMBERS`, `SISMEMBER`, `SCARD` |

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -109,6 +109,8 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "DEL" => handle_del(state, args).await,
         "EXISTS" => handle_exists(state, args).await,
         "EXPIRE" => handle_expire(state, args).await,
+        "EXPIREAT" => handle_expireat(state, args).await,
+        "PEXPIREAT" => handle_pexpireat(state, args).await,
         "PERSIST" => handle_persist(state, args).await,
         "TTL" => handle_ttl(state, args).await,
         "KEYS" => handle_keys(state, args).await,
@@ -256,6 +258,22 @@ async fn handle_expire(state: &State, args: Vec<Bytes>) -> Result<RespReply, Rus
     let key = arg_as_str(&args[0])?;
     let secs = parse_i64(&args[1], "seconds")?;
     let set = state.storage.expire_at(key, now_ms() + secs * 1000).await?;
+    Ok(RespReply::Integer(i64::from(set)))
+}
+
+async fn handle_expireat(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("EXPIREAT", args.len() == 2)?;
+    let key = arg_as_str(&args[0])?;
+    let unix_secs = parse_i64(&args[1], "unix-time-seconds")?;
+    let set = state.storage.expire_at(key, unix_secs.saturating_mul(1000)).await?;
+    Ok(RespReply::Integer(i64::from(set)))
+}
+
+async fn handle_pexpireat(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("PEXPIREAT", args.len() == 2)?;
+    let key = arg_as_str(&args[0])?;
+    let unix_ms = parse_i64(&args[1], "unix-time-milliseconds")?;
+    let set = state.storage.expire_at(key, unix_ms).await?;
     Ok(RespReply::Integer(i64::from(set)))
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -231,6 +231,36 @@ async fn expire_on_missing_key_returns_zero() {
     call(&state, &[b"EXPIRE", b"nope", b"100"]).await.expect_integer(0);
 }
 
+#[tokio::test]
+async fn expireat_accepts_absolute_unix_seconds() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    // 100s from now → unix seconds roughly now + 100.
+    let target = (rustyant::storage::now_ms() / 1000 + 100).to_string();
+    call(&state, &[b"EXPIREAT", b"k", target.as_bytes()]).await.expect_integer(1);
+    // TTL should be in (0, 100].
+    let reply = call(&state, &[b"TTL", b"k"]).await;
+    let raw = String::from_utf8_lossy(&reply.raw);
+    let n: i64 = raw.trim_start_matches(':').trim_end().parse().expect("parse int");
+    assert!((1..=100).contains(&n), "TTL out of range: {n}");
+}
+
+#[tokio::test]
+async fn pexpireat_accepts_absolute_unix_milliseconds() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    // Past timestamp → key expires immediately.
+    call(&state, &[b"PEXPIREAT", b"k", b"1"]).await.expect_integer(1);
+    call(&state, &[b"GET", b"k"]).await.expect_nil();
+}
+
+#[tokio::test]
+async fn expireat_on_missing_key_returns_zero() {
+    let state = test_state();
+    let future = (rustyant::storage::now_ms() / 1000 + 60).to_string();
+    call(&state, &[b"EXPIREAT", b"missing", future.as_bytes()]).await.expect_integer(0);
+}
+
 // ---------------------------------------------------------------------------
 // Hashes
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Absolute-time variants of `EXPIRE`. `EXPIREAT` takes unix-seconds, `PEXPIREAT` takes unix-milliseconds — both convert to ms and funnel through the same `storage::expire_at` CAS path already used by `EXPIRE` and `SET EX/PX`. No storage-layer change needed.

Covers the common case where a caller knows the absolute deadline (e.g. a session token's server-issued `exp` claim) rather than a TTL from now.

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-targets` — 129 pass (3 new: absolute-seconds sets TTL in range, past-ms expires immediately, missing key returns 0)