### PR TITLE
:sparkles: add STRLEN and APPEND

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Implemented:
 |---|---|
 | Server | `PING` |
 | Keyspace | `KEYS`, `SCAN` (+ `MATCH` / `COUNT` options), `TYPE` |
-| Strings | `GET`, `SET` (+ `EX` / `PX` options), `GETSET`, `GETDEL`, `SETNX`, `SETEX`, `MGET`, `MSET`, `DEL`, `EXISTS`, `EXPIRE`, `EXPIREAT`, `PEXPIREAT`, `PERSIST`, `TTL`, `INCR`, `INCRBY`, `DECR`, `DECRBY` |
+| Strings | `GET`, `SET` (+ `EX` / `PX` options), `GETSET`, `GETDEL`, `SETNX`, `SETEX`, `MGET`, `MSET`, `APPEND`, `STRLEN`, `DEL`, `EXISTS`, `EXPIRE`, `EXPIREAT`, `PEXPIREAT`, `PERSIST`, `TTL`, `INCR`, `INCRBY`, `DECR`, `DECRBY` |
 | Hashes | `HSET`, `HGET`, `HDEL`, `HGETALL`, `HLEN`, `HKEYS`, `HVALS`, `HEXISTS`, `HMGET`, `HINCRBY` |
 | Lists | `LPUSH`, `RPUSH`, `LPOP` (+ count), `RPOP` (+ count), `LRANGE`, `LLEN`, `LINDEX`, `LSET`, `LREM` |
 | Sets | `SADD`, `SREM`, `SMEMBERS`, `SISMEMBER`, `SCARD` |

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -102,6 +102,8 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "GET" => handle_get(state, args).await,
         "GETSET" => handle_getset(state, args).await,
         "GETDEL" => handle_getdel(state, args).await,
+        "STRLEN" => handle_strlen(state, args).await,
+        "APPEND" => handle_append(state, args).await,
         "SET" => handle_set(state, args).await,
         "SETNX" => handle_setnx(state, args).await,
         "SETEX" => handle_setex(state, args).await,
@@ -520,6 +522,20 @@ async fn handle_getdel(state: &State, args: Vec<Bytes>) -> Result<RespReply, Rus
     let key = arg_as_str(&args[0])?;
     let old = state.storage.get_and_delete(key).await?;
     Ok(old.map_or(RespReply::Nil, |v| RespReply::BulkString(Some(v))))
+}
+
+async fn handle_strlen(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("STRLEN", args.len() == 1)?;
+    let key = arg_as_str(&args[0])?;
+    let len = state.storage.strlen(key).await?;
+    Ok(RespReply::Integer(len))
+}
+
+async fn handle_append(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("APPEND", args.len() == 2)?;
+    let key = arg_as_str(&args[0])?;
+    let len = state.storage.append(key, args[1].clone()).await?;
+    Ok(RespReply::Integer(len))
 }
 
 async fn handle_persist(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -216,6 +216,8 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn set_string_nx(&self, key: &str, value: Bytes, expires_at_ms: Option<i64>) -> Result<bool, RustyAntError>;
     async fn getset(&self, key: &str, value: Bytes) -> Result<Option<Bytes>, RustyAntError>;
     async fn get_and_delete(&self, key: &str) -> Result<Option<Bytes>, RustyAntError>;
+    async fn strlen(&self, key: &str) -> Result<i64, RustyAntError>;
+    async fn append(&self, key: &str, value: Bytes) -> Result<i64, RustyAntError>;
     async fn incr_by(&self, key: &str, delta: i64) -> Result<i64, RustyAntError>;
     async fn persist(&self, key: &str) -> Result<bool, RustyAntError>;
 
@@ -823,6 +825,29 @@ impl Storage for S3Storage {
                 Ok(CasAction::Delete(Some(Bytes::from(data.clone()))))
             }
             Some(_) => Err(wrong_type(key)),
+        })
+        .await
+    }
+
+    async fn strlen(&self, key: &str) -> Result<i64, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::String(data), .. }) => Ok(i64::try_from(data.len()).unwrap_or(i64::MAX)),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(0),
+        }
+    }
+
+    async fn append(&self, key: &str, value: Bytes) -> Result<i64, RustyAntError> {
+        self.cas(key, move |entry| {
+            let (mut data, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::String(d), expires_at_ms }) => (d.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => (Vec::new(), None),
+            };
+            data.extend_from_slice(&value);
+            let len = i64::try_from(data.len()).unwrap_or(i64::MAX);
+            let new_entry = StoredValue { expires_at_ms, value: Value::String(data) };
+            Ok(CasAction::Write(new_entry, len))
         })
         .await
     }
