### PR TITLE
:sparkles: expand Keyspace, Strings, and Sorted-Set commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,18 +58,18 @@ Implemented:
 | Group | Commands |
 |---|---|
 | Server | `PING` |
-| Keyspace | `KEYS`, `SCAN` (+ `MATCH` / `COUNT` options), `TYPE` |
-| Strings | `GET`, `SET` (+ `EX` / `PX` options), `GETSET`, `GETDEL`, `SETNX`, `SETEX`, `MGET`, `MSET`, `APPEND`, `STRLEN`, `DEL`, `EXISTS`, `EXPIRE`, `EXPIREAT`, `PEXPIREAT`, `PERSIST`, `TTL`, `INCR`, `INCRBY`, `DECR`, `DECRBY` |
+| Keyspace | `KEYS`, `SCAN` (+ `MATCH` / `COUNT` options), `TYPE`, `RENAME`, `RENAMENX` |
+| Strings | `GET`, `SET` (+ `EX` / `PX` options), `GETSET`, `GETDEL`, `GETRANGE`, `SETRANGE`, `SETNX`, `SETEX`, `MGET`, `MSET`, `MSETNX`, `APPEND`, `STRLEN`, `DEL`, `EXISTS`, `EXPIRE`, `EXPIREAT`, `PEXPIRE`, `PEXPIREAT`, `PERSIST`, `TTL`, `PTTL`, `INCR`, `INCRBY`, `INCRBYFLOAT`, `DECR`, `DECRBY` |
 | Hashes | `HSET`, `HSETNX`, `HGET`, `HDEL`, `HGETALL`, `HLEN`, `HKEYS`, `HVALS`, `HEXISTS`, `HSTRLEN`, `HMGET`, `HINCRBY` |
 | Lists | `LPUSH`, `RPUSH`, `LPUSHX`, `RPUSHX`, `LPOP` (+ count), `RPOP` (+ count), `LRANGE`, `LLEN`, `LINDEX`, `LSET`, `LREM`, `LINSERT`, `LTRIM` |
 | Sets | `SADD`, `SREM`, `SMEMBERS`, `SISMEMBER`, `SMISMEMBER`, `SCARD`, `SINTER`, `SUNION`, `SDIFF`, `SPOP` (+ count), `SRANDMEMBER` (+ count) |
-| Sorted Sets | `ZADD`, `ZREM`, `ZINCRBY`, `ZRANGE`, `ZRANGEBYSCORE`, `ZSCORE`, `ZMSCORE`, `ZCARD`, `ZCOUNT`, `ZRANK`, `ZREVRANK` |
+| Sorted Sets | `ZADD`, `ZREM`, `ZINCRBY`, `ZRANGE`, `ZREVRANGE`, `ZRANGEBYSCORE`, `ZREVRANGEBYSCORE`, `ZREMRANGEBYRANK`, `ZREMRANGEBYSCORE`, `ZPOPMIN` (+ count), `ZPOPMAX` (+ count), `ZSCORE`, `ZMSCORE`, `ZCARD`, `ZCOUNT`, `ZRANK`, `ZREVRANK` |
 
 `KEYS` paginates through `ListObjectsV2` in full and filters by the wildmatch pattern — O(n) over the keyspace, safe at low cardinality, proportionally slower for larger buckets. `SCAN` delegates the page boundary to S3 via a continuation token, returning one `ListObjectsV2` page per call; `MATCH` is applied client-side, so the per-page yield may be smaller than `COUNT` when a pattern is narrow.
 
 Not implemented (PRs welcome): pub/sub, transactions, scripting, streams, geo.
 
-`MSET` is **not atomic across keys** — a failure partway through leaves earlier keys set. Real Redis is atomic here; rustyant's S3 backing makes the all-or-none semantic expensive, and the fire-and-forget variant is fine for most workloads.
+`MSET` is **not atomic across keys** — a failure partway through leaves earlier keys set. Real Redis is atomic here; rustyant's S3 backing makes the all-or-none semantic expensive, and the fire-and-forget variant is fine for most workloads. `MSETNX` and `RENAME` / `RENAMENX` are similarly best-effort on the S3 backend: the in-memory path is fully atomic under its `Mutex`, but on S3 a concurrent writer landing between the existence check and the write can leak past the `NX` guard. `RENAMENX` uses `If-None-Match: *` on the destination to shrink that window, so the failure mode is "rename reports 0 / error" rather than data loss.
 
 ### Concurrency
 
