### PR TITLE
:sparkles: add ZCOUNT and ZMSCORE

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Implemented:
 | Hashes | `HSET`, `HSETNX`, `HGET`, `HDEL`, `HGETALL`, `HLEN`, `HKEYS`, `HVALS`, `HEXISTS`, `HSTRLEN`, `HMGET`, `HINCRBY` |
 | Lists | `LPUSH`, `RPUSH`, `LPOP` (+ count), `RPOP` (+ count), `LRANGE`, `LLEN`, `LINDEX`, `LSET`, `LREM` |
 | Sets | `SADD`, `SREM`, `SMEMBERS`, `SISMEMBER`, `SCARD` |
-| Sorted Sets | `ZADD`, `ZREM`, `ZINCRBY`, `ZRANGE`, `ZRANGEBYSCORE`, `ZSCORE`, `ZCARD`, `ZRANK`, `ZREVRANK` |
+| Sorted Sets | `ZADD`, `ZREM`, `ZINCRBY`, `ZRANGE`, `ZRANGEBYSCORE`, `ZSCORE`, `ZMSCORE`, `ZCARD`, `ZCOUNT`, `ZRANK`, `ZREVRANK` |
 
 `KEYS` paginates through `ListObjectsV2` in full and filters by the wildmatch pattern — O(n) over the keyspace, safe at low cardinality, proportionally slower for larger buckets. `SCAN` delegates the page boundary to S3 via a continuation token, returning one `ListObjectsV2` page per call; `MATCH` is applied client-side, so the per-page yield may be smaller than `COUNT` when a pattern is narrow.
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -169,6 +169,8 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "ZCARD" => handle_zcard(state, args).await,
         "ZRANK" => handle_zrank(state, args, false).await,
         "ZREVRANK" => handle_zrank(state, args, true).await,
+        "ZCOUNT" => handle_zcount(state, args).await,
+        "ZMSCORE" => handle_zmscore(state, args).await,
         other => Err(RustyAntError::UnknownCommand(other.to_string())),
     }
 }
@@ -534,6 +536,30 @@ async fn handle_zrank(state: &State, args: Vec<Bytes>, reverse: bool) -> Result<
     let rank =
         if reverse { state.storage.zrevrank(key, member).await? } else { state.storage.zrank(key, member).await? };
     Ok(rank.map_or(RespReply::Nil, RespReply::Integer))
+}
+
+async fn handle_zcount(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("ZCOUNT", args.len() == 3)?;
+    let key = arg_as_str(&args[0])?;
+    let min = ScoreBound::parse(arg_as_str(&args[1])?)?;
+    let max = ScoreBound::parse(arg_as_str(&args[2])?)?;
+    let n = state.storage.zcount(key, min, max).await?;
+    Ok(RespReply::Integer(n))
+}
+
+async fn handle_zmscore(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("ZMSCORE", args.len() >= 2)?;
+    let key = arg_as_str(&args[0])?;
+    let members: Vec<String> = args.iter().skip(1).map(arg_as_string).collect::<Result<_, _>>()?;
+    let scores = state.storage.zmscore(key, &members).await?;
+    Ok(RespReply::Array(
+        scores
+            .into_iter()
+            .map(|s| {
+                s.map_or(RespReply::Nil, |v| RespReply::BulkString(Some(Bytes::from(format_score(v).into_bytes()))))
+            })
+            .collect(),
+    ))
 }
 
 // ---- String multi-key + NX/EX + GETSET + PERSIST --------------------------

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -167,6 +167,13 @@ fn filter_zset_by_score(map: BTreeMap<String, f64>, min: ScoreBound, max: ScoreB
     sorted.into_iter().filter(|(_, s)| min.ge_min(*s) && max.le_max(*s)).map(|(m, _)| m).collect()
 }
 
+/// Number of members whose score falls within `[min, max]` (inclusive/
+/// exclusive per `ScoreBound`). Shared between `S3Storage` and `InMemoryStorage`.
+fn count_zset_by_score(map: &BTreeMap<String, f64>, min: ScoreBound, max: ScoreBound) -> i64 {
+    let n = map.values().filter(|s| min.ge_min(**s) && max.le_max(**s)).count();
+    i64::try_from(n).unwrap_or(i64::MAX)
+}
+
 // ---------------------------------------------------------------------------
 // S3 optimistic-locking primitives.
 //
@@ -291,6 +298,8 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn zcard(&self, key: &str) -> Result<i64, RustyAntError>;
     async fn zrank(&self, key: &str, member: &str) -> Result<Option<i64>, RustyAntError>;
     async fn zrevrank(&self, key: &str, member: &str) -> Result<Option<i64>, RustyAntError>;
+    async fn zcount(&self, key: &str, min: ScoreBound, max: ScoreBound) -> Result<i64, RustyAntError>;
+    async fn zmscore(&self, key: &str, members: &[String]) -> Result<Vec<Option<f64>>, RustyAntError>;
 
     /// Return every key matching `pattern` (Redis-style glob: `*`, `?`).
     /// On S3 this fans out to repeated `ListObjectsV2` calls until the