@@ -1470,6 +1495,29 @@ impl Storage for InMemoryStorage {
             }
             Some(_) => Err(wrong_type(key)),
         }
+    }
+
+    async fn strlen(&self, key: &str) -> Result<i64, RustyAntError> {
+        match self.load(key) {
+            Some(StoredValue { value: Value::String(data), .. }) => Ok(i64::try_from(data.len()).unwrap_or(i64::MAX)),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(0),
+        }
+    }
+
+    async fn append(&self, key: &str, value: Bytes) -> Result<i64, RustyAntError> {
+        let (mut data, expires_at_ms) = match self.load(key) {
+            Some(StoredValue { value: Value::String(d), expires_at_ms }) => (d, expires_at_ms),
+            Some(_) => return Err(wrong_type(key)),
+            None => (Vec::new(), None),
+        };
+        data.extend_from_slice(&value);
+        let len = i64::try_from(data.len()).unwrap_or(i64::MAX);
+        let entry = StoredValue { expires_at_ms, value: Value::String(data) };
+        self.with_entry_mut(|store| {
+            store.insert(key.to_string(), entry);
+        });
+        Ok(len)
     }
 
     async fn persist(&self, key: &str) -> Result<bool, RustyAntError> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -233,6 +233,49 @@ async fn getdel_on_wrong_type_errors_and_preserves_key() {
 }
 
 #[tokio::test]
+async fn strlen_returns_byte_length() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"hello"]).await;
+    call(&state, &[b"STRLEN", b"k"]).await.expect_integer(5);
+}
+
+#[tokio::test]
+async fn strlen_on_missing_key_returns_zero() {
+    let state = test_state();
+    call(&state, &[b"STRLEN", b"ghost"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn strlen_on_wrong_type_errors() {
+    let state = test_state();
+    call(&state, &[b"LPUSH", b"queue", b"item"]).await;
+    call(&state, &[b"STRLEN", b"queue"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn append_to_missing_key_creates_string() {
+    let state = test_state();
+    call(&state, &[b"APPEND", b"k", b"hello"]).await.expect_integer(5);
+    call(&state, &[b"GET", b"k"]).await.expect_bulk(b"hello");
+}
+
+#[tokio::test]
+async fn append_to_existing_string_concatenates() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"hello"]).await;
+    call(&state, &[b"APPEND", b"k", b" world"]).await.expect_integer(11);
+    call(&state, &[b"GET", b"k"]).await.expect_bulk(b"hello world");
+}
+
+#[tokio::test]
+async fn append_on_wrong_type_errors_and_preserves_key() {
+    let state = test_state();
+    call(&state, &[b"LPUSH", b"queue", b"item"]).await;
+    call(&state, &[b"APPEND", b"queue", b"x"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"LLEN", b"queue"]).await.expect_integer(1);
+}
+
+#[tokio::test]
 async fn set_with_ex_sets_ttl() {
     let state = test_state();
     call(&state, &[b"SET", b"k", b"v", b"EX", b"60"]).await.expect_simple("OK");


### PR DESCRIPTION
## Summary

Byte-length and byte-concatenation on string keys.

`STRLEN` is a plain load — returns 0 on a missing key, `ERR wrong type` on a non-string. `APPEND` routes through the existing CAS helper: extend the loaded value and write back under `If-Match`, creating the key when absent and preserving any existing TTL. Both return the resulting length as an integer.

Common workloads: `STRLEN` for size-gating stored payloads and `APPEND` for bounded log-like keys where a new record is appended per write.

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-targets` — 140 pass (6 new: strlen byte-length / missing returns 0 / wrong-type errors; append creates-on-missing / concatenates / wrong-type preserves key)