### PR TITLE
:sparkles: add DECR and DECRBY

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Implemented:
 |---|---|
 | Server | `PING` |
 | Keyspace | `KEYS`, `SCAN` (+ `MATCH` / `COUNT` options), `TYPE` |
-| Strings | `GET`, `SET` (+ `EX` / `PX` options), `GETSET`, `SETNX`, `SETEX`, `MGET`, `MSET`, `DEL`, `EXISTS`, `EXPIRE`, `EXPIREAT`, `PEXPIREAT`, `PERSIST`, `TTL`, `INCR`, `INCRBY` |
+| Strings | `GET`, `SET` (+ `EX` / `PX` options), `GETSET`, `SETNX`, `SETEX`, `MGET`, `MSET`, `DEL`, `EXISTS`, `EXPIRE`, `EXPIREAT`, `PEXPIREAT`, `PERSIST`, `TTL`, `INCR`, `INCRBY`, `DECR`, `DECRBY` |
 | Hashes | `HSET`, `HGET`, `HDEL`, `HGETALL`, `HLEN`, `HKEYS`, `HVALS`, `HEXISTS`, `HMGET`, `HINCRBY` |
 | Lists | `LPUSH`, `RPUSH`, `LPOP` (+ count), `RPOP` (+ count), `LRANGE`, `LLEN`, `LINDEX`, `LSET`, `LREM` |
 | Sets | `SADD`, `SREM`, `SMEMBERS`, `SISMEMBER`, `SCARD` |

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -121,6 +121,12 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
             let delta = parse_delta(&args)?;
             handle_incrby(state, args, delta).await
         }
+        "DECR" => handle_incrby(state, args, -1).await,
+        "DECRBY" => {
+            let delta = parse_delta(&args)?;
+            let neg = delta.checked_neg().ok_or_else(|| RustyAntError::Parse("decrement overflow".into()))?;
+            handle_incrby(state, args, neg).await
+        }
         // Hashes
         "HSET" => handle_hset(state, args).await,
         "HGET" => handle_hget(state, args).await,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -194,6 +194,22 @@ async fn incr_on_non_integer_errors() {
 }
 
 #[tokio::test]
+async fn decr_on_missing_key_starts_at_minus_one() {
+    let state = test_state();
+    call(&state, &[b"DECR", b"c"]).await.expect_integer(-1);
+    call(&state, &[b"DECR", b"c"]).await.expect_integer(-2);
+    call(&state, &[b"DECRBY", b"c", b"10"]).await.expect_integer(-12);
+}
+
+#[tokio::test]
+async fn decrby_negative_value_increments() {
+    // Redis semantics: DECRBY k -5 is the same as INCRBY k 5.
+    let state = test_state();
+    call(&state, &[b"SET", b"n", b"10"]).await;
+    call(&state, &[b"DECRBY", b"n", b"-5"]).await.expect_integer(15);
+}
+
+#[tokio::test]
 async fn set_with_ex_sets_ttl() {
     let state = test_state();
     call(&state, &[b"SET", b"k", b"v", b"EX", b"60"]).await.expect_simple("OK");


### PR DESCRIPTION
## Summary

Round out the integer-arithmetic command set.

- `DECR <key>` — `handle_incrby(state, args, -1)`.
- `DECRBY <key> <amount>` — negates the parsed delta and forwards. Handles `i64::MIN` via `checked_neg` so a malicious `DECRBY k -9223372036854775808` returns a parse error instead of panicking.

Matches Redis semantics: `DECRBY k -5` is the same as `INCRBY k 5` (covered by test).

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-targets` — 131 pass (2 new: missing key starts at -1, negative DECRBY increments)