@@ -865,6 +874,24 @@ impl Storage for S3Storage {
             }
             Some(_) => Err(wrong_type(key)),
             None => Ok(None),
+        }
+    }
+
+    async fn zcount(&self, key: &str, min: ScoreBound, max: ScoreBound) -> Result<i64, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::ZSet(m), .. }) => Ok(count_zset_by_score(&m, min, max)),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(0),
+        }
+    }
+
+    async fn zmscore(&self, key: &str, members: &[String]) -> Result<Vec<Option<f64>>, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::ZSet(m), .. }) => {
+                Ok(members.iter().map(|mem| m.get(mem).copied()).collect())
+            }
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(members.iter().map(|_| None).collect()),
         }
     }
 
@@ -1569,6 +1596,24 @@ impl Storage for InMemoryStorage {
             Some(StoredValue { value: Value::ZSet(m), .. }) => Ok(asc_rank_of(&m, member)),
             Some(_) => Err(wrong_type(key)),
             None => Ok(None),
+        }
+    }
+
+    async fn zcount(&self, key: &str, min: ScoreBound, max: ScoreBound) -> Result<i64, RustyAntError> {
+        match self.load(key) {
+            Some(StoredValue { value: Value::ZSet(m), .. }) => Ok(count_zset_by_score(&m, min, max)),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(0),
+        }
+    }
+
+    async fn zmscore(&self, key: &str, members: &[String]) -> Result<Vec<Option<f64>>, RustyAntError> {
+        match self.load(key) {
+            Some(StoredValue { value: Value::ZSet(m), .. }) => {
+                Ok(members.iter().map(|mem| m.get(mem).copied()).collect())
+            }
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(members.iter().map(|_| None).collect()),
         }
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -780,6 +780,61 @@ async fn zrank_on_wrong_type_errors() {
     call(&state, &[b"ZREVRANK", b"k", b"m"]).await.expect_error_prefix("ERR");
 }
 
+#[tokio::test]
+async fn zcount_counts_inclusive_range() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"a", b"2", b"b", b"3", b"c", b"4", b"d"]).await;
+    call(&state, &[b"ZCOUNT", b"z", b"2", b"3"]).await.expect_integer(2);
+    call(&state, &[b"ZCOUNT", b"z", b"1", b"4"]).await.expect_integer(4);
+    call(&state, &[b"ZCOUNT", b"z", b"-inf", b"+inf"]).await.expect_integer(4);
+}
+
+#[tokio::test]
+async fn zcount_honors_exclusive_bounds() {
+    // "(N" = exclusive; Redis ZRANGEBYSCORE / ZCOUNT share this syntax.
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"a", b"2", b"b", b"3", b"c"]).await;
+    call(&state, &[b"ZCOUNT", b"z", b"(1", b"3"]).await.expect_integer(2);
+    call(&state, &[b"ZCOUNT", b"z", b"1", b"(3"]).await.expect_integer(2);
+    call(&state, &[b"ZCOUNT", b"z", b"(1", b"(3"]).await.expect_integer(1);
+}
+
+#[tokio::test]
+async fn zcount_on_missing_key_returns_zero() {
+    let state = test_state();
+    call(&state, &[b"ZCOUNT", b"ghost", b"-inf", b"+inf"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn zcount_on_wrong_type_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"ZCOUNT", b"k", b"0", b"1"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn zmscore_returns_scores_or_nil_per_member() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"a", b"2.5", b"b"]).await;
+    let raw = call(&state, &[b"ZMSCORE", b"z", b"a", b"missing", b"b"]).await.raw;
+    // Array of 3: bulk "1", nil, bulk "2.5"
+    assert_eq!(&raw, b"*3\r\n$1\r\n1\r\n$-1\r\n$3\r\n2.5\r\n");
+}
+
+#[tokio::test]
+async fn zmscore_on_missing_key_returns_all_nils() {
+    let state = test_state();
+    let raw = call(&state, &[b"ZMSCORE", b"ghost", b"a", b"b"]).await.raw;
+    assert_eq!(&raw, b"*2\r\n$-1\r\n$-1\r\n");
+}
+
+#[tokio::test]
+async fn zmscore_on_wrong_type_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"ZMSCORE", b"k", b"m"]).await.expect_error_prefix("ERR");
+}
+
 // ---------------------------------------------------------------------------
 // Additional mutating commands (HINCRBY, SREM, ZREM, ZINCRBY)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `ZCOUNT key min max` — number of members whose score falls in the range, sharing `ZRANGEBYSCORE`'s `ScoreBound` parser (bare = inclusive, `(N` = exclusive, `+inf`/`-inf`)
- `ZMSCORE key member [member ...]` — batch score lookup, returning one nil-or-bulk-score per member (HMGET-style shape); all-nils when the key is missing
- Both return WRONGTYPE for non-zset keys; `count_zset_by_score` helper is shared between the S3 and in-memory backends

## Test plan
- [x] `just check` (fmt + clippy -D warnings)
- [x] `just test` — 156 tests pass, including 7 new integration cases covering inclusive/exclusive bounds, missing key, wrong type, and the nil-for-missing-member shape