### PR TITLE
:sparkles: add server housekeeping + RANDOMKEY/UNLINK/COPY

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ Cargo.lock.bak
 .DS_Store
 Thumbs.db
 
+# Local agent overrides
+CLAUDE.md
+CLAUDE.local.md
+
 # Env / secrets
 .env
 .env.*

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Implemented:
 
 | Group | Commands |
 |---|---|
-| Server | `PING` |
-| Keyspace | `KEYS`, `SCAN` (+ `MATCH` / `COUNT` options), `TYPE`, `RENAME`, `RENAMENX` |
+| Server | `PING`, `ECHO`, `TIME`, `DBSIZE`, `FLUSHDB`, `FLUSHALL` |
+| Keyspace | `KEYS`, `SCAN` (+ `MATCH` / `COUNT` options), `TYPE`, `RENAME`, `RENAMENX`, `RANDOMKEY`, `UNLINK`, `COPY` (+ `REPLACE` / `DB 0`) |
 | Strings | `GET`, `SET` (+ `EX` / `PX` options), `GETSET`, `GETDEL`, `GETRANGE`, `SETRANGE`, `SETNX`, `SETEX`, `MGET`, `MSET`, `MSETNX`, `APPEND`, `STRLEN`, `DEL`, `EXISTS`, `EXPIRE`, `EXPIREAT`, `PEXPIRE`, `PEXPIREAT`, `PERSIST`, `TTL`, `PTTL`, `INCR`, `INCRBY`, `INCRBYFLOAT`, `DECR`, `DECRBY` |
 | Hashes | `HSET`, `HSETNX`, `HGET`, `HDEL`, `HGETALL`, `HLEN`, `HKEYS`, `HVALS`, `HEXISTS`, `HSTRLEN`, `HMGET`, `HINCRBY` |
 | Lists | `LPUSH`, `RPUSH`, `LPUSHX`, `RPUSHX`, `LPOP` (+ count), `RPOP` (+ count), `LRANGE`, `LLEN`, `LINDEX`, `LSET`, `LREM`, `LINSERT`, `LTRIM` |
@@ -67,9 +67,11 @@ Implemented:
 
 `KEYS` paginates through `ListObjectsV2` in full and filters by the wildmatch pattern — O(n) over the keyspace, safe at low cardinality, proportionally slower for larger buckets. `SCAN` delegates the page boundary to S3 via a continuation token, returning one `ListObjectsV2` page per call; `MATCH` is applied client-side, so the per-page yield may be smaller than `COUNT` when a pattern is narrow.
 
+`DBSIZE` and `RANDOMKEY` walk the same `ListObjectsV2` pagination: O(n) on the S3 backend, instant on the in-memory backend. Recently-expired keys that haven't been GC'd yet still count toward `DBSIZE`, matching Redis's lazy-expiry semantics. `FLUSHDB` and `FLUSHALL` are aliases here — rustyant exposes one logical namespace — and batch-delete a page (up to 1000 objects) per `DeleteObjects` call. The optional `ASYNC` / `SYNC` modifier is accepted but ignored: the flush is always synchronous over S3. `UNLINK` shares the synchronous `DEL` path; rustyant has no background freer thread.
+
 Not implemented (PRs welcome): pub/sub, transactions, scripting, streams, geo.
 
-`MSET` is **not atomic across keys** — a failure partway through leaves earlier keys set. Real Redis is atomic here; rustyant's S3 backing makes the all-or-none semantic expensive, and the fire-and-forget variant is fine for most workloads. `MSETNX` and `RENAME` / `RENAMENX` are similarly best-effort on the S3 backend: the in-memory path is fully atomic under its `Mutex`, but on S3 a concurrent writer landing between the existence check and the write can leak past the `NX` guard. `RENAMENX` uses `If-None-Match: *` on the destination to shrink that window, so the failure mode is "rename reports 0 / error" rather than data loss.
+`MSET` is **not atomic across keys** — a failure partway through leaves earlier keys set. Real Redis is atomic here; rustyant's S3 backing makes the all-or-none semantic expensive, and the fire-and-forget variant is fine for most workloads. `MSETNX`, `RENAME` / `RENAMENX`, and `COPY` are similarly best-effort on the S3 backend: the in-memory path is fully atomic under its `Mutex`, but on S3 a concurrent writer landing between the existence check and the write can leak past the `NX` guard. `RENAMENX` and `COPY` (without `REPLACE`) use `If-None-Match: *` on the destination to shrink that window, so the failure mode is "operation reports 0 / error" rather than data loss.
 
 ### Concurrency
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use bytes::Bytes;
 use tracing::info;
