### PR TITLE
:sparkles: expand List and Set command surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Implemented:
 | Keyspace | `KEYS`, `SCAN` (+ `MATCH` / `COUNT` options), `TYPE` |
 | Strings | `GET`, `SET` (+ `EX` / `PX` options), `GETSET`, `GETDEL`, `SETNX`, `SETEX`, `MGET`, `MSET`, `APPEND`, `STRLEN`, `DEL`, `EXISTS`, `EXPIRE`, `EXPIREAT`, `PEXPIREAT`, `PERSIST`, `TTL`, `INCR`, `INCRBY`, `DECR`, `DECRBY` |
 | Hashes | `HSET`, `HSETNX`, `HGET`, `HDEL`, `HGETALL`, `HLEN`, `HKEYS`, `HVALS`, `HEXISTS`, `HSTRLEN`, `HMGET`, `HINCRBY` |
-| Lists | `LPUSH`, `RPUSH`, `LPOP` (+ count), `RPOP` (+ count), `LRANGE`, `LLEN`, `LINDEX`, `LSET`, `LREM` |
-| Sets | `SADD`, `SREM`, `SMEMBERS`, `SISMEMBER`, `SCARD` |
+| Lists | `LPUSH`, `RPUSH`, `LPUSHX`, `RPUSHX`, `LPOP` (+ count), `RPOP` (+ count), `LRANGE`, `LLEN`, `LINDEX`, `LSET`, `LREM`, `LINSERT`, `LTRIM` |
+| Sets | `SADD`, `SREM`, `SMEMBERS`, `SISMEMBER`, `SMISMEMBER`, `SCARD`, `SINTER`, `SUNION`, `SDIFF`, `SPOP` (+ count), `SRANDMEMBER` (+ count) |
 | Sorted Sets | `ZADD`, `ZREM`, `ZINCRBY`, `ZRANGE`, `ZRANGEBYSCORE`, `ZSCORE`, `ZMSCORE`, `ZCARD`, `ZCOUNT`, `ZRANK`, `ZREVRANK` |
 
 `KEYS` paginates through `ListObjectsV2` in full and filters by the wildmatch pattern — O(n) over the keyspace, safe at low cardinality, proportionally slower for larger buckets. `SCAN` delegates the page boundary to S3 via a continuation token, returning one `ListObjectsV2` page per call; `MATCH` is applied client-side, so the per-page yield may be smaller than `COUNT` when a pattern is narrow.
