### PR TITLE
:sparkles: add HSETNX and HSTRLEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Implemented:
 | Server | `PING` |
 | Keyspace | `KEYS`, `SCAN` (+ `MATCH` / `COUNT` options), `TYPE` |
 | Strings | `GET`, `SET` (+ `EX` / `PX` options), `GETSET`, `GETDEL`, `SETNX`, `SETEX`, `MGET`, `MSET`, `APPEND`, `STRLEN`, `DEL`, `EXISTS`, `EXPIRE`, `EXPIREAT`, `PEXPIREAT`, `PERSIST`, `TTL`, `INCR`, `INCRBY`, `DECR`, `DECRBY` |
-| Hashes | `HSET`, `HGET`, `HDEL`, `HGETALL`, `HLEN`, `HKEYS`, `HVALS`, `HEXISTS`, `HMGET`, `HINCRBY` |
+| Hashes | `HSET`, `HSETNX`, `HGET`, `HDEL`, `HGETALL`, `HLEN`, `HKEYS`, `HVALS`, `HEXISTS`, `HSTRLEN`, `HMGET`, `HINCRBY` |
 | Lists | `LPUSH`, `RPUSH`, `LPOP` (+ count), `RPOP` (+ count), `LRANGE`, `LLEN`, `LINDEX`, `LSET`, `LREM` |
 | Sets | `SADD`, `SREM`, `SMEMBERS`, `SISMEMBER`, `SCARD` |
 | Sorted Sets | `ZADD`, `ZREM`, `ZINCRBY`, `ZRANGE`, `ZRANGEBYSCORE`, `ZSCORE`, `ZCARD` |

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -132,6 +132,7 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         }
         // Hashes
         "HSET" => handle_hset(state, args).await,
+        "HSETNX" => handle_hsetnx(state, args).await,
         "HGET" => handle_hget(state, args).await,
         "HDEL" => handle_hdel(state, args).await,
         "HGETALL" => handle_hgetall(state, args).await,
@@ -139,6 +140,7 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "HKEYS" => handle_hkeys(state, args).await,
         "HVALS" => handle_hvals(state, args).await,
         "HEXISTS" => handle_hexists(state, args).await,
+        "HSTRLEN" => handle_hstrlen(state, args).await,
         "HMGET" => handle_hmget(state, args).await,
         "HINCRBY" => handle_hincrby(state, args).await,
         // Lists
@@ -455,6 +457,20 @@ async fn handle_hexists(state: &State, args: Vec<Bytes>) -> Result<RespReply, Ru
     arity("HEXISTS", args.len() == 2)?;
     let present = state.storage.hexists(arg_as_str(&args[0])?, arg_as_str(&args[1])?).await?;
     Ok(RespReply::Integer(i64::from(present)))
+}
+
+async fn handle_hsetnx(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("HSETNX", args.len() == 3)?;
+    let key = arg_as_str(&args[0])?;
+    let field = arg_as_str(&args[1])?;
+    let set = state.storage.hsetnx(key, field, args[2].clone()).await?;
+    Ok(RespReply::Integer(i64::from(set)))
+}
+
+async fn handle_hstrlen(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("HSTRLEN", args.len() == 2)?;
+    let len = state.storage.hstrlen(arg_as_str(&args[0])?, arg_as_str(&args[1])?).await?;
+    Ok(RespReply::Integer(len))
 }
 
 async fn handle_hmget(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -243,6 +243,7 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     }
 
     async fn hset(&self, key: &str, pairs: Vec<(String, Bytes)>) -> Result<i64, RustyAntError>;
+    async fn hsetnx(&self, key: &str, field: &str, value: Bytes) -> Result<bool, RustyAntError>;
     async fn hget(&self, key: &str, field: &str) -> Result<Option<Bytes>, RustyAntError>;
     async fn hdel(&self, key: &str, fields: &[String]) -> Result<i64, RustyAntError>;
     async fn hgetall(&self, key: &str) -> Result<Vec<(String, Bytes)>, RustyAntError>;
@@ -250,6 +251,7 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn hkeys(&self, key: &str) -> Result<Vec<String>, RustyAntError>;
     async fn hvals(&self, key: &str) -> Result<Vec<Bytes>, RustyAntError>;
     async fn hexists(&self, key: &str, field: &str) -> Result<bool, RustyAntError>;
+    async fn hstrlen(&self, key: &str, field: &str) -> Result<i64, RustyAntError>;
     async fn hmget(&self, key: &str, fields: &[String]) -> Result<Vec<Option<Bytes>>, RustyAntError>;
     async fn hincr_by(&self, key: &str, field: &str, delta: i64) -> Result<i64, RustyAntError>;
 
@@ -558,6 +560,24 @@ impl Storage for S3Storage {
         .await
     }
 