@@ -98,6 +98,15 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
 
     match cmd.as_str() {
         "PING" => Ok(RespReply::SimpleString("PONG".into())),
+        "ECHO" => handle_echo(&args),
+        "TIME" => handle_time(&args),
+        "DBSIZE" => handle_dbsize(state, args).await,
+        "FLUSHDB" | "FLUSHALL" => handle_flushall(state, args, &cmd).await,
+        "RANDOMKEY" => handle_randomkey(state, args).await,
+        // UNLINK is Redis's lazy-delete variant; rustyant has no background
+        // freer thread, so it folds into the same synchronous DEL path.
+        "DEL" | "UNLINK" => handle_del(state, args).await,
+        "COPY" => handle_copy(state, args).await,
         // Strings
         "GET" => handle_get(state, args).await,
         "GETSET" => handle_getset(state, args).await,
@@ -112,7 +121,6 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "MGET" => handle_mget(state, args).await,
         "MSET" => handle_mset(state, args).await,
         "MSETNX" => handle_msetnx(state, args).await,
-        "DEL" => handle_del(state, args).await,
         "EXISTS" => handle_exists(state, args).await,
         "EXPIRE" => handle_expire(state, args).await,
         "EXPIREAT" => handle_expireat(state, args).await,
@@ -1062,4 +1070,84 @@ async fn handle_zpop(state: &State, args: Vec<Bytes>, from_max: bool) -> Result<
         flat.push(RespReply::BulkString(Some(Bytes::from(format_score(s).into_bytes()))));
     }
     Ok(RespReply::Array(flat))
+}
+
+// ---- Server / keyspace housekeeping ---------------------------------------
+
+fn handle_echo(args: &[Bytes]) -> Result<RespReply, RustyAntError> {
+    arity("ECHO", args.len() == 1)?;
+    Ok(RespReply::BulkString(Some(args[0].clone())))
+}
+
+fn handle_time(args: &[Bytes]) -> Result<RespReply, RustyAntError> {
+    arity("TIME", args.is_empty())?;
+    let dur = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default();
+    let secs = dur.as_secs().to_string();
+    let micros = dur.subsec_micros().to_string();
+    Ok(RespReply::Array(vec![
+        RespReply::BulkString(Some(Bytes::from(secs.into_bytes()))),
+        RespReply::BulkString(Some(Bytes::from(micros.into_bytes()))),
+    ]))
+}
+
+async fn handle_dbsize(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("DBSIZE", args.is_empty())?;
+    let n = state.storage.dbsize().await?;
+    Ok(RespReply::Integer(n))
+}
+
+async fn handle_flushall(state: &State, args: Vec<Bytes>, cmd: &str) -> Result<RespReply, RustyAntError> {
+    // Accept the optional ASYNC / SYNC modifier (Redis 4+) but ignore it —
+    // rustyant's flush is always synchronous over S3.
+    if args.len() > 1 {
+        return Err(RustyAntError::WrongArity { command: cmd.to_string() });
+    }
+    if let Some(mode) = args.first() {
+        match arg_as_str(mode)?.to_ascii_uppercase().as_str() {
+            "ASYNC" | "SYNC" => {}
+            other => return Err(RustyAntError::Parse(format!("unsupported {cmd} option: {other}"))),
+        }
+    }
+    state.storage.flushall().await?;
+    Ok(RespReply::ok())
+}
+
+async fn handle_randomkey(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("RANDOMKEY", args.is_empty())?;
+    Ok(state
+        .storage
+        .random_key()
+        .await?
+        .map_or(RespReply::Nil, |k| RespReply::BulkString(Some(Bytes::from(k.into_bytes())))))
+}
+
+async fn handle_copy(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    if args.len() < 2 {
+        return Err(RustyAntError::WrongArity { command: "COPY".into() });
+    }
+    let from = arg_as_str(&args[0])?;
+    let to = arg_as_str(&args[1])?;
+    let mut replace = false;
+    let mut i = 2;
+    while i < args.len() {
+        let opt = arg_as_str(&args[i])?.to_ascii_uppercase();
+        match opt.as_str() {
+            "REPLACE" => {
+                replace = true;
+                i += 1;
+            }
+            "DB" => {
+                // Single-DB rustyant — only DB 0 is acceptable.
+                let v = args.get(i + 1).ok_or_else(|| RustyAntError::Parse("DB requires a value".into()))?;
+                let db = parse_i64(v, "DB")?;
+                if db != 0 {
+                    return Err(RustyAntError::Parse("DB must be 0 — rustyant exposes a single namespace".into()));
+                }
+                i += 2;
+            }
+            other => return Err(RustyAntError::Parse(format!("unsupported COPY option: {other}"))),
+        }
+    }
+    let copied = state.storage.copy(from, to, replace).await?;
+    Ok(RespReply::Integer(i64::from(copied)))
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -589,6 +589,27 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
         pattern: Option<&str>,
         count: usize,
     ) -> Result<(Vec<String>, Option<String>), RustyAntError>;
