### PR TITLE
:sparkles: add ZRANK and ZREVRANK

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Implemented:
 | Hashes | `HSET`, `HSETNX`, `HGET`, `HDEL`, `HGETALL`, `HLEN`, `HKEYS`, `HVALS`, `HEXISTS`, `HSTRLEN`, `HMGET`, `HINCRBY` |
 | Lists | `LPUSH`, `RPUSH`, `LPOP` (+ count), `RPOP` (+ count), `LRANGE`, `LLEN`, `LINDEX`, `LSET`, `LREM` |
 | Sets | `SADD`, `SREM`, `SMEMBERS`, `SISMEMBER`, `SCARD` |
-| Sorted Sets | `ZADD`, `ZREM`, `ZINCRBY`, `ZRANGE`, `ZRANGEBYSCORE`, `ZSCORE`, `ZCARD` |
+| Sorted Sets | `ZADD`, `ZREM`, `ZINCRBY`, `ZRANGE`, `ZRANGEBYSCORE`, `ZSCORE`, `ZCARD`, `ZRANK`, `ZREVRANK` |
 
 `KEYS` paginates through `ListObjectsV2` in full and filters by the wildmatch pattern — O(n) over the keyspace, safe at low cardinality, proportionally slower for larger buckets. `SCAN` delegates the page boundary to S3 via a continuation token, returning one `ListObjectsV2` page per call; `MATCH` is applied client-side, so the per-page yield may be smaller than `COUNT` when a pattern is narrow.
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -167,6 +167,8 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "ZRANGEBYSCORE" => handle_zrangebyscore(state, args).await,
         "ZSCORE" => handle_zscore(state, args).await,
         "ZCARD" => handle_zcard(state, args).await,
+        "ZRANK" => handle_zrank(state, args, false).await,
+        "ZREVRANK" => handle_zrank(state, args, true).await,
         other => Err(RustyAntError::UnknownCommand(other.to_string())),
     }
 }
@@ -522,6 +524,16 @@ async fn handle_zcard(state: &State, args: Vec<Bytes>) -> Result<RespReply, Rust
     arity("ZCARD", args.len() == 1)?;
     let n = state.storage.zcard(arg_as_str(&args[0])?).await?;
     Ok(RespReply::Integer(n))
+}
+
+async fn handle_zrank(state: &State, args: Vec<Bytes>, reverse: bool) -> Result<RespReply, RustyAntError> {
+    let cmd = if reverse { "ZREVRANK" } else { "ZRANK" };
+    arity(cmd, args.len() == 2)?;
+    let key = arg_as_str(&args[0])?;
+    let member = arg_as_str(&args[1])?;
+    let rank =
+        if reverse { state.storage.zrevrank(key, member).await? } else { state.storage.zrank(key, member).await? };
+    Ok(rank.map_or(RespReply::Nil, RespReply::Integer))
 }
 
 // ---- String multi-key + NX/EX + GETSET + PERSIST --------------------------

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -101,6 +101,19 @@ fn resolve_range(len: i64, start: i64, stop: i64) -> Option<(usize, usize)> {
     Some((usize::try_from(s).unwrap_or(0), usize::try_from(e).unwrap_or(0)))
 }
 
+/// 0-based ascending rank of `member` in a zset: sort by (score asc, member
+/// asc for tied scores) — the Redis canonical ordering — and return the
+/// member's index, or `None` if absent.
+fn asc_rank_of(map: &BTreeMap<String, f64>, member: &str) -> Option<i64> {
+    if !map.contains_key(member) {
+        return None;
+    }
+    let mut sorted: Vec<(&str, f64)> = map.iter().map(|(m, s)| (m.as_str(), *s)).collect();
+    sorted.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal).then_with(|| a.0.cmp(b.0)));
+    let pos = sorted.iter().position(|(m, _)| *m == member)?;
+    Some(i64::try_from(pos).unwrap_or(i64::MAX))
+}
+
 fn wrong_type(key: &str) -> RustyAntError {
     RustyAntError::WrongType { key: key.to_string() }
 }
@@ -276,6 +289,8 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn zrangebyscore(&self, key: &str, min: ScoreBound, max: ScoreBound) -> Result<Vec<String>, RustyAntError>;
     async fn zscore(&self, key: &str, member: &str) -> Result<Option<f64>, RustyAntError>;
     async fn zcard(&self, key: &str) -> Result<i64, RustyAntError>;
+    async fn zrank(&self, key: &str, member: &str) -> Result<Option<i64>, RustyAntError>;
+    async fn zrevrank(&self, key: &str, member: &str) -> Result<Option<i64>, RustyAntError>;
 
     /// Return every key matching `pattern` (Redis-style glob: `*`, `?`).
     /// On S3 this fans out to repeated `ListObjectsV2` calls until the
