### PR TITLE
:sparkles: add GETDEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Implemented:
 |---|---|
 | Server | `PING` |
 | Keyspace | `KEYS`, `SCAN` (+ `MATCH` / `COUNT` options), `TYPE` |
-| Strings | `GET`, `SET` (+ `EX` / `PX` options), `GETSET`, `SETNX`, `SETEX`, `MGET`, `MSET`, `DEL`, `EXISTS`, `EXPIRE`, `EXPIREAT`, `PEXPIREAT`, `PERSIST`, `TTL`, `INCR`, `INCRBY`, `DECR`, `DECRBY` |
+| Strings | `GET`, `SET` (+ `EX` / `PX` options), `GETSET`, `GETDEL`, `SETNX`, `SETEX`, `MGET`, `MSET`, `DEL`, `EXISTS`, `EXPIRE`, `EXPIREAT`, `PEXPIREAT`, `PERSIST`, `TTL`, `INCR`, `INCRBY`, `DECR`, `DECRBY` |
 | Hashes | `HSET`, `HGET`, `HDEL`, `HGETALL`, `HLEN`, `HKEYS`, `HVALS`, `HEXISTS`, `HMGET`, `HINCRBY` |
 | Lists | `LPUSH`, `RPUSH`, `LPOP` (+ count), `RPOP` (+ count), `LRANGE`, `LLEN`, `LINDEX`, `LSET`, `LREM` |
 | Sets | `SADD`, `SREM`, `SMEMBERS`, `SISMEMBER`, `SCARD` |

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -101,6 +101,7 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         // Strings
         "GET" => handle_get(state, args).await,
         "GETSET" => handle_getset(state, args).await,
+        "GETDEL" => handle_getdel(state, args).await,
         "SET" => handle_set(state, args).await,
         "SETNX" => handle_setnx(state, args).await,
         "SETEX" => handle_setex(state, args).await,
@@ -511,6 +512,13 @@ async fn handle_getset(state: &State, args: Vec<Bytes>) -> Result<RespReply, Rus
     arity("GETSET", args.len() == 2)?;
     let key = arg_as_str(&args[0])?;
     let old = state.storage.getset(key, args[1].clone()).await?;
+    Ok(old.map_or(RespReply::Nil, |v| RespReply::BulkString(Some(v))))
+}
+
+async fn handle_getdel(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("GETDEL", args.len() == 1)?;
+    let key = arg_as_str(&args[0])?;
+    let old = state.storage.get_and_delete(key).await?;
     Ok(old.map_or(RespReply::Nil, |v| RespReply::BulkString(Some(v))))
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -215,6 +215,7 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn set_string(&self, key: &str, value: Bytes, expires_at_ms: Option<i64>) -> Result<(), RustyAntError>;
     async fn set_string_nx(&self, key: &str, value: Bytes, expires_at_ms: Option<i64>) -> Result<bool, RustyAntError>;
     async fn getset(&self, key: &str, value: Bytes) -> Result<Option<Bytes>, RustyAntError>;
+    async fn get_and_delete(&self, key: &str) -> Result<Option<Bytes>, RustyAntError>;
     async fn incr_by(&self, key: &str, delta: i64) -> Result<i64, RustyAntError>;
     async fn persist(&self, key: &str) -> Result<bool, RustyAntError>;
 
@@ -811,6 +812,17 @@ impl Storage for S3Storage {
             // Redis: GETSET clears any existing TTL (matches SET semantics).
             let new_entry = StoredValue { expires_at_ms: None, value: Value::String(value.to_vec()) };
             Ok(CasAction::Write(new_entry, old))
+        })
+        .await
+    }
+
+    async fn get_and_delete(&self, key: &str) -> Result<Option<Bytes>, RustyAntError> {
+        self.cas(key, move |entry| match entry {
+            None => Ok(CasAction::NoOp(None)),
+            Some(StoredValue { value: Value::String(data), .. }) => {
+                Ok(CasAction::Delete(Some(Bytes::from(data.clone()))))
+            }
+            Some(_) => Err(wrong_type(key)),
         })
         .await
     }
@@ -1447,6 +1459,17 @@ impl Storage for InMemoryStorage {
             store.insert(key.to_string(), entry);
         });
         Ok(old)
+    }
+
+    async fn get_and_delete(&self, key: &str) -> Result<Option<Bytes>, RustyAntError> {
+        match self.load(key) {
+            None => Ok(None),
+            Some(StoredValue { value: Value::String(data), .. }) => {
+                self.with_entry_mut(|store| store.remove(key));
+                Ok(Some(Bytes::from(data)))
+            }
+            Some(_) => Err(wrong_type(key)),
+        }
     }
 
     async fn persist(&self, key: &str) -> Result<bool, RustyAntError> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -210,6 +210,29 @@ async fn decrby_negative_value_increments() {
 }
 
 #[tokio::test]
+async fn getdel_returns_value_and_removes_key() {
+    let state = test_state();
+    call(&state, &[b"SET", b"token", b"abc123"]).await;
+    call(&state, &[b"GETDEL", b"token"]).await.expect_bulk(b"abc123");
+    call(&state, &[b"EXISTS", b"token"]).await.expect_integer(0);
+    call(&state, &[b"GET", b"token"]).await.expect_nil();
+}
+
+#[tokio::test]
+async fn getdel_on_missing_key_returns_nil() {
+    let state = test_state();
+    call(&state, &[b"GETDEL", b"ghost"]).await.expect_nil();
+}
+
+#[tokio::test]
+async fn getdel_on_wrong_type_errors_and_preserves_key() {
+    let state = test_state();
+    call(&state, &[b"LPUSH", b"queue", b"item"]).await;
+    call(&state, &[b"GETDEL", b"queue"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"EXISTS", b"queue"]).await.expect_integer(1);
+}
+
+#[tokio::test]
 async fn set_with_ex_sets_ttl() {
     let state = test_state();
     call(&state, &[b"SET", b"k", b"v", b"EX", b"60"]).await.expect_simple("OK");


### PR DESCRIPTION
## Summary

Atomic get-and-delete on a string key, matching Redis's `GETDEL`.

S3 path uses the existing CAS helper: `load → CasAction::Delete(Some(value))`. The conditional `If-Match` on the DeleteObject (landed in #20) means a concurrent writer can't have their new value wiped — if they raced in, the CAS retries, the reloaded entry no longer matches the original bytes, and the handler sees the current state.

`get_and_delete` on the Storage trait keeps the wrong-type contract: a non-string key returns `ERR wrong type` and stays intact.

Common pattern for one-shot token consumption, session handshakes, lease handoffs — where "read the value and make sure no one else can read it" is the desired atomicity.

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-targets` — 134 pass (3 new: roundtrip-and-remove, missing returns nil, wrong-type preserves key)