+
+    /// Total live key count. On S3 this is a full `ListObjectsV2` walk
+    /// (proportional to keyspace size); recently-expired keys that have
+    /// not yet been GC'd are still counted, matching Redis's lazy-expiry
+    /// behavior.
+    async fn dbsize(&self) -> Result<i64, RustyAntError>;
+
+    /// Wipe every key in the namespace. Drives both `FLUSHDB` and `FLUSHALL`
+    /// — rustyant has only one logical database, so the two commands collapse
+    /// to the same operation.
+    async fn flushall(&self) -> Result<(), RustyAntError>;
+
+    /// Pick one key uniformly at random from the live keyspace, or `None`
+    /// when the namespace is empty. Backs `RANDOMKEY`.
+    async fn random_key(&self) -> Result<Option<String>, RustyAntError>;
+
+    /// Copy `from`'s value (and TTL) to `to`. Returns `true` when the copy
+    /// happened, `false` when it was refused — source missing, destination
+    /// already present without `replace`, or `from == to`. On S3 the two
+    /// objects aren't modified atomically, same caveat as `RENAME`.
+    async fn copy(&self, from: &str, to: &str, replace: bool) -> Result<bool, RustyAntError>;
 }
 
 // ---------------------------------------------------------------------------
@@ -1760,6 +1781,101 @@ impl Storage for S3Storage {
             Err(e) => Err(e),
         }
     }