@@ -831,6 +846,25 @@ impl Storage for S3Storage {
             Some(StoredValue { value: Value::ZSet(m), .. }) => Ok(i64::try_from(m.len()).unwrap_or(i64::MAX)),
             Some(_) => Err(wrong_type(key)),
             None => Ok(0),
+        }
+    }
+
+    async fn zrank(&self, key: &str, member: &str) -> Result<Option<i64>, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::ZSet(m), .. }) => Ok(asc_rank_of(&m, member)),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(None),
+        }
+    }
+
+    async fn zrevrank(&self, key: &str, member: &str) -> Result<Option<i64>, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::ZSet(m), .. }) => {
+                let len = i64::try_from(m.len()).unwrap_or(i64::MAX);
+                Ok(asc_rank_of(&m, member).map(|r| len - 1 - r))
+            }
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(None),
         }
     }
 
@@ -1527,6 +1561,25 @@ impl Storage for InMemoryStorage {
             Some(StoredValue { value: Value::ZSet(m), .. }) => Ok(i64::try_from(m.len()).unwrap_or(i64::MAX)),
             Some(_) => Err(wrong_type(key)),
             None => Ok(0),
+        }
+    }
+
+    async fn zrank(&self, key: &str, member: &str) -> Result<Option<i64>, RustyAntError> {
+        match self.load(key) {
+            Some(StoredValue { value: Value::ZSet(m), .. }) => Ok(asc_rank_of(&m, member)),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(None),
+        }
+    }
+
+    async fn zrevrank(&self, key: &str, member: &str) -> Result<Option<i64>, RustyAntError> {
+        match self.load(key) {
+            Some(StoredValue { value: Value::ZSet(m), .. }) => {
+                let len = i64::try_from(m.len()).unwrap_or(i64::MAX);
+                Ok(asc_rank_of(&m, member).map(|r| len - 1 - r))
+            }
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(None),
         }
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -732,6 +732,54 @@ async fn zcard_counts_members() {
     call(&state, &[b"ZCARD", b"z"]).await.expect_integer(3);
 }
 
+#[tokio::test]
+async fn zrank_returns_ascending_index() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"a", b"2", b"b", b"3", b"c"]).await;
+    call(&state, &[b"ZRANK", b"z", b"a"]).await.expect_integer(0);
+    call(&state, &[b"ZRANK", b"z", b"b"]).await.expect_integer(1);
+    call(&state, &[b"ZRANK", b"z", b"c"]).await.expect_integer(2);
+}
+
+#[tokio::test]
+async fn zrevrank_returns_descending_index() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"a", b"2", b"b", b"3", b"c"]).await;
+    call(&state, &[b"ZREVRANK", b"z", b"a"]).await.expect_integer(2);
+    call(&state, &[b"ZREVRANK", b"z", b"b"]).await.expect_integer(1);
+    call(&state, &[b"ZREVRANK", b"z", b"c"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn zrank_ties_break_lexicographically() {
+    // Equal scores: ascending tie-break is member-asc, descending flips it.
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"b", b"1", b"a", b"1", b"c"]).await;
+    call(&state, &[b"ZRANK", b"z", b"a"]).await.expect_integer(0);
+    call(&state, &[b"ZRANK", b"z", b"b"]).await.expect_integer(1);
+    call(&state, &[b"ZRANK", b"z", b"c"]).await.expect_integer(2);
+    call(&state, &[b"ZREVRANK", b"z", b"a"]).await.expect_integer(2);
+    call(&state, &[b"ZREVRANK", b"z", b"c"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn zrank_on_missing_member_or_key_returns_nil() {
+    let state = test_state();
+    call(&state, &[b"ZRANK", b"ghost", b"m"]).await.expect_nil();
+    call(&state, &[b"ZREVRANK", b"ghost", b"m"]).await.expect_nil();
+    call(&state, &[b"ZADD", b"z", b"1", b"a"]).await;
+    call(&state, &[b"ZRANK", b"z", b"missing"]).await.expect_nil();
+    call(&state, &[b"ZREVRANK", b"z", b"missing"]).await.expect_nil();
+}
+
+#[tokio::test]
+async fn zrank_on_wrong_type_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"ZRANK", b"k", b"m"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"ZREVRANK", b"k", b"m"]).await.expect_error_prefix("ERR");
+}
+
 // ---------------------------------------------------------------------------
 // Additional mutating commands (HINCRBY, SREM, ZREM, ZINCRBY)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

0-based rank of a member in a sorted set, ascending and descending.

Both routes share a small `asc_rank_of` helper that sorts by Redis's canonical ordering — score ascending, member ascending for tied scores — and returns the target's index. `ZREVRANK` is `len - 1 - asc_rank`, which implicitly flips the tie-break direction the same way Redis does.

Returns `nil` when the key is missing or the member is absent; `ERR wrong type` when the key holds a non-zset value. `ZRANGE`/`ZSCORE`/`ZCARD` already rely on the same ordering, so the behavior is consistent with everything else in the zset surface.

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-targets` — 149 pass (5 new: ascending indexes, descending indexes, lex tie-break on equal scores, missing member/key returns nil, wrong-type errors)