@@ -154,6 +154,6 @@ The `rustyant` and `rustyant-ws` binaries emit structured JSON logs via `tracing
 
 ## Status
 
-Working: RESP over HTTP and WebSocket, full string/hash/list/set/zset command dispatch plus `KEYS` / `SCAN`, S3-backed storage with per-key TTL and conditional-write CAS on every read-modify-write, 187 Rust tests across 5 suites (18 lib units + 145 HTTP integration + 11 redis-py compat + 6 WebSocket E2E + 7 floci/S3) and 13 Python client tests, structured logs and CloudWatch EMF metrics, CI on GitHub Actions with floci as a service container, SAM template validated in CI.
+Working: RESP over HTTP and WebSocket, full string/hash/list/set/zset command dispatch plus `KEYS` / `SCAN`, S3-backed storage with per-key TTL and conditional-write CAS on every read-modify-write, 218 Rust tests across 5 suites (18 lib units + 176 HTTP integration + 11 redis-py compat + 6 WebSocket E2E + 7 floci/S3) and 13 Python client tests, structured logs and CloudWatch EMF metrics, CI on GitHub Actions with floci as a service container, SAM template validated in CI.
 
 Not wired: no end-to-end test driving a real WebSocket connection against a deployed binary in AWS; the `s3_concurrent_incr_converges` CAS test is gated behind `RUSTYANT_S3_CAS=1` because floci doesn't enforce `If-Match` headers.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -87,7 +87,7 @@ pub async fn dispatch(state: &State, command_tokens: Vec<Bytes>) -> RespReply {
     }
 }
 
-#[allow(clippy::large_stack_frames)]
+#[allow(clippy::large_stack_frames, clippy::too_many_lines)]
 async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
     let mut iter = tokens.into_iter();
     let cmd_bytes = iter.next().ok_or_else(|| RustyAntError::RespParse("empty command array".into()))?;
@@ -102,6 +102,8 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "GET" => handle_get(state, args).await,
         "GETSET" => handle_getset(state, args).await,
         "GETDEL" => handle_getdel(state, args).await,
+        "GETRANGE" => handle_getrange(state, args).await,
+        "SETRANGE" => handle_setrange(state, args).await,
         "STRLEN" => handle_strlen(state, args).await,
         "APPEND" => handle_append(state, args).await,
         "SET" => handle_set(state, args).await,
@@ -109,13 +111,18 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "SETEX" => handle_setex(state, args).await,
         "MGET" => handle_mget(state, args).await,
         "MSET" => handle_mset(state, args).await,
+        "MSETNX" => handle_msetnx(state, args).await,
         "DEL" => handle_del(state, args).await,
         "EXISTS" => handle_exists(state, args).await,
         "EXPIRE" => handle_expire(state, args).await,
         "EXPIREAT" => handle_expireat(state, args).await,
+        "PEXPIRE" => handle_pexpire(state, args).await,
         "PEXPIREAT" => handle_pexpireat(state, args).await,
         "PERSIST" => handle_persist(state, args).await,
         "TTL" => handle_ttl(state, args).await,
+        "PTTL" => handle_pttl(state, args).await,
+        "RENAME" => handle_rename(state, args).await,
+        "RENAMENX" => handle_renamenx(state, args).await,
         "KEYS" => handle_keys(state, args).await,
         "SCAN" => handle_scan(state, args).await,
         "TYPE" => handle_type(state, args).await,
@@ -124,6 +131,7 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
             let delta = parse_delta(&args)?;
             handle_incrby(state, args, delta).await
         }
+        "INCRBYFLOAT" => handle_incrbyfloat(state, args).await,
         "DECR" => handle_incrby(state, args, -1).await,
         "DECRBY" => {
             let delta = parse_delta(&args)?;
@@ -174,7 +182,13 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "ZREM" => handle_zrem(state, args).await,
         "ZINCRBY" => handle_zincrby(state, args).await,
         "ZRANGE" => handle_zrange(state, args).await,
+        "ZREVRANGE" => handle_zrevrange(state, args).await,
         "ZRANGEBYSCORE" => handle_zrangebyscore(state, args).await,
+        "ZREVRANGEBYSCORE" => handle_zrevrangebyscore(state, args).await,
+        "ZREMRANGEBYRANK" => handle_zremrangebyrank(state, args).await,
+        "ZREMRANGEBYSCORE" => handle_zremrangebyscore(state, args).await,
+        "ZPOPMIN" => handle_zpop(state, args, false).await,
+        "ZPOPMAX" => handle_zpop(state, args, true).await,
         "ZSCORE" => handle_zscore(state, args).await,
         "ZCARD" => handle_zcard(state, args).await,
         "ZRANK" => handle_zrank(state, args, false).await,
@@ -898,4 +912,154 @@ fn format_score(s: f64) -> String {
         return as_int.to_string();
     }
     format!("{s}")
+}
+
+// ---- New keyspace commands -------------------------------------------------
+
+async fn handle_pexpire(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("PEXPIRE", args.len() == 2)?;
+    let key = arg_as_str(&args[0])?;
+    let ms = parse_i64(&args[1], "milliseconds")?;
+    let set = state.storage.expire_at(key, now_ms() + ms).await?;
+    Ok(RespReply::Integer(i64::from(set)))
+}
+
+async fn handle_pttl(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("PTTL", args.len() == 1)?;
+    let key = arg_as_str(&args[0])?;
+    Ok(match state.storage.ttl_ms(key).await? {
+        TtlResult::NoKey => RespReply::Integer(-2),
+        TtlResult::NoExpire => RespReply::Integer(-1),
+        TtlResult::Ms(ms) => RespReply::Integer(ms),
+    })
+}
+
+async fn handle_rename(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("RENAME", args.len() == 2)?;
+    let from = arg_as_str(&args[0])?;
+    let to = arg_as_str(&args[1])?;
+    state.storage.rename(from, to).await?;
+    Ok(RespReply::ok())
+}
+
+async fn handle_renamenx(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("RENAMENX", args.len() == 2)?;
+    let from = arg_as_str(&args[0])?;
+    let to = arg_as_str(&args[1])?;
+    let renamed = state.storage.renamenx(from, to).await?;
+    Ok(RespReply::Integer(i64::from(renamed)))
+}
+
+// ---- New string commands ---------------------------------------------------
+
+async fn handle_incrbyfloat(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("INCRBYFLOAT", args.len() == 2)?;
+    let key = arg_as_str(&args[0])?;
+    let delta = parse_f64(&args[1], "increment")?;
+    let new = state.storage.incr_by_float(key, delta).await?;
+    Ok(RespReply::BulkString(Some(Bytes::from(format_score(new).into_bytes()))))
+}
+
+async fn handle_getrange(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("GETRANGE", args.len() == 3)?;
+    let key = arg_as_str(&args[0])?;
+    let start = parse_i64(&args[1], "start")?;
+    let end = parse_i64(&args[2], "end")?;
+    let slice = state.storage.getrange(key, start, end).await?;
+    Ok(RespReply::BulkString(Some(slice)))
+}
+
+async fn handle_setrange(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("SETRANGE", args.len() == 3)?;
+    let key = arg_as_str(&args[0])?;
+    let offset = parse_i64(&args[1], "offset")?;
+    if offset < 0 {
+        return Err(RustyAntError::Parse("offset must be >= 0".into()));
+    }
+    let offset_u = usize::try_from(offset).unwrap_or(0);
+    let len = state.storage.setrange(key, offset_u, args[2].clone()).await?;
+    Ok(RespReply::Integer(len))
+}
+
+async fn handle_msetnx(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    if args.is_empty() || args.len() % 2 != 0 {
+        return Err(RustyAntError::WrongArity { command: "MSETNX".into() });
+    }
+    let mut pairs: Vec<(String, Bytes)> = Vec::with_capacity(args.len() / 2);
+    let mut i = 0;
+    while i < args.len() {
+        pairs.push((arg_as_string(&args[i])?, args[i + 1].clone()));
+        i += 2;
+    }
+    let all_set = state.storage.msetnx(pairs).await?;
+    Ok(RespReply::Integer(i64::from(all_set)))
+}
+
+// ---- New sorted-set commands ----------------------------------------------
+
+async fn handle_zrevrange(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("ZREVRANGE", args.len() == 3)?;
+    let key = arg_as_str(&args[0])?;
+    let start = parse_i64(&args[1], "start")?;
+    let stop = parse_i64(&args[2], "stop")?;
+    let members = state.storage.zrevrange(key, start, stop).await?;
+    Ok(RespReply::Array(
+        members.into_iter().map(|m| RespReply::BulkString(Some(Bytes::from(m.into_bytes())))).collect(),
+    ))
+}
+
+async fn handle_zrevrangebyscore(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("ZREVRANGEBYSCORE", args.len() == 3)?;
+    let key = arg_as_str(&args[0])?;
+    // Note: argument order is (max, min) — the reverse of ZRANGEBYSCORE —
+    // to match Redis's CLI convention.
+    let max = ScoreBound::parse(arg_as_str(&args[1])?)?;
+    let min = ScoreBound::parse(arg_as_str(&args[2])?)?;
+    let members = state.storage.zrevrangebyscore(key, max, min).await?;
+    Ok(RespReply::Array(
+        members.into_iter().map(|m| RespReply::BulkString(Some(Bytes::from(m.into_bytes())))).collect(),
+    ))
+}
+
+async fn handle_zremrangebyrank(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("ZREMRANGEBYRANK", args.len() == 3)?;
+    let key = arg_as_str(&args[0])?;
+    let start = parse_i64(&args[1], "start")?;
+    let stop = parse_i64(&args[2], "stop")?;
+    let removed = state.storage.zremrangebyrank(key, start, stop).await?;
+    Ok(RespReply::Integer(removed))
+}
+
+async fn handle_zremrangebyscore(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("ZREMRANGEBYSCORE", args.len() == 3)?;
+    let key = arg_as_str(&args[0])?;
+    let min = ScoreBound::parse(arg_as_str(&args[1])?)?;
+    let max = ScoreBound::parse(arg_as_str(&args[2])?)?;
+    let removed = state.storage.zremrangebyscore(key, min, max).await?;
+    Ok(RespReply::Integer(removed))
+}
+
+async fn handle_zpop(state: &State, args: Vec<Bytes>, from_max: bool) -> Result<RespReply, RustyAntError> {
+    let cmd = if from_max { "ZPOPMAX" } else { "ZPOPMIN" };
+    arity(cmd, !args.is_empty() && args.len() <= 2)?;
+    let key = arg_as_str(&args[0])?;
+    let count = if args.len() == 2 {
+        let c = parse_i64(&args[1], "count")?;
+        if c < 0 {
+            return Err(RustyAntError::Parse("count must be >= 0".into()));
+        }
+        usize::try_from(c).unwrap_or(0)
+    } else {
+        1
+    };
+    let popped =
+        if from_max { state.storage.zpopmax(key, count).await? } else { state.storage.zpopmin(key, count).await? };
+    // Flatten [(member, score), ...] into a flat RESP array matching Redis's
+    // `member, score, member, score, ...` encoding.
+    let mut flat: Vec<RespReply> = Vec::with_capacity(popped.len() * 2);
+    for (m, s) in popped {
+        flat.push(RespReply::BulkString(Some(Bytes::from(m.into_bytes()))));
+        flat.push(RespReply::BulkString(Some(Bytes::from(format_score(s).into_bytes()))));
+    }
+    Ok(RespReply::Array(flat))
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -159,12 +159,73 @@ fn remove_list_occurrences(list: &mut Vec<Vec<u8>>, target: &[u8], count: i64) -
     removed
 }
 
+/// Sort a `ZSet` by (score asc, member asc) — the canonical Redis ordering.
+fn sorted_zset(map: BTreeMap<String, f64>) -> Vec<(String, f64)> {
+    let mut sorted: Vec<(String, f64)> = map.into_iter().collect();
+    sorted.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal).then_with(|| a.0.cmp(&b.0)));
+    sorted
+}
+
+/// Pull the f64 numeric representation out of a string-typed entry,
+/// preserving any existing TTL. Used by `INCRBYFLOAT`.
+fn parse_string_as_f64(entry: Option<&StoredValue>, key: &str) -> Result<(f64, Option<i64>), RustyAntError> {
+    match entry {
+        Some(StoredValue { value: Value::String(data), expires_at_ms }) => {
+            let s = std::str::from_utf8(data).map_err(|_| RustyAntError::Parse("value is not a float".into()))?;
+            let n: f64 = s.parse().map_err(|_| RustyAntError::Parse("value is not a float".into()))?;
+            Ok((n, *expires_at_ms))
+        }
+        Some(_) => Err(wrong_type(key)),
+        None => Ok((0.0, None)),
+    }
+}
+
+/// Render a finite float the way Redis renders `INCRBYFLOAT` output: integer
+/// values come back without a decimal, others via shortest round-trip.
+fn format_float(v: f64) -> String {
+    if v.fract() == 0.0 && v.abs() < 9.007_199_254_740_992e15 {
+        #[allow(clippy::cast_possible_truncation)] // fract==0 && range checked
+        let as_int = v as i64;
+        return as_int.to_string();
+    }
+    format!("{v}")
+}
+
+/// Redis `GETRANGE` substring: inclusive end, negative indices relative to
+/// end, out-of-range collapses to empty. Operates on raw bytes, not UTF-8.
+fn slice_string_range(data: &[u8], start: i64, end: i64) -> Vec<u8> {
+    if data.is_empty() {
+        return Vec::new();
+    }
+    let len = i64::try_from(data.len()).unwrap_or(i64::MAX);
+    let s = if start < 0 { (len + start).max(0) } else { start };
+    let e = if end < 0 { len + end } else { end.min(len - 1) };
+    if s >= len || e < 0 || s > e {
+        return Vec::new();
+    }
+    let su = usize::try_from(s).unwrap_or(0);
+    let eu = usize::try_from(e).unwrap_or(0);
+    data[su..=eu].to_vec()
+}
+
+/// Redis `SETRANGE` in-place overwrite: pad with zero bytes out to `offset`
+/// if the existing string is shorter, then splat `value` starting at `offset`,
+/// extending the buffer if the write runs past the end.
+fn apply_setrange(data: &mut Vec<u8>, offset: usize, value: &[u8]) {
+    if data.len() < offset {
+        data.resize(offset, 0);
+    }
+    let end = offset + value.len();
+    if data.len() < end {
+        data.resize(end, 0);
+    }
+    data[offset..end].copy_from_slice(value);
+}
+
 /// Sort a `ZSet` by (score asc, member asc), then filter by the min/max
 /// bounds. Shared between `S3Storage` and `InMemoryStorage`.
 fn filter_zset_by_score(map: BTreeMap<String, f64>, min: ScoreBound, max: ScoreBound) -> Vec<String> {
-    let mut sorted: Vec<(String, f64)> = map.into_iter().collect();
-    sorted.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal).then_with(|| a.0.cmp(&b.0)));
-    sorted.into_iter().filter(|(_, s)| min.ge_min(*s) && max.le_max(*s)).map(|(m, _)| m).collect()
+    sorted_zset(map).into_iter().filter(|(_, s)| min.ge_min(*s) && max.le_max(*s)).map(|(m, _)| m).collect()
 }
 
 /// Number of members whose score falls within `[min, max]` (inclusive/
@@ -172,6 +233,84 @@ fn filter_zset_by_score(map: BTreeMap<String, f64>, min: ScoreBound, max: ScoreB
 fn count_zset_by_score(map: &BTreeMap<String, f64>, min: ScoreBound, max: ScoreBound) -> i64 {
     let n = map.values().filter(|s| min.ge_min(**s) && max.le_max(**s)).count();
     i64::try_from(n).unwrap_or(i64::MAX)
+}
+
+/// `ZREVRANGE` slice: sort ascending, reverse, then apply the rank window.
+fn slice_zset_reversed(map: BTreeMap<String, f64>, start: i64, stop: i64) -> Vec<String> {
+    let mut sorted = sorted_zset(map);
+    sorted.reverse();
+    let len = i64::try_from(sorted.len()).unwrap_or(i64::MAX);
+    let Some((s, e)) = resolve_range(len, start, stop) else {
+        return Vec::new();
+    };
+    sorted[s..=e].iter().map(|(m, _)| m.clone()).collect()
+}
+
+/// Split a zset into (kept, `removed_count`) based on an ascending rank range
+/// — drives `ZREMRANGEBYRANK`.
+fn partition_zset_by_rank(map: BTreeMap<String, f64>, start: i64, stop: i64) -> (BTreeMap<String, f64>, usize) {
+    let sorted = sorted_zset(map);
+    let len = i64::try_from(sorted.len()).unwrap_or(i64::MAX);
+    let Some((s, e)) = resolve_range(len, start, stop) else {
+        return (sorted.into_iter().collect(), 0);
+    };
+    let mut kept = BTreeMap::new();
+    let mut removed = 0usize;
+    for (i, (m, score)) in sorted.into_iter().enumerate() {
+        if i >= s && i <= e {
+            removed += 1;
+        } else {
+            kept.insert(m, score);
+        }
+    }
+    (kept, removed)
+}
+
+/// Split a zset into (kept, `removed_count`) based on a score range — drives
+/// `ZREMRANGEBYSCORE`.
+fn partition_zset_by_score(
+    map: BTreeMap<String, f64>,
+    min: ScoreBound,
+    max: ScoreBound,
+) -> (BTreeMap<String, f64>, usize) {
+    let mut kept = BTreeMap::new();
+    let mut removed = 0usize;
+    for (m, score) in map {
+        if min.ge_min(score) && max.le_max(score) {
+            removed += 1;
+        } else {
+            kept.insert(m, score);
+        }
+    }
+    (kept, removed)
+}
+
+/// Take up to `count` members from one end of a zset. `from_max=true` pops
+/// the highest-ranked (descending score, then lex desc within a tie);
+/// otherwise pops from the bottom.
+fn pop_zset_edge(
+    map: BTreeMap<String, f64>,
+    count: usize,
+    from_max: bool,
+) -> (BTreeMap<String, f64>, Vec<(String, f64)>) {
+    if count == 0 || map.is_empty() {
+        return (map, Vec::new());
+    }
+    let mut sorted = sorted_zset(map);
+    if from_max {
+        sorted.reverse();
+    }
+    let take = count.min(sorted.len());
+    let mut popped: Vec<(String, f64)> = Vec::with_capacity(take);
+    let mut kept = BTreeMap::new();
+    for (i, (m, score)) in sorted.into_iter().enumerate() {
+        if i < take {
+            popped.push((m, score));
+        } else {
+            kept.insert(m, score);
+        }
+    }
+    (kept, popped)
 }
 
 /// Time-seeded xorshift — good enough for Redis `SPOP` / `SRANDMEMBER`, which
@@ -352,7 +491,13 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn strlen(&self, key: &str) -> Result<i64, RustyAntError>;
     async fn append(&self, key: &str, value: Bytes) -> Result<i64, RustyAntError>;
     async fn incr_by(&self, key: &str, delta: i64) -> Result<i64, RustyAntError>;
+    async fn incr_by_float(&self, key: &str, delta: f64) -> Result<f64, RustyAntError>;
+    async fn getrange(&self, key: &str, start: i64, end: i64) -> Result<Bytes, RustyAntError>;
+    async fn setrange(&self, key: &str, offset: usize, value: Bytes) -> Result<i64, RustyAntError>;
+    async fn msetnx(&self, pairs: Vec<(String, Bytes)>) -> Result<bool, RustyAntError>;
     async fn persist(&self, key: &str) -> Result<bool, RustyAntError>;
+    async fn rename(&self, from: &str, to: &str) -> Result<(), RustyAntError>;
+    async fn renamenx(&self, from: &str, to: &str) -> Result<bool, RustyAntError>;
 
     /// Default: sequential `get_string` per key. Impls may override with a
     /// batched S3 request.
@@ -415,7 +560,14 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn zrem(&self, key: &str, members: &[String]) -> Result<i64, RustyAntError>;
     async fn zincr_by(&self, key: &str, member: &str, delta: f64) -> Result<f64, RustyAntError>;
     async fn zrange(&self, key: &str, start: i64, stop: i64) -> Result<Vec<String>, RustyAntError>;
+    async fn zrevrange(&self, key: &str, start: i64, stop: i64) -> Result<Vec<String>, RustyAntError>;
     async fn zrangebyscore(&self, key: &str, min: ScoreBound, max: ScoreBound) -> Result<Vec<String>, RustyAntError>;
+    async fn zrevrangebyscore(&self, key: &str, max: ScoreBound, min: ScoreBound)
+    -> Result<Vec<String>, RustyAntError>;
+    async fn zremrangebyrank(&self, key: &str, start: i64, stop: i64) -> Result<i64, RustyAntError>;
+    async fn zremrangebyscore(&self, key: &str, min: ScoreBound, max: ScoreBound) -> Result<i64, RustyAntError>;
+    async fn zpopmin(&self, key: &str, count: usize) -> Result<Vec<(String, f64)>, RustyAntError>;
+    async fn zpopmax(&self, key: &str, count: usize) -> Result<Vec<(String, f64)>, RustyAntError>;
     async fn zscore(&self, key: &str, member: &str) -> Result<Option<f64>, RustyAntError>;
     async fn zcard(&self, key: &str) -> Result<i64, RustyAntError>;
     async fn zrank(&self, key: &str, member: &str) -> Result<Option<i64>, RustyAntError>;
@@ -566,6 +718,33 @@ impl S3Storage {
                 }
             }
         }
+    }
+
+    /// Shared `ZPOPMIN` / `ZPOPMAX` implementation. `from_max=true` pops the
+    /// highest-ranked members; otherwise pops from the bottom.
+    async fn zpop_impl(&self, key: &str, count: usize, from_max: bool) -> Result<Vec<(String, f64)>, RustyAntError> {
+        if count == 0 {
+            // Type-check even for a no-op count so a string key still errors.
+            match self.load(key).await? {
+                Some(StoredValue { value: Value::ZSet(_), .. }) | None => return Ok(Vec::new()),
+                Some(_) => return Err(wrong_type(key)),
+            }
+        }
+        self.cas(key, move |entry| {
+            let (map, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::ZSet(m), expires_at_ms }) => (m.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => return Ok(CasAction::NoOp(Vec::new())),
+            };
+            let (kept, popped) = pop_zset_edge(map, count, from_max);
+            if kept.is_empty() {
+                Ok(CasAction::Delete(popped))
+            } else {
+                let new_entry = StoredValue { expires_at_ms, value: Value::ZSet(kept) };
+                Ok(CasAction::Write(new_entry, popped))
+            }
+        })
+        .await
     }
 
     /// Read-modify-write helper: runs `modify` against the latest entry,
@@ -1065,6 +1244,64 @@ impl Storage for S3Storage {
         .await
     }
 
+    async fn incr_by_float(&self, key: &str, delta: f64) -> Result<f64, RustyAntError> {
+        self.cas(key, move |entry| {
+            let (current, expires_at_ms) = parse_string_as_f64(entry, key)?;
+            let new_val = current + delta;
+            if new_val.is_nan() || new_val.is_infinite() {
+                return Err(RustyAntError::Parse("increment would produce NaN or infinity".into()));
+            }
+            let rendered = format_float(new_val).into_bytes();
+            let new_entry = StoredValue { expires_at_ms, value: Value::String(rendered) };
+            Ok(CasAction::Write(new_entry, new_val))
+        })
+        .await
+    }
+
+    async fn getrange(&self, key: &str, start: i64, end: i64) -> Result<Bytes, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::String(d), .. }) => Ok(Bytes::from(slice_string_range(&d, start, end))),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(Bytes::new()),
+        }
+    }
+
+    async fn setrange(&self, key: &str, offset: usize, value: Bytes) -> Result<i64, RustyAntError> {
+        self.cas(key, move |entry| {
+            let (mut data, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::String(d), expires_at_ms }) => (d.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => (Vec::new(), None),
+            };
+            // SETRANGE with empty value on missing key is a no-op — Redis
+            // does not create the key in that corner case.
+            if value.is_empty() && data.is_empty() {
+                return Ok(CasAction::NoOp(0));
+            }
+            apply_setrange(&mut data, offset, &value);
+            let len = i64::try_from(data.len()).unwrap_or(i64::MAX);
+            let new_entry = StoredValue { expires_at_ms, value: Value::String(data) };
+            Ok(CasAction::Write(new_entry, len))
+        })
+        .await
+    }
+
+    async fn msetnx(&self, pairs: Vec<(String, Bytes)>) -> Result<bool, RustyAntError> {
+        // Best-effort atomicity — scan first, abort if any key exists, then
+        // sequentially write. A concurrent setter landing between the scan
+        // and the writes can leak past the NX guard; Redis's all-or-nothing
+        // version is expensive to emulate over S3 and unused in practice.
+        for (k, _) in &pairs {
+            if self.load(k).await?.is_some() {
+                return Ok(false);
+            }
+        }
+        for (k, v) in pairs {
+            self.set_string(&k, v, None).await?;
+        }
+        Ok(true)
+    }
+
     async fn persist(&self, key: &str) -> Result<bool, RustyAntError> {
         self.cas(key, move |entry| match entry {
             Some(existing) if existing.expires_at_ms.is_some() => {
@@ -1412,6 +1649,116 @@ impl Storage for S3Storage {
             Ok(CasAction::Write(new_entry, new_score))
         })
         .await
+    }
+
+    async fn zrevrange(&self, key: &str, start: i64, stop: i64) -> Result<Vec<String>, RustyAntError> {
+        let map = match self.load(key).await? {
+            Some(StoredValue { value: Value::ZSet(m), .. }) => m,
+            Some(_) => return Err(wrong_type(key)),
+            None => return Ok(Vec::new()),
+        };
+        Ok(slice_zset_reversed(map, start, stop))
+    }
+
+    async fn zrevrangebyscore(
+        &self,
+        key: &str,
+        max: ScoreBound,
+        min: ScoreBound,
+    ) -> Result<Vec<String>, RustyAntError> {
+        let map = match self.load(key).await? {
+            Some(StoredValue { value: Value::ZSet(m), .. }) => m,
+            Some(_) => return Err(wrong_type(key)),
+            None => return Ok(Vec::new()),
+        };
+        let mut members = filter_zset_by_score(map, min, max);
+        members.reverse();
+        Ok(members)
+    }
+
+    async fn zremrangebyrank(&self, key: &str, start: i64, stop: i64) -> Result<i64, RustyAntError> {
+        self.cas(key, move |entry| {
+            let (map, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::ZSet(m), expires_at_ms }) => (m.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => return Ok(CasAction::NoOp(0)),
+            };
+            let (kept, removed) = partition_zset_by_rank(map, start, stop);
+            let removed_i = i64::try_from(removed).unwrap_or(i64::MAX);
+            if kept.is_empty() {
+                Ok(CasAction::Delete(removed_i))
+            } else {
+                let new_entry = StoredValue { expires_at_ms, value: Value::ZSet(kept) };
+                Ok(CasAction::Write(new_entry, removed_i))
+            }
+        })
+        .await
+    }
+
+    async fn zremrangebyscore(&self, key: &str, min: ScoreBound, max: ScoreBound) -> Result<i64, RustyAntError> {
+        self.cas(key, move |entry| {
+            let (map, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::ZSet(m), expires_at_ms }) => (m.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => return Ok(CasAction::NoOp(0)),
+            };
+            let (kept, removed) = partition_zset_by_score(map, min, max);
+            let removed_i = i64::try_from(removed).unwrap_or(i64::MAX);
+            if kept.is_empty() {
+                Ok(CasAction::Delete(removed_i))
+            } else {
+                let new_entry = StoredValue { expires_at_ms, value: Value::ZSet(kept) };
+                Ok(CasAction::Write(new_entry, removed_i))
+            }
+        })
+        .await
+    }
+
+    async fn zpopmin(&self, key: &str, count: usize) -> Result<Vec<(String, f64)>, RustyAntError> {
+        self.zpop_impl(key, count, false).await
+    }
+
+    async fn zpopmax(&self, key: &str, count: usize) -> Result<Vec<(String, f64)>, RustyAntError> {
+        self.zpop_impl(key, count, true).await
+    }
+
+    async fn rename(&self, from: &str, to: &str) -> Result<(), RustyAntError> {
+        let Some(entry) = self.load(from).await? else {
+            return Err(RustyAntError::Parse("no such key".into()));
+        };
+        if from == to {
+            return Ok(());
+        }
+        // Match the destination's current etag (if present) to avoid stomping
+        // on a concurrent writer; create-only otherwise. Two-object ops aren't
+        // atomic over S3, but either half can still fail safely.
+        let cond =
+            self.load_with_etag(to).await?.map_or(CasCondition::CreateOnly, |(_, etag)| CasCondition::IfMatch(etag));
+        self.save_cas(to, &entry, cond).await?;
+        self.delete_raw(from).await?;
+        Ok(())
+    }
+
+    async fn renamenx(&self, from: &str, to: &str) -> Result<bool, RustyAntError> {
+        let Some(entry) = self.load(from).await? else {
+            return Err(RustyAntError::Parse("no such key".into()));
+        };
+        if from == to {
+            return Ok(false);
+        }
+        if self.load(to).await?.is_some() {
+            return Ok(false);
+        }
+        // CreateOnly guards against a racing writer populating the destination
+        // between the existence check and this write.
+        match self.save_cas(to, &entry, CasCondition::CreateOnly).await {
+            Ok(()) => {
+                self.delete_raw(from).await?;
+                Ok(true)
+            }
+            Err(RustyAntError::Contention) => Ok(false),
+            Err(e) => Err(e),
+        }
     }
 }
 
@@ -1918,6 +2265,65 @@ impl Storage for InMemoryStorage {
         Ok(len)
     }
 
+    async fn incr_by_float(&self, key: &str, delta: f64) -> Result<f64, RustyAntError> {
+        let loaded = self.load(key);
+        let (current, expires_at_ms) = parse_string_as_f64(loaded.as_ref(), key)?;
+        let new_val = current + delta;
+        if new_val.is_nan() || new_val.is_infinite() {
+            return Err(RustyAntError::Parse("increment would produce NaN or infinity".into()));
+        }
+        let rendered = format_float(new_val).into_bytes();
+        let entry = StoredValue { expires_at_ms, value: Value::String(rendered) };
+        self.with_entry_mut(|store| {
+            store.insert(key.to_string(), entry);
+        });
+        Ok(new_val)
+    }
+
+    async fn getrange(&self, key: &str, start: i64, end: i64) -> Result<Bytes, RustyAntError> {
+        match self.load(key) {
+            Some(StoredValue { value: Value::String(d), .. }) => Ok(Bytes::from(slice_string_range(&d, start, end))),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(Bytes::new()),
+        }
+    }
+
+    async fn setrange(&self, key: &str, offset: usize, value: Bytes) -> Result<i64, RustyAntError> {
+        let (mut data, expires_at_ms) = match self.load(key) {
+            Some(StoredValue { value: Value::String(d), expires_at_ms }) => (d, expires_at_ms),
+            Some(_) => return Err(wrong_type(key)),
+            None => (Vec::new(), None),
+        };
+        if value.is_empty() && data.is_empty() {
+            return Ok(0);
+        }
+        apply_setrange(&mut data, offset, &value);
+        let len = i64::try_from(data.len()).unwrap_or(i64::MAX);
+        let entry = StoredValue { expires_at_ms, value: Value::String(data) };
+        self.with_entry_mut(|store| {
+            store.insert(key.to_string(), entry);
+        });
+        Ok(len)
+    }
+
+    async fn msetnx(&self, pairs: Vec<(String, Bytes)>) -> Result<bool, RustyAntError> {
+        // Single-lock check-and-set so the `NX` guard is genuinely atomic here,
+        // unlike the S3 backend which can only approximate it.
+        Ok(self.with_entry_mut(|map| {
+            for (k, _) in &pairs {
+                if let Some(v) = map.get(k) {
+                    if !is_expired(v) {
+                        return false;
+                    }
+                }
+            }
+            for (k, v) in pairs {
+                map.insert(k, StoredValue { expires_at_ms: None, value: Value::String(v.to_vec()) });
+            }
+            true
+        }))
+    }
+
     async fn persist(&self, key: &str) -> Result<bool, RustyAntError> {
         // Evict expired keys first so we don't "persist" a zombie.
         if self.load(key).is_none() {
@@ -1934,6 +2340,37 @@ impl Storage for InMemoryStorage {
                 false
             }
         }))
+    }
+
+    async fn rename(&self, from: &str, to: &str) -> Result<(), RustyAntError> {
+        let Some(entry) = self.load(from) else {
+            return Err(RustyAntError::Parse("no such key".into()));
+        };
+        if from == to {
+            return Ok(());
+        }
+        self.with_entry_mut(|map| {
+            map.remove(from);
+            map.insert(to.to_string(), entry);
+        });
+        Ok(())
+    }
+
+    async fn renamenx(&self, from: &str, to: &str) -> Result<bool, RustyAntError> {
+        let Some(entry) = self.load(from) else {
+            return Err(RustyAntError::Parse("no such key".into()));
+        };
+        if from == to {
+            return Ok(false);
+        }
+        if self.load(to).is_some() {
+            return Ok(false);
+        }
+        self.with_entry_mut(|map| {
+            map.remove(from);
+            map.insert(to.to_string(), entry);
+        });
+        Ok(true)
     }
 
     async fn lindex(&self, key: &str, index: i64) -> Result<Option<Bytes>, RustyAntError> {
@@ -2256,6 +2693,106 @@ impl Storage for InMemoryStorage {
             store.insert(key.to_string(), entry);
         });
         Ok(new_score)
+    }
+
+    async fn zrevrange(&self, key: &str, start: i64, stop: i64) -> Result<Vec<String>, RustyAntError> {
+        let map = match self.load(key) {
+            Some(StoredValue { value: Value::ZSet(m), .. }) => m,
+            Some(_) => return Err(wrong_type(key)),
+            None => return Ok(Vec::new()),
+        };
+        Ok(slice_zset_reversed(map, start, stop))
+    }
+
+    async fn zrevrangebyscore(
+        &self,
+        key: &str,
+        max: ScoreBound,
+        min: ScoreBound,
+    ) -> Result<Vec<String>, RustyAntError> {
+        let map = match self.load(key) {
+            Some(StoredValue { value: Value::ZSet(m), .. }) => m,
+            Some(_) => return Err(wrong_type(key)),
+            None => return Ok(Vec::new()),
+        };
+        let mut members = filter_zset_by_score(map, min, max);
+        members.reverse();
+        Ok(members)
+    }
+
+    async fn zremrangebyrank(&self, key: &str, start: i64, stop: i64) -> Result<i64, RustyAntError> {
+        let (map, expires_at_ms) = match self.load(key) {
+            Some(StoredValue { value: Value::ZSet(m), expires_at_ms }) => (m, expires_at_ms),
+            Some(_) => return Err(wrong_type(key)),
+            None => return Ok(0),
+        };
+        let (kept, removed) = partition_zset_by_rank(map, start, stop);
+        let removed_i = i64::try_from(removed).unwrap_or(i64::MAX);
+        if kept.is_empty() {
+            self.with_entry_mut(|store| {
+                store.remove(key);
+            });
+        } else {
+            let entry = StoredValue { expires_at_ms, value: Value::ZSet(kept) };
+            self.with_entry_mut(|store| {
+                store.insert(key.to_string(), entry);
+            });
+        }
+        Ok(removed_i)
+    }
+
+    async fn zremrangebyscore(&self, key: &str, min: ScoreBound, max: ScoreBound) -> Result<i64, RustyAntError> {
+        let (map, expires_at_ms) = match self.load(key) {
+            Some(StoredValue { value: Value::ZSet(m), expires_at_ms }) => (m, expires_at_ms),
+            Some(_) => return Err(wrong_type(key)),
+            None => return Ok(0),
+        };
+        let (kept, removed) = partition_zset_by_score(map, min, max);
+        let removed_i = i64::try_from(removed).unwrap_or(i64::MAX);
+        if kept.is_empty() {
+            self.with_entry_mut(|store| {
+                store.remove(key);
+            });
+        } else {
+            let entry = StoredValue { expires_at_ms, value: Value::ZSet(kept) };
+            self.with_entry_mut(|store| {
+                store.insert(key.to_string(), entry);
+            });
+        }
+        Ok(removed_i)
+    }
+
+    async fn zpopmin(&self, key: &str, count: usize) -> Result<Vec<(String, f64)>, RustyAntError> {
+        self.zpop_inmem(key, count, false)
+    }
+
+    async fn zpopmax(&self, key: &str, count: usize) -> Result<Vec<(String, f64)>, RustyAntError> {
+        self.zpop_inmem(key, count, true)
+    }
+}
+
+impl InMemoryStorage {
+    fn zpop_inmem(&self, key: &str, count: usize, from_max: bool) -> Result<Vec<(String, f64)>, RustyAntError> {
+        let (map, expires_at_ms) = match self.load(key) {
+            Some(StoredValue { value: Value::ZSet(m), expires_at_ms }) => (m, expires_at_ms),
+            Some(_) => return Err(wrong_type(key)),
+            None => return Ok(Vec::new()),
+        };
+        if count == 0 {
+            return Ok(Vec::new());
+        }
+        let (kept, popped) = pop_zset_edge(map, count, from_max);
+        if kept.is_empty() {
+            self.with_entry_mut(|store| {
+                store.remove(key);
+            });
+        } else {
+            let entry = StoredValue { expires_at_ms, value: Value::ZSet(kept) };
+            self.with_entry_mut(|store| {
+                store.insert(key.to_string(), entry);
+            });
+        }
+        Ok(popped)
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1496,6 +1496,300 @@ async fn srandmember_on_wrong_type_errors() {
     call(&state, &[b"SRANDMEMBER", b"k"]).await.expect_error_prefix("ERR");
 }
 
+// ---------------------------------------------------------------------------
+// PEXPIRE / PTTL / RENAME / RENAMENX
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn pexpire_sets_millisecond_ttl() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"PEXPIRE", b"k", b"60000"]).await.expect_integer(1);
+    let reply = call(&state, &[b"PTTL", b"k"]).await;
+    // 60 seconds in ms ≈ 60000; allow some drift below for test latency.
+    let pttl_raw = String::from_utf8_lossy(&reply.raw).into_owned();
+    let ms: i64 = pttl_raw.trim_start_matches(':').trim_end().parse().expect("pttl");
+    assert!((0..=60_000).contains(&ms), "pttl out of band: {ms}");
+}
+
+#[tokio::test]
+async fn pexpire_missing_key_returns_zero() {
+    let state = test_state();
+    call(&state, &[b"PEXPIRE", b"missing", b"1000"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn pttl_returns_minus_two_for_missing_key() {
+    let state = test_state();
+    call(&state, &[b"PTTL", b"missing"]).await.expect_integer(-2);
+}
+
+#[tokio::test]
+async fn pttl_returns_minus_one_without_expiry() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"PTTL", b"k"]).await.expect_integer(-1);
+}
+
+#[tokio::test]
+async fn rename_moves_value_and_deletes_source() {
+    let state = test_state();
+    call(&state, &[b"SET", b"a", b"v"]).await;
+    call(&state, &[b"RENAME", b"a", b"b"]).await.expect_simple("OK");
+    call(&state, &[b"EXISTS", b"a"]).await.expect_integer(0);
+    call(&state, &[b"GET", b"b"]).await.expect_bulk(b"v");
+}
+
+#[tokio::test]
+async fn rename_overwrites_destination() {
+    let state = test_state();
+    call(&state, &[b"SET", b"a", b"new"]).await;
+    call(&state, &[b"SET", b"b", b"old"]).await;
+    call(&state, &[b"RENAME", b"a", b"b"]).await.expect_simple("OK");
+    call(&state, &[b"GET", b"b"]).await.expect_bulk(b"new");
+    call(&state, &[b"EXISTS", b"a"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn rename_missing_source_errors() {
+    let state = test_state();
+    call(&state, &[b"RENAME", b"missing", b"b"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn rename_to_self_is_noop() {
+    let state = test_state();
+    call(&state, &[b"SET", b"a", b"v"]).await;
+    call(&state, &[b"RENAME", b"a", b"a"]).await.expect_simple("OK");
+    call(&state, &[b"GET", b"a"]).await.expect_bulk(b"v");
+}
+
+#[tokio::test]
+async fn renamenx_moves_when_dest_absent() {
+    let state = test_state();
+    call(&state, &[b"SET", b"a", b"v"]).await;
+    call(&state, &[b"RENAMENX", b"a", b"b"]).await.expect_integer(1);
+    call(&state, &[b"GET", b"b"]).await.expect_bulk(b"v");
+}
+
+#[tokio::test]
+async fn renamenx_refuses_when_dest_present() {
+    let state = test_state();
+    call(&state, &[b"SET", b"a", b"v1"]).await;
+    call(&state, &[b"SET", b"b", b"v2"]).await;
+    call(&state, &[b"RENAMENX", b"a", b"b"]).await.expect_integer(0);
+    call(&state, &[b"GET", b"a"]).await.expect_bulk(b"v1");
+    call(&state, &[b"GET", b"b"]).await.expect_bulk(b"v2");
+}
+
+#[tokio::test]
+async fn renamenx_missing_source_errors() {
+    let state = test_state();
+    call(&state, &[b"RENAMENX", b"missing", b"b"]).await.expect_error_prefix("ERR");
+}
+
+// ---------------------------------------------------------------------------
+// INCRBYFLOAT / GETRANGE / SETRANGE / MSETNX
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn incrbyfloat_creates_from_zero() {
+    let state = test_state();
+    call(&state, &[b"INCRBYFLOAT", b"k", b"3.14"]).await.expect_bulk(b"3.14");
+    call(&state, &[b"INCRBYFLOAT", b"k", b"0.86"]).await.expect_bulk(b"4");
+    call(&state, &[b"GET", b"k"]).await.expect_bulk(b"4");
+}
+
+#[tokio::test]
+async fn incrbyfloat_on_non_numeric_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"abc"]).await;
+    call(&state, &[b"INCRBYFLOAT", b"k", b"1.0"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn incrbyfloat_preserves_ttl() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"1", b"EX", b"60"]).await;
+    call(&state, &[b"INCRBYFLOAT", b"k", b"0.5"]).await.expect_bulk(b"1.5");
+    let reply = call(&state, &[b"TTL", b"k"]).await;
+    let raw = String::from_utf8_lossy(&reply.raw).into_owned();
+    let ttl: i64 = raw.trim_start_matches(':').trim_end().parse().expect("ttl");
+    assert!(ttl > 0, "ttl should be preserved, got {ttl}");
+}
+
+#[tokio::test]
+async fn getrange_basic_and_negative_indices() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"Hello World"]).await;
+    call(&state, &[b"GETRANGE", b"k", b"0", b"4"]).await.expect_bulk(b"Hello");
+    call(&state, &[b"GETRANGE", b"k", b"6", b"10"]).await.expect_bulk(b"World");
+    call(&state, &[b"GETRANGE", b"k", b"-5", b"-1"]).await.expect_bulk(b"World");
+    call(&state, &[b"GETRANGE", b"k", b"0", b"-1"]).await.expect_bulk(b"Hello World");
+}
+
+#[tokio::test]
+async fn getrange_out_of_bounds_returns_empty() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"abc"]).await;
+    call(&state, &[b"GETRANGE", b"k", b"10", b"20"]).await.expect_bulk(b"");
+    call(&state, &[b"GETRANGE", b"missing", b"0", b"5"]).await.expect_bulk(b"");
+}
+
+#[tokio::test]
+async fn setrange_pads_and_overwrites() {
+    let state = test_state();
+    call(&state, &[b"SETRANGE", b"k", b"5", b"Hello"]).await.expect_integer(10);
+    call(&state, &[b"GET", b"k"]).await.expect_bulk(b"\0\0\0\0\0Hello");
+    call(&state, &[b"SETRANGE", b"k", b"0", b"World"]).await.expect_integer(10);
+    // Overwriting the leading NULs with "World" leaves "WorldHello" — no
+    // padding between the new prefix and the old trailing "Hello".
+    call(&state, &[b"GET", b"k"]).await.expect_bulk(b"WorldHello");
+}
+
+#[tokio::test]
+async fn setrange_empty_value_on_missing_is_noop() {
+    let state = test_state();
+    call(&state, &[b"SETRANGE", b"missing", b"0", b""]).await.expect_integer(0);
+    call(&state, &[b"EXISTS", b"missing"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn setrange_on_wrong_type_errors() {
+    let state = test_state();
+    call(&state, &[b"LPUSH", b"l", b"x"]).await;
+    call(&state, &[b"SETRANGE", b"l", b"0", b"v"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn msetnx_all_or_nothing() {
+    let state = test_state();
+    call(&state, &[b"MSETNX", b"a", b"1", b"b", b"2"]).await.expect_integer(1);
+    call(&state, &[b"GET", b"a"]).await.expect_bulk(b"1");
+    call(&state, &[b"GET", b"b"]).await.expect_bulk(b"2");
+    // One existing key → entire MSETNX fails.
+    call(&state, &[b"MSETNX", b"c", b"3", b"b", b"4"]).await.expect_integer(0);
+    call(&state, &[b"EXISTS", b"c"]).await.expect_integer(0);
+    call(&state, &[b"GET", b"b"]).await.expect_bulk(b"2");
+}
+
+// ---------------------------------------------------------------------------
+// ZREVRANGE / ZREVRANGEBYSCORE / ZREMRANGEBYRANK / ZREMRANGEBYSCORE / ZPOP*
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn zrevrange_returns_descending_slice() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"a", b"2", b"b", b"3", b"c", b"4", b"d"]).await;
+    let m = call(&state, &[b"ZREVRANGE", b"z", b"0", b"1"]).await.into_bulk_array();
+    assert_eq!(m.len(), 2);
+    assert_eq!(m[0].as_ref(), b"d");
+    assert_eq!(m[1].as_ref(), b"c");
+    let full = call(&state, &[b"ZREVRANGE", b"z", b"0", b"-1"]).await.into_bulk_array();
+    let names: Vec<&[u8]> = full.iter().map(AsRef::as_ref).collect();
+    assert_eq!(names, vec![&b"d"[..], &b"c"[..], &b"b"[..], &b"a"[..]]);
+}
+
+#[tokio::test]
+async fn zrevrangebyscore_descending_arg_order() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"a", b"2", b"b", b"3", b"c"]).await;
+    // Redis semantics: max before min.
+    let m = call(&state, &[b"ZREVRANGEBYSCORE", b"z", b"3", b"1"]).await.into_bulk_array();
+    assert_eq!(m.len(), 3);
+    assert_eq!(m[0].as_ref(), b"c");
+    assert_eq!(m[2].as_ref(), b"a");
+    let m = call(&state, &[b"ZREVRANGEBYSCORE", b"z", b"(3", b"1"]).await.into_bulk_array();
+    assert_eq!(m.len(), 2);
+    assert_eq!(m[0].as_ref(), b"b");
+}
+
+#[tokio::test]
+async fn zremrangebyrank_removes_inclusive_window() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"a", b"2", b"b", b"3", b"c", b"4", b"d"]).await;
+    call(&state, &[b"ZREMRANGEBYRANK", b"z", b"0", b"1"]).await.expect_integer(2);
+    let remaining = call(&state, &[b"ZRANGE", b"z", b"0", b"-1"]).await.into_bulk_array();
+    assert_eq!(remaining.len(), 2);
+    assert_eq!(remaining[0].as_ref(), b"c");
+    assert_eq!(remaining[1].as_ref(), b"d");
+}
+
+#[tokio::test]
+async fn zremrangebyrank_empties_and_deletes_key() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"a", b"2", b"b"]).await;
+    call(&state, &[b"ZREMRANGEBYRANK", b"z", b"0", b"-1"]).await.expect_integer(2);
+    call(&state, &[b"EXISTS", b"z"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn zremrangebyscore_removes_by_score_range() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"a", b"2", b"b", b"3", b"c", b"4", b"d"]).await;
+    call(&state, &[b"ZREMRANGEBYSCORE", b"z", b"(1", b"3"]).await.expect_integer(2);
+    let remaining = call(&state, &[b"ZRANGE", b"z", b"0", b"-1"]).await.into_bulk_array();
+    let names: Vec<&[u8]> = remaining.iter().map(AsRef::as_ref).collect();
+    assert_eq!(names, vec![&b"a"[..], &b"d"[..]]);
+}
+
+#[tokio::test]
+async fn zpopmin_returns_lowest_score_with_score() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"a", b"2", b"b", b"3", b"c"]).await;
+    let r = call(&state, &[b"ZPOPMIN", b"z"]).await.into_bulk_array();
+    assert_eq!(r.len(), 2);
+    assert_eq!(r[0].as_ref(), b"a");
+    assert_eq!(r[1].as_ref(), b"1");
+    call(&state, &[b"ZCARD", b"z"]).await.expect_integer(2);
+}
+
+#[tokio::test]
+async fn zpopmax_returns_highest_score_with_score() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"a", b"2", b"b", b"3", b"c"]).await;
+    let r = call(&state, &[b"ZPOPMAX", b"z"]).await.into_bulk_array();
+    assert_eq!(r.len(), 2);
+    assert_eq!(r[0].as_ref(), b"c");
+    assert_eq!(r[1].as_ref(), b"3");
+}
+
+#[tokio::test]
+async fn zpop_count_flattens_pairs() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"a", b"2", b"b", b"3", b"c"]).await;
+    let r = call(&state, &[b"ZPOPMIN", b"z", b"2"]).await.into_bulk_array();
+    // Flat RESP array: member, score, member, score.
+    assert_eq!(r.len(), 4);
+    assert_eq!(r[0].as_ref(), b"a");
+    assert_eq!(r[1].as_ref(), b"1");
+    assert_eq!(r[2].as_ref(), b"b");
+    assert_eq!(r[3].as_ref(), b"2");
+}
+
+#[tokio::test]
+async fn zpop_empties_and_deletes_key() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"a"]).await;
+    call(&state, &[b"ZPOPMIN", b"z"]).await;
+    call(&state, &[b"EXISTS", b"z"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn zpop_missing_key_returns_empty_array() {
+    let state = test_state();
+    let r = call(&state, &[b"ZPOPMIN", b"missing"]).await.into_bulk_array();
+    assert!(r.is_empty());
+}
+
+#[tokio::test]
+async fn zpop_on_wrong_type_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"ZPOPMIN", b"k"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"ZPOPMAX", b"k"]).await.expect_error_prefix("ERR");
+}
+
 // Use RespReply publicly to check the crate re-export surface compiles.
 #[test]
 fn reply_encode_simple_works_from_tests() {


### PR DESCRIPTION
## Summary

- **Keyspace (+4):** `PEXPIRE`, `PTTL`, `RENAME`, `RENAMENX`
- **Strings (+4):** `INCRBYFLOAT`, `GETRANGE`, `SETRANGE`, `MSETNX`
- **Sorted Sets (+6):** `ZREVRANGE`, `ZREVRANGEBYSCORE`, `ZREMRANGEBYRANK`, `ZREMRANGEBYSCORE`, `ZPOPMIN` (+ count), `ZPOPMAX` (+ count)

Storage trait gains matching methods on both backends. Shared zset sort / range / partition helpers sit next to the existing zset helpers; `SETRANGE` and `INCRBYFLOAT` get their own string-level helpers (`apply_setrange`, `slice_string_range`, `parse_string_as_f64`, `format_float`).

`RENAME` / `RENAMENX` / `MSETNX` are fully atomic on the in-memory backend (single mutex critical section) but best-effort on S3 — the README now documents where the `NX` guard can leak under concurrent writers, and `RENAMENX` uses `If-None-Match: *` on the destination to narrow that window.

`ZREVRANGEBYSCORE` keeps Redis's reversed arg order (max before min). `ZPOPMIN` / `ZPOPMAX` flatten `(member, score)` pairs into the wire-format RESP array Redis returns (`member, score, member, score, ...`).

## Test plan

- [x] `just check` — fmt + clippy clean (required `#[allow(clippy::too_many_lines)]` on the dispatch `run()` function as the command table keeps growing)
- [x] `just test` — 218/218 passing (18 lib + 176 HTTP integration + 11 redis-py + 6 WS + 7 floci)
- [x] Integration suite grew by 31 tests covering: millisecond-TTL round-trips, source/dest combinations for `RENAME`/`RENAMENX`, zero-padding behavior of `SETRANGE`, negative-index `GETRANGE`, all-or-nothing `MSETNX`, descending ranges and flat-pair encoding for the zset additions, empty-collection key cleanup for `ZREMRANGE*` and `ZPOP*`.