+
+    async fn dbsize(&self) -> Result<i64, RustyAntError> {
+        let mut count: i64 = 0;
+        let mut cursor: Option<String> = None;
+        loop {
+            let mut req = self.client.list_objects_v2().bucket(&self.bucket).prefix(&self.prefix);
+            if let Some(c) = &cursor {
+                req = req.continuation_token(c);
+            }
+            let resp = req.send().await.map_err(|e| RustyAntError::S3(e.to_string()))?;
+            count = count.saturating_add(i64::try_from(resp.contents().len()).unwrap_or(i64::MAX));
+            match resp.next_continuation_token() {
+                Some(next) => cursor = Some(next.to_string()),
+                None => break,
+            }
+        }
+        Ok(count)
+    }
+
+    async fn flushall(&self) -> Result<(), RustyAntError> {
+        let mut cursor: Option<String> = None;
+        loop {
+            let mut req = self.client.list_objects_v2().bucket(&self.bucket).prefix(&self.prefix);
+            if let Some(c) = &cursor {
+                req = req.continuation_token(c);
+            }
+            let resp = req.send().await.map_err(|e| RustyAntError::S3(e.to_string()))?;
+            // S3 batch DeleteObjects accepts up to 1000 keys per request,
+            // exactly matching ListObjectsV2's page size, so one delete
+            // call per list page is the natural batching.
+            let ids: Vec<aws_sdk_s3::types::ObjectIdentifier> = resp
+                .contents()
+                .iter()
+                .filter_map(|o| o.key())
+                .map(|k| {
+                    aws_sdk_s3::types::ObjectIdentifier::builder()
+                        .key(k)
+                        .build()
+                        .map_err(|e| RustyAntError::S3(format!("object id: {e}")))
+                })
+                .collect::<Result<_, _>>()?;
+            if !ids.is_empty() {
+                let delete = aws_sdk_s3::types::Delete::builder()
+                    .set_objects(Some(ids))
+                    .quiet(true)
+                    .build()
+                    .map_err(|e| RustyAntError::S3(format!("delete payload: {e}")))?;
+                self.client
+                    .delete_objects()
+                    .bucket(&self.bucket)
+                    .delete(delete)
+                    .send()
+                    .await
+                    .map_err(|e| RustyAntError::S3(e.to_string()))?;
+            }
+            match resp.next_continuation_token() {
+                Some(next) => cursor = Some(next.to_string()),
+                None => break,
+            }
+        }
+        Ok(())
+    }
+
+    async fn random_key(&self) -> Result<Option<String>, RustyAntError> {
+        // Walk the full keyspace then pick — S3 has no native random sampling.
+        // Documented as O(n) in the README.
+        let all = self.keys("*").await?;
+        if all.is_empty() {
+            return Ok(None);
+        }
+        let idx = usize::try_from(pseudo_rand_u64() % (all.len() as u64)).unwrap_or(0);
+        Ok(Some(all[idx].clone()))
+    }
+
+    async fn copy(&self, from: &str, to: &str, replace: bool) -> Result<bool, RustyAntError> {
+        if from == to {
+            return Ok(false);
+        }
+        let Some(entry) = self.load(from).await? else {
+            return Ok(false);
+        };
+        let dest = self.load_with_etag(to).await?;
+        let cond = match (&dest, replace) {
+            (Some(_), false) => return Ok(false),
+            (Some((_, etag)), true) => CasCondition::IfMatch(etag.clone()),
+            (None, _) => CasCondition::CreateOnly,
+        };
+        match self.save_cas(to, &entry, cond).await {
+            Ok(()) => Ok(true),
+            // CAS race: a concurrent writer beat us. Surface as "not copied"
+            // rather than retrying — Redis COPY is a one-shot, not an RMW.
+            Err(RustyAntError::Contention) => Ok(false),
+            Err(e) => Err(e),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2768,6 +2884,48 @@ impl Storage for InMemoryStorage {
 
     async fn zpopmax(&self, key: &str, count: usize) -> Result<Vec<(String, f64)>, RustyAntError> {
         self.zpop_inmem(key, count, true)
+    }
+
+    async fn dbsize(&self) -> Result<i64, RustyAntError> {
+        let now = now_ms();
+        Ok(self.with_entry_mut(|map| {
+            let n = map.values().filter(|v| v.expires_at_ms.is_none_or(|exp| exp > now)).count();
+            i64::try_from(n).unwrap_or(i64::MAX)
+        }))
+    }
+
+    async fn flushall(&self) -> Result<(), RustyAntError> {
+        self.with_entry_mut(BTreeMap::clear);
+        Ok(())
+    }
+
+    async fn random_key(&self) -> Result<Option<String>, RustyAntError> {
+        let now = now_ms();
+        let live: Vec<String> = self.with_entry_mut(|map| {
+            map.iter().filter(|(_, v)| v.expires_at_ms.is_none_or(|exp| exp > now)).map(|(k, _)| k.clone()).collect()
+        });
+        if live.is_empty() {
+            return Ok(None);
+        }
+        let idx = usize::try_from(pseudo_rand_u64() % (live.len() as u64)).unwrap_or(0);
+        Ok(Some(live[idx].clone()))
+    }
+
+    async fn copy(&self, from: &str, to: &str, replace: bool) -> Result<bool, RustyAntError> {
+        if from == to {
+            return Ok(false);
+        }
+        let Some(entry) = self.load(from) else {
+            return Ok(false);
+        };
+        let dest_present = self.load(to).is_some();
+        if dest_present && !replace {
+            return Ok(false);
+        }
+        self.with_entry_mut(|store| {
+            store.insert(to.to_string(), entry);
+        });
+        Ok(true)
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1790,6 +1790,221 @@ async fn zpop_on_wrong_type_errors() {
     call(&state, &[b"ZPOPMAX", b"k"]).await.expect_error_prefix("ERR");
 }
 
+// ---------------------------------------------------------------------------
+// ECHO / TIME / DBSIZE / FLUSHDB / FLUSHALL / RANDOMKEY / UNLINK / COPY
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn echo_returns_input_bulk() {
+    let state = test_state();
+    call(&state, &[b"ECHO", b"hello world"]).await.expect_bulk(b"hello world");
+}
+
+#[tokio::test]
+async fn echo_passes_binary_payload_unchanged() {
+    let state = test_state();
+    call(&state, &[b"ECHO", b"\x00\xff\x01\x02"]).await.expect_bulk(b"\x00\xff\x01\x02");
+}
+
+#[tokio::test]
+async fn echo_wrong_arity_errors() {
+    let state = test_state();
+    call(&state, &[b"ECHO"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"ECHO", b"a", b"b"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn time_returns_seconds_and_microseconds_pair() {
+    let state = test_state();
+    let parts = call(&state, &[b"TIME"]).await.into_bulk_array();
+    assert_eq!(parts.len(), 2, "expected [secs, micros]");
+    let secs: i64 = std::str::from_utf8(&parts[0]).expect("utf8 secs").parse().expect("parse secs");
+    let micros: i64 = std::str::from_utf8(&parts[1]).expect("utf8 micros").parse().expect("parse micros");
+    // Sanity: rustyant only ever ships forward in time, so the seconds field
+    // should be at least past the 2026 epoch boundary (1_767_225_600).
+    assert!(secs > 1_767_225_600, "secs implausibly small: {secs}");
+    assert!((0..1_000_000).contains(&micros), "micros out of band: {micros}");
+}
+
+#[tokio::test]
+async fn time_rejects_extra_args() {
+    let state = test_state();
+    call(&state, &[b"TIME", b"now"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn dbsize_empty_returns_zero() {
+    let state = test_state();
+    call(&state, &[b"DBSIZE"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn dbsize_counts_every_value_kind() {
+    let state = test_state();
+    call(&state, &[b"SET", b"s", b"v"]).await;
+    call(&state, &[b"HSET", b"h", b"f", b"v"]).await;
+    call(&state, &[b"LPUSH", b"l", b"v"]).await;
+    call(&state, &[b"SADD", b"set", b"v"]).await;
+    call(&state, &[b"ZADD", b"z", b"1", b"v"]).await;
+    call(&state, &[b"DBSIZE"]).await.expect_integer(5);
+}
+
+#[tokio::test]
+async fn dbsize_drops_after_del() {
+    let state = test_state();
+    call(&state, &[b"SET", b"a", b"1"]).await;
+    call(&state, &[b"SET", b"b", b"2"]).await;
+    call(&state, &[b"DEL", b"a"]).await;
+    call(&state, &[b"DBSIZE"]).await.expect_integer(1);
+}
+
+#[tokio::test]
+async fn flushdb_clears_every_key() {
+    let state = test_state();
+    call(&state, &[b"SET", b"a", b"1"]).await;
+    call(&state, &[b"HSET", b"h", b"f", b"v"]).await;
+    call(&state, &[b"FLUSHDB"]).await.expect_simple("OK");
+    call(&state, &[b"DBSIZE"]).await.expect_integer(0);
+    call(&state, &[b"GET", b"a"]).await.expect_nil();
+}
+
+#[tokio::test]
+async fn flushall_is_alias_of_flushdb() {
+    let state = test_state();
+    call(&state, &[b"SET", b"a", b"1"]).await;
+    call(&state, &[b"FLUSHALL"]).await.expect_simple("OK");
+    call(&state, &[b"DBSIZE"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn flushdb_accepts_async_modifier() {
+    let state = test_state();
+    call(&state, &[b"SET", b"a", b"1"]).await;
+    // Redis 4+ added the ASYNC / SYNC modifier; rustyant ignores the choice
+    // (always synchronous) but must not error on it.
+    call(&state, &[b"FLUSHDB", b"ASYNC"]).await.expect_simple("OK");
+    call(&state, &[b"DBSIZE"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn flushdb_rejects_unknown_modifier() {
+    let state = test_state();
+    call(&state, &[b"FLUSHDB", b"BOGUS"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn randomkey_empty_returns_nil() {
+    let state = test_state();
+    call(&state, &[b"RANDOMKEY"]).await.expect_nil();
+}
+
+#[tokio::test]
+async fn randomkey_returns_one_of_existing_keys() {
+    let state = test_state();
+    call(&state, &[b"SET", b"alpha", b"1"]).await;
+    call(&state, &[b"SET", b"beta", b"2"]).await;
+    call(&state, &[b"SET", b"gamma", b"3"]).await;
+    let reply = call(&state, &[b"RANDOMKEY"]).await;
+    let raw = String::from_utf8_lossy(&reply.raw).into_owned();
+    assert!(
+        raw.contains("alpha") || raw.contains("beta") || raw.contains("gamma"),
+        "RANDOMKEY did not return a known key: {raw:?}"
+    );
+}
+
+#[tokio::test]
+async fn unlink_behaves_like_del() {
+    let state = test_state();
+    call(&state, &[b"SET", b"a", b"1"]).await;
+    call(&state, &[b"SET", b"b", b"2"]).await;
+    call(&state, &[b"UNLINK", b"a", b"b", b"missing"]).await.expect_integer(2);
+    call(&state, &[b"EXISTS", b"a", b"b"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn copy_basic_creates_destination() {
+    let state = test_state();
+    call(&state, &[b"SET", b"src", b"v"]).await;
+    call(&state, &[b"COPY", b"src", b"dst"]).await.expect_integer(1);
+    call(&state, &[b"GET", b"dst"]).await.expect_bulk(b"v");
+    // Source still present — COPY is not a move.
+    call(&state, &[b"GET", b"src"]).await.expect_bulk(b"v");
+}
+
+#[tokio::test]
+async fn copy_missing_source_returns_zero() {
+    let state = test_state();
+    call(&state, &[b"COPY", b"missing", b"dst"]).await.expect_integer(0);
+    call(&state, &[b"EXISTS", b"dst"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn copy_dest_exists_without_replace_refuses() {
+    let state = test_state();
+    call(&state, &[b"SET", b"src", b"new"]).await;
+    call(&state, &[b"SET", b"dst", b"old"]).await;
+    call(&state, &[b"COPY", b"src", b"dst"]).await.expect_integer(0);
+    call(&state, &[b"GET", b"dst"]).await.expect_bulk(b"old");
+}
+
+#[tokio::test]
+async fn copy_with_replace_overwrites_destination() {
+    let state = test_state();
+    call(&state, &[b"SET", b"src", b"new"]).await;
+    call(&state, &[b"SET", b"dst", b"old"]).await;
+    call(&state, &[b"COPY", b"src", b"dst", b"REPLACE"]).await.expect_integer(1);
+    call(&state, &[b"GET", b"dst"]).await.expect_bulk(b"new");
+}
+
+#[tokio::test]
+async fn copy_self_returns_zero() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"COPY", b"k", b"k"]).await.expect_integer(0);
+    call(&state, &[b"COPY", b"k", b"k", b"REPLACE"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn copy_preserves_ttl_on_destination() {
+    let state = test_state();
+    call(&state, &[b"SET", b"src", b"v", b"EX", b"60"]).await;
+    call(&state, &[b"COPY", b"src", b"dst"]).await.expect_integer(1);
+    let reply = call(&state, &[b"TTL", b"dst"]).await;
+    let raw = String::from_utf8_lossy(&reply.raw).into_owned();
+    let ttl: i64 = raw.trim_start_matches(':').trim_end().parse().expect("ttl");
+    assert!((50..=60).contains(&ttl), "TTL not preserved on copy: {ttl}");
+}
+
+#[tokio::test]
+async fn copy_preserves_value_kind_for_collections() {
+    let state = test_state();
+    call(&state, &[b"HSET", b"src", b"f", b"v"]).await;
+    call(&state, &[b"COPY", b"src", b"dst"]).await.expect_integer(1);
+    call(&state, &[b"HGET", b"dst", b"f"]).await.expect_bulk(b"v");
+    call(&state, &[b"HLEN", b"dst"]).await.expect_integer(1);
+}
+
+#[tokio::test]
+async fn copy_db_zero_is_accepted() {
+    let state = test_state();
+    call(&state, &[b"SET", b"src", b"v"]).await;
+    call(&state, &[b"COPY", b"src", b"dst", b"DB", b"0"]).await.expect_integer(1);
+}
+
+#[tokio::test]
+async fn copy_other_db_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"src", b"v"]).await;
+    call(&state, &[b"COPY", b"src", b"dst", b"DB", b"1"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn copy_unknown_option_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"src", b"v"]).await;
+    call(&state, &[b"COPY", b"src", b"dst", b"NUKE"]).await.expect_error_prefix("ERR");
+}
+
 // Use RespReply publicly to check the crate re-export surface compiles.
 #[test]
 fn reply_encode_simple_works_from_tests() {

--- a/tests/redis_py_compat.rs
+++ b/tests/redis_py_compat.rs
@@ -355,6 +355,38 @@ print('ok')
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn redis_py_server_housekeeping() {
+    // Cover the new server / keyspace housekeeping commands through redis-py
+    // so any encoding mismatch in ECHO / TIME / DBSIZE / FLUSHDB / RANDOMKEY /
+    // UNLINK / COPY surfaces against the real client's parser.
+    run_redis_py_script(
+        r"
+import redis
+r = redis.Redis(host='127.0.0.1', port={port}, socket_timeout=5)
+assert r.echo('ping me') == b'ping me'
+secs, micros = r.time()
+assert isinstance(secs, int) and secs > 1_700_000_000
+assert isinstance(micros, int) and 0 <= micros < 1_000_000
+r.set('a', '1'); r.set('b', '2')
+assert r.dbsize() == 2
+key = r.randomkey()
+assert key in (b'a', b'b')
+assert r.unlink('a', 'b', 'missing') == 2
+assert r.dbsize() == 0
+r.set('src', 'v')
+assert r.copy('src', 'dst') is True
+assert r.get('dst') == b'v'
+assert r.copy('src', 'dst') is False
+assert r.copy('src', 'dst', replace=True) is True
+r.flushdb()
+assert r.dbsize() == 0
+print('ok')
+",
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn redis_py_pipeline() {
     // redis-py's pipeline batches commands and reads replies in order.
     // This exercises the TCP streaming path with multiple frames in flight.


### PR DESCRIPTION
## Summary

- **Server (+5):** `ECHO`, `TIME`, `DBSIZE`, `FLUSHDB`, `FLUSHALL`
- **Keyspace (+3):** `RANDOMKEY`, `UNLINK`, `COPY` (+ `REPLACE` / `DB 0`)

`FLUSHDB` and `FLUSHALL` collapse to one operation — rustyant exposes a single logical namespace. The optional `ASYNC` / `SYNC` modifier is accepted but ignored: the flush is always synchronous over S3. `UNLINK` shares the synchronous `DEL` path; rustyant has no background freer thread.

Storage trait gains `dbsize`, `flushall`, `random_key`, `copy` on both backends. S3 `FLUSHALL` batches up to 1000 deletes per `DeleteObjects` request, paginating over `ListObjectsV2`. `DBSIZE` and `RANDOMKEY` are O(n) on S3 (full keyspace walk); the README documents this and notes that recently-expired keys still count toward `DBSIZE`.

`COPY` on S3 is best-effort (load-then-conditional-put) — same caveat as `RENAME`. Without `REPLACE` it uses `If-None-Match: *` on the destination to narrow the race; with `REPLACE` it uses `If-Match: <etag>`. Source TTL is preserved.

`COPY DB N` only accepts `N == 0` (single-namespace constraint); other values surface as `-ERR`.

Stray local `CLAUDE.md` is now gitignored so per-machine agent tweaks stay out of git.

## Test plan

- [x] `just check` — fmt + clippy clean
- [x] `just test` — 244/244 passing (was 218 before; +26 new tests)
- [x] Integration suite covers: ECHO binary payload + arity, TIME format + arity, DBSIZE across all five value kinds, FLUSHDB/FLUSHALL with and without ASYNC, RANDOMKEY on empty + populated keyspaces, UNLINK multi-key parity with DEL, COPY basic / missing-source / dest-exists-no-replace / REPLACE / self-copy / TTL preservation / collection-typed copy / DB-0 / DB-N rejection / unknown option
- [x] redis-py compat: new `redis_py_server_housekeeping` exercises every new command through real `redis.Redis` against the rustyant TCP harness