+    async fn hsetnx(&self, key: &str, field: &str, value: Bytes) -> Result<bool, RustyAntError> {
+        let field = field.to_string();
+        self.cas(key, move |entry| {
+            let (mut map, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::Hash(m), expires_at_ms }) => (m.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => (BTreeMap::new(), None),
+            };
+            if map.contains_key(&field) {
+                return Ok(CasAction::NoOp(false));
+            }
+            map.insert(field.clone(), value.to_vec());
+            let new_entry = StoredValue { expires_at_ms, value: Value::Hash(map) };
+            Ok(CasAction::Write(new_entry, true))
+        })
+        .await
+    }
+
     async fn hget(&self, key: &str, field: &str) -> Result<Option<Bytes>, RustyAntError> {
         match self.load(key).await? {
             Some(StoredValue { value: Value::Hash(m), .. }) => Ok(m.get(field).map(|v| Bytes::from(v.clone()))),
@@ -743,6 +763,16 @@ impl Storage for S3Storage {
             Some(StoredValue { value: Value::Hash(m), .. }) => Ok(m.contains_key(field)),
             Some(_) => Err(wrong_type(key)),
             None => Ok(false),
+        }
+    }
+
+    async fn hstrlen(&self, key: &str, field: &str) -> Result<i64, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::Hash(m), .. }) => {
+                Ok(m.get(field).map_or(0, |v| i64::try_from(v.len()).unwrap_or(i64::MAX)))
+            }
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(0),
         }
     }
 
@@ -1224,6 +1254,23 @@ impl Storage for InMemoryStorage {
         Ok(new_fields)
     }
 
+    async fn hsetnx(&self, key: &str, field: &str, value: Bytes) -> Result<bool, RustyAntError> {
+        let (mut map, expires_at_ms) = match self.load(key) {
+            Some(StoredValue { value: Value::Hash(m), expires_at_ms }) => (m, expires_at_ms),
+            Some(_) => return Err(wrong_type(key)),
+            None => (BTreeMap::new(), None),
+        };
+        if map.contains_key(field) {
+            return Ok(false);
+        }
+        map.insert(field.to_string(), value.to_vec());
+        let entry = StoredValue { expires_at_ms, value: Value::Hash(map) };
+        self.with_entry_mut(|store| {
+            store.insert(key.to_string(), entry);
+        });
+        Ok(true)
+    }
+
     async fn hget(&self, key: &str, field: &str) -> Result<Option<Bytes>, RustyAntError> {
         match self.load(key) {
             Some(StoredValue { value: Value::Hash(m), .. }) => Ok(m.get(field).map(|v| Bytes::from(v.clone()))),
@@ -1412,6 +1459,16 @@ impl Storage for InMemoryStorage {
             Some(StoredValue { value: Value::Hash(m), .. }) => Ok(m.contains_key(field)),
             Some(_) => Err(wrong_type(key)),
             None => Ok(false),
+        }
+    }
+
+    async fn hstrlen(&self, key: &str, field: &str) -> Result<i64, RustyAntError> {
+        match self.load(key) {
+            Some(StoredValue { value: Value::Hash(m), .. }) => {
+                Ok(m.get(field).map_or(0, |v| i64::try_from(v.len()).unwrap_or(i64::MAX)))
+            }
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(0),
         }
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -632,6 +632,41 @@ async fn hexists_returns_0_or_1() {
 }
 
 #[tokio::test]
+async fn hsetnx_sets_only_when_field_absent() {
+    let state = test_state();
+    call(&state, &[b"HSETNX", b"h", b"name", b"alice"]).await.expect_integer(1);
+    call(&state, &[b"HGET", b"h", b"name"]).await.expect_bulk(b"alice");
+    // Second HSETNX on the same field is a no-op.
+    call(&state, &[b"HSETNX", b"h", b"name", b"bob"]).await.expect_integer(0);
+    call(&state, &[b"HGET", b"h", b"name"]).await.expect_bulk(b"alice");
+}
+
+#[tokio::test]
+async fn hsetnx_on_wrong_type_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"HSETNX", b"k", b"f", b"x"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn hstrlen_returns_field_byte_length() {
+    let state = test_state();
+    call(&state, &[b"HSET", b"h", b"name", b"alice"]).await;
+    call(&state, &[b"HSTRLEN", b"h", b"name"]).await.expect_integer(5);
+    // Missing field: 0.
+    call(&state, &[b"HSTRLEN", b"h", b"ghost"]).await.expect_integer(0);
+    // Missing key: 0.
+    call(&state, &[b"HSTRLEN", b"nope", b"f"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn hstrlen_on_wrong_type_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"HSTRLEN", b"k", b"f"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
 async fn hmget_returns_nil_for_missing_fields() {
     let state = test_state();
     call(&state, &[b"HSET", b"h", b"a", b"1", b"c", b"3"]).await;


### PR DESCRIPTION
## Summary

Field-level counterparts to `SETNX` and `STRLEN`.

`HSETNX` inserts a field only when absent: routes through the existing CAS helper, returns `1` on the create and `0` when the field already exists (no write). Creates the hash if the key is missing. `HSTRLEN` is a plain load — returns the byte length of the field's value, or `0` for a missing key or missing field. Both surface `ERR wrong type` when the key holds a non-hash value.

Useful when a hash models per-user initialization state and you want exactly-once write semantics on individual fields, or want size-gating on individual field payloads without pulling the whole value.

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-targets` — 144 pass (4 new: hsetnx sets-only-when-absent / wrong-type; hstrlen field-byte-length / wrong-type)