@@ -154,6 +154,6 @@ The `rustyant` and `rustyant-ws` binaries emit structured JSON logs via `tracing
 
 ## Status
 
-Working: RESP over HTTP and WebSocket, full string/hash/list/set/zset command dispatch plus `KEYS` / `SCAN`, S3-backed storage with per-key TTL and conditional-write CAS on every read-modify-write, 123 Rust tests across 5 suites (18 lib units + 81 HTTP integration + 11 redis-py compat + 6 WebSocket E2E + 7 encoder) and 13 Python client tests, structured logs and CloudWatch EMF metrics, CI on GitHub Actions with floci as a service container, SAM template validated in CI.
+Working: RESP over HTTP and WebSocket, full string/hash/list/set/zset command dispatch plus `KEYS` / `SCAN`, S3-backed storage with per-key TTL and conditional-write CAS on every read-modify-write, 187 Rust tests across 5 suites (18 lib units + 145 HTTP integration + 11 redis-py compat + 6 WebSocket E2E + 7 floci/S3) and 13 Python client tests, structured logs and CloudWatch EMF metrics, CI on GitHub Actions with floci as a service container, SAM template validated in CI.
 
 Not wired: no end-to-end test driving a real WebSocket connection against a deployed binary in AWS; the `s3_concurrent_incr_converges` CAS test is gated behind `RUSTYANT_S3_CAS=1` because floci doesn't enforce `If-Match` headers.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -146,6 +146,8 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         // Lists
         "LPUSH" => handle_push(state, args, true).await,
         "RPUSH" => handle_push(state, args, false).await,
+        "LPUSHX" => handle_pushx(state, args, true).await,
+        "RPUSHX" => handle_pushx(state, args, false).await,
         "LPOP" => handle_pop(state, args, true).await,
         "RPOP" => handle_pop(state, args, false).await,
         "LRANGE" => handle_lrange(state, args).await,
@@ -153,12 +155,20 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "LINDEX" => handle_lindex(state, args).await,
         "LSET" => handle_lset(state, args).await,
         "LREM" => handle_lrem(state, args).await,
+        "LINSERT" => handle_linsert(state, args).await,
+        "LTRIM" => handle_ltrim(state, args).await,
         // Sets
         "SADD" => handle_sadd(state, args).await,
         "SREM" => handle_srem(state, args).await,
         "SMEMBERS" => handle_smembers(state, args).await,
         "SISMEMBER" => handle_sismember(state, args).await,
+        "SMISMEMBER" => handle_smismember(state, args).await,
         "SCARD" => handle_scard(state, args).await,
+        "SINTER" => handle_sinter(state, args).await,
+        "SUNION" => handle_sunion(state, args).await,
+        "SDIFF" => handle_sdiff(state, args).await,
+        "SPOP" => handle_spop(state, args).await,
+        "SRANDMEMBER" => handle_srandmember(state, args).await,
         // Sorted sets
         "ZADD" => handle_zadd(state, args).await,
         "ZREM" => handle_zrem(state, args).await,
@@ -676,6 +686,109 @@ async fn handle_lrem(state: &State, args: Vec<Bytes>) -> Result<RespReply, Rusty
     let value = args[2].clone();
     let removed = state.storage.lrem(key, count, value).await?;
     Ok(RespReply::Integer(removed))
+}
+
+async fn handle_linsert(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("LINSERT", args.len() == 4)?;
+    let key = arg_as_str(&args[0])?;
+    let before = match arg_as_str(&args[1])?.to_ascii_uppercase().as_str() {
+        "BEFORE" => true,
+        "AFTER" => false,
+        other => return Err(RustyAntError::Parse(format!("LINSERT direction must be BEFORE or AFTER, got {other}"))),
+    };
+    let pivot = args[2].clone();
+    let value = args[3].clone();
+    let new_len = state.storage.linsert(key, before, pivot, value).await?;
+    Ok(RespReply::Integer(new_len))
+}
+
+async fn handle_ltrim(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("LTRIM", args.len() == 3)?;
+    let key = arg_as_str(&args[0])?;
+    let start = parse_i64(&args[1], "start")?;
+    let stop = parse_i64(&args[2], "stop")?;
+    state.storage.ltrim(key, start, stop).await?;
+    Ok(RespReply::ok())
+}
+
+async fn handle_pushx(state: &State, args: Vec<Bytes>, left: bool) -> Result<RespReply, RustyAntError> {
+    let cmd = if left { "LPUSHX" } else { "RPUSHX" };
+    arity(cmd, args.len() >= 2)?;
+    let key = arg_as_string(&args[0])?;
+    let values: Vec<Bytes> = args.into_iter().skip(1).collect();
+    let len = state.storage.list_pushx(&key, values, left).await?;
+    Ok(RespReply::Integer(len))
+}
+
+async fn handle_smismember(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("SMISMEMBER", args.len() >= 2)?;
+    let key = arg_as_str(&args[0])?;
+    let members: Vec<String> = args.iter().skip(1).map(arg_as_string).collect::<Result<_, _>>()?;
+    let flags = state.storage.smismember(key, &members).await?;
+    Ok(RespReply::Array(flags.into_iter().map(|b| RespReply::Integer(i64::from(b))).collect()))
+}
+
+async fn handle_sinter(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("SINTER", !args.is_empty())?;
+    let keys: Vec<String> = args.iter().map(arg_as_string).collect::<Result<_, _>>()?;
+    let members = state.storage.sinter(&keys).await?;
+    Ok(RespReply::Array(
+        members.into_iter().map(|m| RespReply::BulkString(Some(Bytes::from(m.into_bytes())))).collect(),
+    ))
+}
+
+async fn handle_sunion(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("SUNION", !args.is_empty())?;
+    let keys: Vec<String> = args.iter().map(arg_as_string).collect::<Result<_, _>>()?;
+    let members = state.storage.sunion(&keys).await?;
+    Ok(RespReply::Array(
+        members.into_iter().map(|m| RespReply::BulkString(Some(Bytes::from(m.into_bytes())))).collect(),
+    ))
+}
+
+async fn handle_sdiff(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("SDIFF", !args.is_empty())?;
+    let keys: Vec<String> = args.iter().map(arg_as_string).collect::<Result<_, _>>()?;
+    let members = state.storage.sdiff(&keys).await?;
+    Ok(RespReply::Array(
+        members.into_iter().map(|m| RespReply::BulkString(Some(Bytes::from(m.into_bytes())))).collect(),
+    ))
+}
+
+async fn handle_spop(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("SPOP", !args.is_empty() && args.len() <= 2)?;
+    let key = arg_as_str(&args[0])?;
+    if args.len() == 2 {
+        let count = parse_i64(&args[1], "count")?;
+        if count < 0 {
+            return Err(RustyAntError::Parse("count must be >= 0".into()));
+        }
+        let count_usize = usize::try_from(count).unwrap_or(0);
+        let popped = state.storage.spop(key, count_usize).await?;
+        Ok(RespReply::Array(
+            popped.into_iter().map(|m| RespReply::BulkString(Some(Bytes::from(m.into_bytes())))).collect(),
+        ))
+    } else {
+        let mut popped = state.storage.spop(key, 1).await?;
+        Ok(popped.pop().map_or(RespReply::Nil, |m| RespReply::BulkString(Some(Bytes::from(m.into_bytes())))))
+    }
+}
+
+async fn handle_srandmember(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("SRANDMEMBER", !args.is_empty() && args.len() <= 2)?;
+    let key = arg_as_str(&args[0])?;
+    if args.len() == 2 {
+        let count = parse_i64(&args[1], "count")?;
+        let allow_duplicates = count < 0;
+        let abs_count = count.checked_abs().ok_or_else(|| RustyAntError::Parse("count overflow".into()))?;
+        let picked = state.storage.srandmember(key, abs_count, allow_duplicates).await?;
+        Ok(RespReply::Array(
+            picked.into_iter().map(|m| RespReply::BulkString(Some(Bytes::from(m.into_bytes())))).collect(),
+        ))
+    } else {
+        let mut picked = state.storage.srandmember(key, 1, false).await?;
+        Ok(picked.pop().map_or(RespReply::Nil, |m| RespReply::BulkString(Some(Bytes::from(m.into_bytes())))))
+    }
 }
 
 async fn handle_zrangebyscore(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -174,6 +174,119 @@ fn count_zset_by_score(map: &BTreeMap<String, f64>, min: ScoreBound, max: ScoreB
     i64::try_from(n).unwrap_or(i64::MAX)
 }
 
+/// Time-seeded xorshift — good enough for Redis `SPOP` / `SRANDMEMBER`, which
+/// only require "random-ish" sampling, not cryptographic randomness.
+fn pseudo_rand_u64() -> u64 {
+    let nanos: u64 =
+        SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| u64::try_from(d.as_nanos()).unwrap_or(u64::MAX));
+    let mut x = nanos ^ 0x2545_F491_4F6C_DD1D_u64;
+    x ^= x << 13;
+    x ^= x >> 7;
+    x ^= x << 17;
+    x
+}
+
+/// Translate `start` / `stop` into absolute indices for `LTRIM`. Returns
+/// `None` when the resulting slice would be empty — Redis drops the key
+/// entirely in that case, unlike `LRANGE` which only returns an empty reply.
+/// The pair is `(keep_start, keep_stop_exclusive)`.
+fn resolve_trim_range(len: usize, start: i64, stop: i64) -> Option<(usize, usize)> {
+    if len == 0 {
+        return None;
+    }
+    let len_i = i64::try_from(len).unwrap_or(i64::MAX);
+    let s = if start < 0 { (len_i + start).max(0) } else { start };
+    let e = if stop < 0 { len_i + stop } else { stop.min(len_i - 1) };
+    if s >= len_i || e < 0 || s > e {
+        return None;
+    }
+    Some((usize::try_from(s).unwrap_or(0), usize::try_from(e).unwrap_or(0) + 1))
+}
+
+/// Sequentially load every key as a `Set`. Missing keys contribute an empty
+/// set (Redis semantics for `SINTER`/`SUNION`/`SDIFF`); any key that exists
+/// with a non-set type bubbles up a `WRONGTYPE` error.
+async fn load_sets_seq<S: Storage + ?Sized>(
+    storage: &S,
+    keys: &[String],
+) -> Result<Vec<BTreeSet<String>>, RustyAntError> {
+    let mut out = Vec::with_capacity(keys.len());
+    for k in keys {
+        let members = storage.smembers(k).await?;
+        out.push(members.into_iter().collect());
+    }
+    Ok(out)
+}
+
+/// Intersection of `sets` — members present in every set. An empty input or
+/// any empty set collapses the result to empty.
+fn set_intersection(sets: Vec<BTreeSet<String>>) -> Vec<String> {
+    let mut iter = sets.into_iter();
+    let Some(first) = iter.next() else {
+        return Vec::new();
+    };
+    iter.fold(first, |acc, s| acc.intersection(&s).cloned().collect()).into_iter().collect()
+}
+
+/// Union of all members across `sets`.
+fn set_union(sets: Vec<BTreeSet<String>>) -> Vec<String> {
+    let mut out = BTreeSet::new();
+    for s in sets {
+        out.extend(s);
+    }
+    out.into_iter().collect()
+}
+
+/// Members in the first set that are absent from every subsequent set.
+fn set_difference(sets: Vec<BTreeSet<String>>) -> Vec<String> {
+    let mut iter = sets.into_iter();
+    let Some(first) = iter.next() else {
+        return Vec::new();
+    };
+    let mut remaining = first;
+    for s in iter {
+        remaining = remaining.difference(&s).cloned().collect();
+    }
+    remaining.into_iter().collect()
+}
+
+/// Pick up to `count` unique members from `set` via pseudo-random rotation.
+/// Used by `SPOP` (which mutates the caller's copy afterwards) and by the
+/// positive-count branch of `SRANDMEMBER`.
+fn pick_random_unique(set: &BTreeSet<String>, count: usize) -> Vec<String> {
+    if set.is_empty() || count == 0 {
+        return Vec::new();
+    }
+    let ordered: Vec<&String> = set.iter().collect();
+    let take = count.min(ordered.len());
+    let start = usize::try_from(pseudo_rand_u64() % (ordered.len() as u64)).unwrap_or(0);
+    (0..take).map(|i| ordered[(start + i) % ordered.len()].clone()).collect()
+}
+
+/// `SRANDMEMBER` sampler: `count` is the absolute length wanted, and
+/// `allow_duplicates` flips between Redis's positive-count (unique) and
+/// negative-count (with repetition) semantics.
+fn pick_random(set: &BTreeSet<String>, count: i64, allow_duplicates: bool) -> Vec<String> {
+    if set.is_empty() || count <= 0 {
+        return Vec::new();
+    }
+    let count_usize = usize::try_from(count).unwrap_or(0);
+    let ordered: Vec<&String> = set.iter().collect();
+    if !allow_duplicates {
+        return pick_random_unique(set, count_usize);
+    }
+    let mut rng = pseudo_rand_u64();
+    (0..count_usize)
+        .map(|_| {
+            rng ^= rng << 13;
+            rng ^= rng >> 7;
+            rng ^= rng << 17;
+            let idx = usize::try_from(rng % (ordered.len() as u64)).unwrap_or(0);
+            ordered[idx].clone()
+        })
+        .collect()
+}
+
 // ---------------------------------------------------------------------------
 // S3 optimistic-locking primitives.
 //
@@ -276,18 +389,27 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn hincr_by(&self, key: &str, field: &str, delta: i64) -> Result<i64, RustyAntError>;
 
     async fn list_push(&self, key: &str, values: Vec<Bytes>, left: bool) -> Result<i64, RustyAntError>;
+    async fn list_pushx(&self, key: &str, values: Vec<Bytes>, left: bool) -> Result<i64, RustyAntError>;
     async fn list_pop(&self, key: &str, count: usize, left: bool) -> Result<Vec<Bytes>, RustyAntError>;
     async fn lrange(&self, key: &str, start: i64, stop: i64) -> Result<Vec<Bytes>, RustyAntError>;
     async fn llen(&self, key: &str) -> Result<i64, RustyAntError>;
     async fn lindex(&self, key: &str, index: i64) -> Result<Option<Bytes>, RustyAntError>;
     async fn lset(&self, key: &str, index: i64, value: Bytes) -> Result<(), RustyAntError>;
     async fn lrem(&self, key: &str, count: i64, value: Bytes) -> Result<i64, RustyAntError>;
+    async fn linsert(&self, key: &str, before: bool, pivot: Bytes, value: Bytes) -> Result<i64, RustyAntError>;
+    async fn ltrim(&self, key: &str, start: i64, stop: i64) -> Result<(), RustyAntError>;
 
     async fn sadd(&self, key: &str, members: Vec<String>) -> Result<i64, RustyAntError>;
     async fn srem(&self, key: &str, members: &[String]) -> Result<i64, RustyAntError>;
     async fn smembers(&self, key: &str) -> Result<Vec<String>, RustyAntError>;
     async fn sismember(&self, key: &str, member: &str) -> Result<bool, RustyAntError>;
+    async fn smismember(&self, key: &str, members: &[String]) -> Result<Vec<bool>, RustyAntError>;
     async fn scard(&self, key: &str) -> Result<i64, RustyAntError>;
+    async fn sinter(&self, keys: &[String]) -> Result<Vec<String>, RustyAntError>;
+    async fn sunion(&self, keys: &[String]) -> Result<Vec<String>, RustyAntError>;
+    async fn sdiff(&self, keys: &[String]) -> Result<Vec<String>, RustyAntError>;
+    async fn spop(&self, key: &str, count: usize) -> Result<Vec<String>, RustyAntError>;
+    async fn srandmember(&self, key: &str, count: i64, allow_duplicates: bool) -> Result<Vec<String>, RustyAntError>;
 
     async fn zadd(&self, key: &str, pairs: Vec<(f64, String)>) -> Result<i64, RustyAntError>;
     async fn zrem(&self, key: &str, members: &[String]) -> Result<i64, RustyAntError>;
@@ -1010,6 +1132,67 @@ impl Storage for S3Storage {
         .await
     }
 
+    async fn linsert(&self, key: &str, before: bool, pivot: Bytes, value: Bytes) -> Result<i64, RustyAntError> {
+        self.cas(key, move |entry| {
+            let (mut list, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::List(l), expires_at_ms }) => (l.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => return Ok(CasAction::NoOp(0)),
+            };
+            let Some(pos) = list.iter().position(|v| v.as_slice() == pivot.as_ref()) else {
+                return Ok(CasAction::NoOp(-1));
+            };
+            let insert_at = if before { pos } else { pos + 1 };
+            list.insert(insert_at, value.to_vec());
+            let len = i64::try_from(list.len()).unwrap_or(i64::MAX);
+            let new_entry = StoredValue { expires_at_ms, value: Value::List(list) };
+            Ok(CasAction::Write(new_entry, len))
+        })
+        .await
+    }
+
+    async fn ltrim(&self, key: &str, start: i64, stop: i64) -> Result<(), RustyAntError> {
+        self.cas(key, move |entry| {
+            let (list, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::List(l), expires_at_ms }) => (l.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => return Ok(CasAction::NoOp(())),
+            };
+            let Some((s, e_excl)) = resolve_trim_range(list.len(), start, stop) else {
+                return Ok(CasAction::Delete(()));
+            };
+            let kept: Vec<Vec<u8>> = list[s..e_excl].to_vec();
+            if kept.is_empty() {
+                Ok(CasAction::Delete(()))
+            } else {
+                let new_entry = StoredValue { expires_at_ms, value: Value::List(kept) };
+                Ok(CasAction::Write(new_entry, ()))
+            }
+        })
+        .await
+    }
+
+    async fn list_pushx(&self, key: &str, values: Vec<Bytes>, left: bool) -> Result<i64, RustyAntError> {
+        self.cas(key, move |entry| {
+            let (mut list, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::List(l), expires_at_ms }) => (l.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => return Ok(CasAction::NoOp(0)),
+            };
+            for v in &values {
+                if left {
+                    list.insert(0, v.to_vec());
+                } else {
+                    list.push(v.to_vec());
+                }
+            }
+            let len = i64::try_from(list.len()).unwrap_or(i64::MAX);
+            let new_entry = StoredValue { expires_at_ms, value: Value::List(list) };
+            Ok(CasAction::Write(new_entry, len))
+        })
+        .await
+    }
+
     async fn zrangebyscore(&self, key: &str, min: ScoreBound, max: ScoreBound) -> Result<Vec<String>, RustyAntError> {
         let map = match self.load(key).await? {
             Some(StoredValue { value: Value::ZSet(m), .. }) => m,
@@ -1125,6 +1308,66 @@ impl Storage for S3Storage {
             }
         })
         .await
+    }
+
+    async fn smismember(&self, key: &str, members: &[String]) -> Result<Vec<bool>, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::Set(s), .. }) => Ok(members.iter().map(|m| s.contains(m)).collect()),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(members.iter().map(|_| false).collect()),
+        }
+    }
+
+    async fn sinter(&self, keys: &[String]) -> Result<Vec<String>, RustyAntError> {
+        let sets = load_sets_seq(self, keys).await?;
+        Ok(set_intersection(sets))
+    }
+
+    async fn sunion(&self, keys: &[String]) -> Result<Vec<String>, RustyAntError> {
+        let sets = load_sets_seq(self, keys).await?;
+        Ok(set_union(sets))
+    }
+
+    async fn sdiff(&self, keys: &[String]) -> Result<Vec<String>, RustyAntError> {
+        let sets = load_sets_seq(self, keys).await?;
+        Ok(set_difference(sets))
+    }
+
+    async fn spop(&self, key: &str, count: usize) -> Result<Vec<String>, RustyAntError> {
+        if count == 0 {
+            // Validate type even on no-op count so a string key still errors.
+            match self.load(key).await? {
+                Some(StoredValue { value: Value::Set(_), .. }) | None => return Ok(Vec::new()),
+                Some(_) => return Err(wrong_type(key)),
+            }
+        }
+        self.cas(key, move |entry| {
+            let (mut set, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::Set(s), expires_at_ms }) => (s.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => return Ok(CasAction::NoOp(Vec::new())),
+            };
+            let picked = pick_random_unique(&set, count);
+            for m in &picked {
+                set.remove(m);
+            }
+            if set.is_empty() {
+                Ok(CasAction::Delete(picked))
+            } else {
+                let new_entry = StoredValue { expires_at_ms, value: Value::Set(set) };
+                Ok(CasAction::Write(new_entry, picked))
+            }
+        })
+        .await
+    }
+
+    async fn srandmember(&self, key: &str, count: i64, allow_duplicates: bool) -> Result<Vec<String>, RustyAntError> {
+        let set = match self.load(key).await? {
+            Some(StoredValue { value: Value::Set(s), .. }) => s,
+            Some(_) => return Err(wrong_type(key)),
+            None => return Ok(Vec::new()),
+        };
+        Ok(pick_random(&set, count, allow_duplicates))
     }
 
     async fn zrem(&self, key: &str, members: &[String]) -> Result<i64, RustyAntError> {
@@ -1749,6 +1992,72 @@ impl Storage for InMemoryStorage {
         Ok(removed)
     }
 
+    async fn linsert(&self, key: &str, before: bool, pivot: Bytes, value: Bytes) -> Result<i64, RustyAntError> {
+        let (mut list, expires_at_ms) = match self.load(key) {
+            Some(StoredValue { value: Value::List(l), expires_at_ms }) => (l, expires_at_ms),
+            Some(_) => return Err(wrong_type(key)),
+            None => return Ok(0),
+        };
+        let Some(pos) = list.iter().position(|v| v.as_slice() == pivot.as_ref()) else {
+            return Ok(-1);
+        };
+        let insert_at = if before { pos } else { pos + 1 };
+        list.insert(insert_at, value.to_vec());
+        let len = i64::try_from(list.len()).unwrap_or(i64::MAX);
+        let entry = StoredValue { expires_at_ms, value: Value::List(list) };
+        self.with_entry_mut(|store| {
+            store.insert(key.to_string(), entry);
+        });
+        Ok(len)
+    }
+
+    async fn ltrim(&self, key: &str, start: i64, stop: i64) -> Result<(), RustyAntError> {
+        let (list, expires_at_ms) = match self.load(key) {
+            Some(StoredValue { value: Value::List(l), expires_at_ms }) => (l, expires_at_ms),
+            Some(_) => return Err(wrong_type(key)),
+            None => return Ok(()),
+        };
+        let Some((s, e_excl)) = resolve_trim_range(list.len(), start, stop) else {
+            self.with_entry_mut(|store| {
+                store.remove(key);
+            });
+            return Ok(());
+        };
+        let kept: Vec<Vec<u8>> = list[s..e_excl].to_vec();
+        if kept.is_empty() {
+            self.with_entry_mut(|store| {
+                store.remove(key);
+            });
+        } else {
+            let entry = StoredValue { expires_at_ms, value: Value::List(kept) };
+            self.with_entry_mut(|store| {
+                store.insert(key.to_string(), entry);
+            });
+        }
+        Ok(())
+    }
+
+    async fn list_pushx(&self, key: &str, values: Vec<Bytes>, left: bool) -> Result<i64, RustyAntError> {
+        let (mut list, expires_at_ms) = match self.load(key) {
+            Some(StoredValue { value: Value::List(l), expires_at_ms }) => (l, expires_at_ms),
+            Some(_) => return Err(wrong_type(key)),
+            None => return Ok(0),
+        };
+        for v in values {
+            if left {
+                list.insert(0, v.to_vec());
+            } else {
+                list.push(v.to_vec());
+            }
+        }
+        let len = i64::try_from(list.len()).unwrap_or(i64::MAX);
+        let entry = StoredValue { expires_at_ms, value: Value::List(list) };
+        self.with_entry_mut(|store| {
+            store.insert(key.to_string(), entry);
+        });
+        Ok(len)
+    }
+
     async fn zrangebyscore(&self, key: &str, min: ScoreBound, max: ScoreBound) -> Result<Vec<String>, RustyAntError> {
         let map = match self.load(key) {
             Some(StoredValue { value: Value::ZSet(m), .. }) => m,
@@ -1845,6 +2154,64 @@ impl Storage for InMemoryStorage {
             });
         }
         Ok(removed)
+    }
+
+    async fn smismember(&self, key: &str, members: &[String]) -> Result<Vec<bool>, RustyAntError> {
+        match self.load(key) {
+            Some(StoredValue { value: Value::Set(s), .. }) => Ok(members.iter().map(|m| s.contains(m)).collect()),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(members.iter().map(|_| false).collect()),
+        }
+    }
+
+    async fn sinter(&self, keys: &[String]) -> Result<Vec<String>, RustyAntError> {
+        let sets = load_sets_seq(self, keys).await?;
+        Ok(set_intersection(sets))
+    }
+
+    async fn sunion(&self, keys: &[String]) -> Result<Vec<String>, RustyAntError> {
+        let sets = load_sets_seq(self, keys).await?;
+        Ok(set_union(sets))
+    }
+
+    async fn sdiff(&self, keys: &[String]) -> Result<Vec<String>, RustyAntError> {
+        let sets = load_sets_seq(self, keys).await?;
+        Ok(set_difference(sets))
+    }
+
+    async fn spop(&self, key: &str, count: usize) -> Result<Vec<String>, RustyAntError> {
+        let (mut set, expires_at_ms) = match self.load(key) {
+            Some(StoredValue { value: Value::Set(s), expires_at_ms }) => (s, expires_at_ms),
+            Some(_) => return Err(wrong_type(key)),
+            None => return Ok(Vec::new()),
+        };
+        if count == 0 {
+            return Ok(Vec::new());
+        }
+        let picked = pick_random_unique(&set, count);
+        for m in &picked {
+            set.remove(m);
+        }
+        if set.is_empty() {
+            self.with_entry_mut(|store| {
+                store.remove(key);
+            });
+        } else {
+            let entry = StoredValue { expires_at_ms, value: Value::Set(set) };
+            self.with_entry_mut(|store| {
+                store.insert(key.to_string(), entry);
+            });
+        }
+        Ok(picked)
+    }
+
+    async fn srandmember(&self, key: &str, count: i64, allow_duplicates: bool) -> Result<Vec<String>, RustyAntError> {
+        let set = match self.load(key) {
+            Some(StoredValue { value: Value::Set(s), .. }) => s,
+            Some(_) => return Err(wrong_type(key)),
+            None => return Ok(Vec::new()),
+        };
+        Ok(pick_random(&set, count, allow_duplicates))
     }
 
     async fn zrem(&self, key: &str, members: &[String]) -> Result<i64, RustyAntError> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1203,6 +1203,299 @@ async fn type_returns_none_after_expiry() {
     call(&state, &[b"TYPE", b"k"]).await.expect_simple("none");
 }
 
+// ---------------------------------------------------------------------------
+// LINSERT / LTRIM / LPUSHX / RPUSHX
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn linsert_before_and_after_pivot() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"l", b"a", b"b", b"c"]).await;
+    call(&state, &[b"LINSERT", b"l", b"BEFORE", b"b", b"X"]).await.expect_integer(4);
+    let items = call(&state, &[b"LRANGE", b"l", b"0", b"-1"]).await.into_bulk_array();
+    assert_eq!(items[0].as_ref(), b"a");
+    assert_eq!(items[1].as_ref(), b"X");
+    assert_eq!(items[2].as_ref(), b"b");
+    call(&state, &[b"LINSERT", b"l", b"AFTER", b"b", b"Y"]).await.expect_integer(5);
+    let items = call(&state, &[b"LRANGE", b"l", b"0", b"-1"]).await.into_bulk_array();
+    assert_eq!(items[3].as_ref(), b"Y");
+    // Lowercase direction still accepted (case-insensitive match).
+    call(&state, &[b"LINSERT", b"l", b"before", b"a", b"Z"]).await.expect_integer(6);
+    let items = call(&state, &[b"LRANGE", b"l", b"0", b"0"]).await.into_bulk_array();
+    assert_eq!(items[0].as_ref(), b"Z");
+}
+
+#[tokio::test]
+async fn linsert_missing_pivot_returns_minus_one() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"l", b"a", b"b"]).await;
+    call(&state, &[b"LINSERT", b"l", b"BEFORE", b"missing", b"X"]).await.expect_integer(-1);
+}
+
+#[tokio::test]
+async fn linsert_missing_key_returns_zero() {
+    let state = test_state();
+    call(&state, &[b"LINSERT", b"missing", b"BEFORE", b"p", b"v"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn linsert_invalid_direction_errors() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"l", b"a"]).await;
+    call(&state, &[b"LINSERT", b"l", b"AROUND", b"a", b"X"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn linsert_on_wrong_type_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"LINSERT", b"k", b"BEFORE", b"p", b"x"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn ltrim_keeps_inclusive_range() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"l", b"a", b"b", b"c", b"d", b"e"]).await;
+    call(&state, &[b"LTRIM", b"l", b"1", b"3"]).await.expect_simple("OK");
+    let items = call(&state, &[b"LRANGE", b"l", b"0", b"-1"]).await.into_bulk_array();
+    assert_eq!(items.len(), 3);
+    assert_eq!(items[0].as_ref(), b"b");
+    assert_eq!(items[2].as_ref(), b"d");
+}
+
+#[tokio::test]
+async fn ltrim_negative_indices() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"l", b"a", b"b", b"c", b"d"]).await;
+    // Keep last two elements.
+    call(&state, &[b"LTRIM", b"l", b"-2", b"-1"]).await.expect_simple("OK");
+    let items = call(&state, &[b"LRANGE", b"l", b"0", b"-1"]).await.into_bulk_array();
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0].as_ref(), b"c");
+    assert_eq!(items[1].as_ref(), b"d");
+}
+
+#[tokio::test]
+async fn ltrim_empty_range_deletes_key() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"l", b"a", b"b", b"c"]).await;
+    // start > stop after normalization → resulting list is empty.
+    call(&state, &[b"LTRIM", b"l", b"5", b"10"]).await.expect_simple("OK");
+    call(&state, &[b"EXISTS", b"l"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn ltrim_on_missing_key_is_noop_ok() {
+    let state = test_state();
+    call(&state, &[b"LTRIM", b"missing", b"0", b"0"]).await.expect_simple("OK");
+}
+
+#[tokio::test]
+async fn ltrim_on_wrong_type_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"LTRIM", b"k", b"0", b"1"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn lpushx_only_when_key_exists() {
+    let state = test_state();
+    call(&state, &[b"LPUSHX", b"missing", b"a"]).await.expect_integer(0);
+    call(&state, &[b"EXISTS", b"missing"]).await.expect_integer(0);
+    call(&state, &[b"RPUSH", b"l", b"a"]).await;
+    call(&state, &[b"LPUSHX", b"l", b"b", b"c"]).await.expect_integer(3);
+    let items = call(&state, &[b"LRANGE", b"l", b"0", b"-1"]).await.into_bulk_array();
+    // LPUSHX b c → inserts b then c at head → final: c, b, a
+    assert_eq!(items[0].as_ref(), b"c");
+    assert_eq!(items[1].as_ref(), b"b");
+    assert_eq!(items[2].as_ref(), b"a");
+}
+
+#[tokio::test]
+async fn rpushx_only_when_key_exists() {
+    let state = test_state();
+    call(&state, &[b"RPUSHX", b"missing", b"a"]).await.expect_integer(0);
+    call(&state, &[b"RPUSH", b"l", b"a"]).await;
+    call(&state, &[b"RPUSHX", b"l", b"b", b"c"]).await.expect_integer(3);
+    let items = call(&state, &[b"LRANGE", b"l", b"0", b"-1"]).await.into_bulk_array();
+    assert_eq!(items[0].as_ref(), b"a");
+    assert_eq!(items[2].as_ref(), b"c");
+}
+
+#[tokio::test]
+async fn pushx_on_wrong_type_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"LPUSHX", b"k", b"x"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"RPUSHX", b"k", b"x"]).await.expect_error_prefix("ERR");
+}
+
+// ---------------------------------------------------------------------------
+// SINTER / SUNION / SDIFF / SMISMEMBER / SPOP / SRANDMEMBER
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn sinter_returns_common_members() {
+    let state = test_state();
+    call(&state, &[b"SADD", b"a", b"x", b"y", b"z"]).await;
+    call(&state, &[b"SADD", b"b", b"y", b"z", b"w"]).await;
+    call(&state, &[b"SADD", b"c", b"z", b"y", b"q"]).await;
+    let mut members = bulks_to_strs(&call(&state, &[b"SINTER", b"a", b"b", b"c"]).await.into_bulk_array());
+    members.sort();
+    assert_eq!(members, vec!["y".to_string(), "z".to_string()]);
+}
+
+#[tokio::test]
+async fn sinter_with_missing_key_returns_empty() {
+    let state = test_state();
+    call(&state, &[b"SADD", b"a", b"x", b"y"]).await;
+    let members = call(&state, &[b"SINTER", b"a", b"missing"]).await.into_bulk_array();
+    assert!(members.is_empty());
+}
+
+#[tokio::test]
+async fn sunion_combines_sets() {
+    let state = test_state();
+    call(&state, &[b"SADD", b"a", b"x", b"y"]).await;
+    call(&state, &[b"SADD", b"b", b"y", b"z"]).await;
+    let mut members = bulks_to_strs(&call(&state, &[b"SUNION", b"a", b"b"]).await.into_bulk_array());
+    members.sort();
+    assert_eq!(members, vec!["x".to_string(), "y".to_string(), "z".to_string()]);
+}
+
+#[tokio::test]
+async fn sdiff_returns_first_minus_rest() {
+    let state = test_state();
+    call(&state, &[b"SADD", b"a", b"x", b"y", b"z"]).await;
+    call(&state, &[b"SADD", b"b", b"y"]).await;
+    call(&state, &[b"SADD", b"c", b"z"]).await;
+    let mut members = bulks_to_strs(&call(&state, &[b"SDIFF", b"a", b"b", b"c"]).await.into_bulk_array());
+    members.sort();
+    assert_eq!(members, vec!["x".to_string()]);
+}
+
+#[tokio::test]
+async fn sinter_on_wrong_type_errors() {
+    let state = test_state();
+    call(&state, &[b"SADD", b"s", b"x"]).await;
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"SINTER", b"s", b"k"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn smismember_reports_per_member_presence() {
+    let state = test_state();
+    call(&state, &[b"SADD", b"s", b"x", b"y"]).await;
+    // Reply shape is an array of RESP integers (:0 / :1). The bulk-array
+    // helper only decodes bulk strings, so check the raw RESP encoding here
+    // and the storage contract below.
+    let reply = call(&state, &[b"SMISMEMBER", b"s", b"x", b"y", b"z"]).await;
+    assert_eq!(reply.raw, b"*3\r\n:1\r\n:1\r\n:0\r\n");
+    let got = state.storage.smismember("s", &["x".into(), "y".into(), "z".into()]).await.expect("smismember");
+    assert_eq!(got, vec![true, true, false]);
+}
+
+#[tokio::test]
+async fn smismember_missing_key_returns_all_zero() {
+    let state = test_state();
+    let got = state.storage.smismember("missing", &["x".into(), "y".into()]).await.expect("smismember");
+    assert_eq!(got, vec![false, false]);
+}
+
+#[tokio::test]
+async fn smismember_on_wrong_type_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"SMISMEMBER", b"k", b"x"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn spop_single_removes_and_returns_member() {
+    let state = test_state();
+    call(&state, &[b"SADD", b"s", b"only"]).await;
+    call(&state, &[b"SPOP", b"s"]).await.expect_bulk(b"only");
+    call(&state, &[b"EXISTS", b"s"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn spop_count_returns_array_and_removes() {
+    let state = test_state();
+    call(&state, &[b"SADD", b"s", b"a", b"b", b"c", b"d"]).await;
+    let popped = call(&state, &[b"SPOP", b"s", b"3"]).await.into_bulk_array();
+    assert_eq!(popped.len(), 3);
+    call(&state, &[b"SCARD", b"s"]).await.expect_integer(1);
+}
+
+#[tokio::test]
+async fn spop_missing_key_returns_nil_or_empty_array() {
+    let state = test_state();
+    call(&state, &[b"SPOP", b"missing"]).await.expect_nil();
+    let arr = call(&state, &[b"SPOP", b"missing", b"3"]).await.into_bulk_array();
+    assert!(arr.is_empty());
+}
+
+#[tokio::test]
+async fn spop_count_zero_is_noop() {
+    let state = test_state();
+    call(&state, &[b"SADD", b"s", b"a", b"b"]).await;
+    let arr = call(&state, &[b"SPOP", b"s", b"0"]).await.into_bulk_array();
+    assert!(arr.is_empty());
+    call(&state, &[b"SCARD", b"s"]).await.expect_integer(2);
+}
+
+#[tokio::test]
+async fn spop_negative_count_errors() {
+    let state = test_state();
+    call(&state, &[b"SADD", b"s", b"a"]).await;
+    call(&state, &[b"SPOP", b"s", b"-1"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn srandmember_single_returns_member_without_removing() {
+    let state = test_state();
+    call(&state, &[b"SADD", b"s", b"only"]).await;
+    call(&state, &[b"SRANDMEMBER", b"s"]).await.expect_bulk(b"only");
+    call(&state, &[b"SCARD", b"s"]).await.expect_integer(1);
+}
+
+#[tokio::test]
+async fn srandmember_missing_key_returns_nil() {
+    let state = test_state();
+    call(&state, &[b"SRANDMEMBER", b"missing"]).await.expect_nil();
+}
+
+#[tokio::test]
+async fn srandmember_positive_count_returns_unique() {
+    let state = test_state();
+    call(&state, &[b"SADD", b"s", b"a", b"b", b"c"]).await;
+    // Positive count 5 ≥ cardinality 3 → all 3 members, no duplicates.
+    let picked = call(&state, &[b"SRANDMEMBER", b"s", b"5"]).await.into_bulk_array();
+    assert_eq!(picked.len(), 3);
+    let mut unique: Vec<&[u8]> = picked.iter().map(AsRef::as_ref).collect();
+    unique.sort_unstable();
+    unique.dedup();
+    assert_eq!(unique.len(), 3);
+}
+
+#[tokio::test]
+async fn srandmember_negative_count_allows_duplicates() {
+    let state = test_state();
+    call(&state, &[b"SADD", b"s", b"only"]).await;
+    // Negative count 5 against a 1-member set → 5 repeats of "only".
+    let picked = call(&state, &[b"SRANDMEMBER", b"s", b"-5"]).await.into_bulk_array();
+    assert_eq!(picked.len(), 5);
+    for b in &picked {
+        assert_eq!(b.as_ref(), b"only");
+    }
+}
+
+#[tokio::test]
+async fn srandmember_on_wrong_type_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"SRANDMEMBER", b"k"]).await.expect_error_prefix("ERR");
+}
+
 // Use RespReply publicly to check the crate re-export surface compiles.
 #[test]
 fn reply_encode_simple_works_from_tests() {


### PR DESCRIPTION
## Summary

- **Lists (+4):** `LINSERT`, `LTRIM`, `LPUSHX`, `RPUSHX`
- **Sets (+6):** `SINTER`, `SUNION`, `SDIFF`, `SPOP` (+ count), `SRANDMEMBER` (+ count), `SMISMEMBER`

Storage trait gains matching methods on both `S3Storage` (CAS-guarded for mutators; empty-set cleanup via conditional `DeleteObject`) and `InMemoryStorage`. Shared set-operation and random-pick helpers sit next to the existing zset helpers.

`SPOP` / `SRANDMEMBER` sample via a time-seeded xorshift — Redis only requires random-ish sampling here, so the change avoids adding a `rand` dependency. Negative-count `SRANDMEMBER` allows repetition; positive count returns uniques.

`LTRIM`'s range normalization differs from `LRANGE`: start beyond the list drops the key entirely (matches Redis), so it gets its own `resolve_trim_range` helper rather than reusing `resolve_range`.

## Test plan

- [x] `just check` — fmt + clippy clean
- [x] `just test` — 187/187 passing (18 lib + 145 HTTP integration + 11 redis-py + 6 WS + 7 floci)
- [x] Integration suite grew by 30 tests covering: pivot found/missing for `LINSERT`, empty/negative-range deletion for `LTRIM`, key-exists gate for `*PUSHX`, intersection/union/diff cases incl. missing-key and wrong-type, `SMISMEMBER` presence encoding, `SPOP` single vs count vs empty, `SRANDMEMBER` unique-vs-duplicate sampling.