### PR TITLE
:sparkles: add bit-ops on Strings (GETBIT/SETBIT/BITCOUNT/BITPOS/BITOP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Implemented:
 |---|---|
 | Server | `PING`, `ECHO`, `TIME`, `DBSIZE`, `FLUSHDB`, `FLUSHALL` |
 | Keyspace | `KEYS`, `SCAN` (+ `MATCH` / `COUNT` options), `TYPE`, `RENAME`, `RENAMENX`, `RANDOMKEY`, `UNLINK`, `COPY` (+ `REPLACE` / `DB 0`) |
-| Strings | `GET`, `SET` (+ `EX` / `PX` options), `GETSET`, `GETDEL`, `GETRANGE`, `SETRANGE`, `SETNX`, `SETEX`, `MGET`, `MSET`, `MSETNX`, `APPEND`, `STRLEN`, `DEL`, `EXISTS`, `EXPIRE`, `EXPIREAT`, `PEXPIRE`, `PEXPIREAT`, `PERSIST`, `TTL`, `PTTL`, `INCR`, `INCRBY`, `INCRBYFLOAT`, `DECR`, `DECRBY` |
+| Strings | `GET`, `SET` (+ `EX` / `PX` options), `GETSET`, `GETDEL`, `GETRANGE`, `SETRANGE`, `SETNX`, `SETEX`, `MGET`, `MSET`, `MSETNX`, `APPEND`, `STRLEN`, `DEL`, `EXISTS`, `EXPIRE`, `EXPIREAT`, `PEXPIRE`, `PEXPIREAT`, `PERSIST`, `TTL`, `PTTL`, `INCR`, `INCRBY`, `INCRBYFLOAT`, `DECR`, `DECRBY`, `GETBIT`, `SETBIT`, `BITCOUNT` (+ `BYTE` / `BIT`), `BITPOS` (+ `BYTE` / `BIT`), `BITOP` (`AND` / `OR` / `XOR` / `NOT`) |
 | Hashes | `HSET`, `HSETNX`, `HGET`, `HDEL`, `HGETALL`, `HLEN`, `HKEYS`, `HVALS`, `HEXISTS`, `HSTRLEN`, `HMGET`, `HINCRBY` |
 | Lists | `LPUSH`, `RPUSH`, `LPUSHX`, `RPUSHX`, `LPOP` (+ count), `RPOP` (+ count), `LRANGE`, `LLEN`, `LINDEX`, `LSET`, `LREM`, `LINSERT`, `LTRIM` |
 | Sets | `SADD`, `SREM`, `SMEMBERS`, `SISMEMBER`, `SMISMEMBER`, `SCARD`, `SINTER`, `SUNION`, `SDIFF`, `SPOP` (+ count), `SRANDMEMBER` (+ count) |
@@ -72,6 +72,8 @@ Implemented:
 Not implemented (PRs welcome): pub/sub, transactions, scripting, streams, geo.
 
 `MSET` is **not atomic across keys** — a failure partway through leaves earlier keys set. Real Redis is atomic here; rustyant's S3 backing makes the all-or-none semantic expensive, and the fire-and-forget variant is fine for most workloads. `MSETNX`, `RENAME` / `RENAMENX`, and `COPY` are similarly best-effort on the S3 backend: the in-memory path is fully atomic under its `Mutex`, but on S3 a concurrent writer landing between the existence check and the write can leak past the `NX` guard. `RENAMENX` and `COPY` (without `REPLACE`) use `If-None-Match: *` on the destination to shrink that window, so the failure mode is "operation reports 0 / error" rather than data loss.
+
+Bit operations follow Redis's bit numbering: bit 0 is the most significant bit of byte 0. `SETBIT` zero-pads the underlying string to fit the requested offset and runs under the same CAS as other read-modify-write commands. `BITPOS` keeps Redis's asymmetric "infinite trailing zeros" behavior — when searching for a 0 bit without an explicit end, an all-ones string returns `strlen * 8` rather than `-1`; pinning an explicit end suppresses that fiction. `BITOP` reads each source sequentially, pads shorter sources to the longest with zero bytes, and stores the result; an empty result removes the destination instead of writing an empty-string entry.
 
 ### Concurrency
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -7,7 +7,7 @@ use crate::error::RustyAntError;
 use crate::metrics;
 use crate::resp::RespReply;
 use crate::state::State;
-use crate::storage::{ScoreBound, TtlResult, now_ms};
+use crate::storage::{ScoreBound, TtlResult, bit_at, now_ms};
 
 /// Coarse classification of a dispatch result, emitted as a structured log
 /// field so `CloudWatch` queries can count/alert by outcome without string
@@ -107,6 +107,12 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         // freer thread, so it folds into the same synchronous DEL path.
         "DEL" | "UNLINK" => handle_del(state, args).await,
         "COPY" => handle_copy(state, args).await,
+        // Bit ops on Strings
+        "GETBIT" => handle_getbit(state, args).await,
+        "SETBIT" => handle_setbit(state, args).await,
+        "BITCOUNT" => handle_bitcount(state, args).await,
+        "BITPOS" => handle_bitpos(state, args).await,
+        "BITOP" => handle_bitop(state, args).await,
         // Strings
         "GET" => handle_get(state, args).await,
         "GETSET" => handle_getset(state, args).await,
@@ -1119,6 +1125,234 @@ async fn handle_randomkey(state: &State, args: Vec<Bytes>) -> Result<RespReply, 
         .random_key()
         .await?
         .map_or(RespReply::Nil, |k| RespReply::BulkString(Some(Bytes::from(k.into_bytes())))))
+}
+
+// ---- Bit ops on Strings ---------------------------------------------------
+
+fn parse_bit_offset(arg: &Bytes) -> Result<u64, RustyAntError> {
+    let n = parse_i64(arg, "offset")?;
+    u64::try_from(n).map_err(|_| RustyAntError::Parse("offset must be >= 0".into()))
+}
+
+async fn handle_getbit(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("GETBIT", args.len() == 2)?;
+    let key = arg_as_str(&args[0])?;
+    let offset = parse_bit_offset(&args[1])?;
+    let v = state.storage.getbit(key, offset).await?;
+    Ok(RespReply::Integer(v))
+}
+
+async fn handle_setbit(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("SETBIT", args.len() == 3)?;
+    let key = arg_as_str(&args[0])?;
+    let offset = parse_bit_offset(&args[1])?;
+    let bit = match parse_i64(&args[2], "value")? {
+        0 => false,
+        1 => true,
+        _ => return Err(RustyAntError::Parse("bit value must be 0 or 1".into())),
+    };
+    let prev = state.storage.setbit(key, offset, bit).await?;
+    Ok(RespReply::Integer(prev))
+}
+
+/// Resolve a Redis-style inclusive byte/bit range against `len_units`,
+/// returning `(start, end_inclusive)` clamped into bounds. `None` means
+/// the requested range collapses to empty (e.g. start past end).
+fn resolve_inclusive_range(start: i64, end: i64, len_units: usize) -> Option<(usize, usize)> {
+    if len_units == 0 {
+        return None;
+    }
+    let len_i = i64::try_from(len_units).unwrap_or(i64::MAX);
+    let s = if start < 0 { (len_i + start).max(0) } else { start };
+    let e = if end < 0 { len_i + end } else { end.min(len_i - 1) };
+    if s >= len_i || e < 0 || s > e {
+        return None;
+    }
+    Some((usize::try_from(s).unwrap_or(0), usize::try_from(e).unwrap_or(0)))
+}
+
+/// Parse the optional trailing `BYTE` / `BIT` keyword on `BITCOUNT` / `BITPOS`.
+/// Defaults to byte-wise when omitted, matching Redis.
+fn parse_range_unit(arg: Option<&Bytes>) -> Result<bool, RustyAntError> {
+    let Some(arg) = arg else { return Ok(false) };
+    match arg_as_str(arg)?.to_ascii_uppercase().as_str() {
+        "BYTE" => Ok(false),
+        "BIT" => Ok(true),
+        other => Err(RustyAntError::Parse(format!("range unit must be BYTE or BIT, got {other}"))),
+    }
+}
+
+/// Count set bits across `data[start..=end]` (byte indices, both inclusive).
+fn count_bits_byte_range(data: &[u8], start: usize, end: usize) -> i64 {
+    let total: u32 = data[start..=end].iter().map(|b| b.count_ones()).sum();
+    i64::from(total)
+}
+
+/// Count set bits across the bit range `[start..=end]` (bit indices, both
+/// inclusive). Walks bit by bit at the boundaries; the fully-covered
+/// interior bytes are summed via `count_ones` for speed.
+fn count_bits_bit_range(data: &[u8], start: u64, end: u64) -> i64 {
+    let mut count: i64 = 0;
+    for bit in start..=end {
+        count += i64::from(bit_at(data, bit));
+    }
+    count
+}
+
+async fn handle_bitcount(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    if args.is_empty() || args.len() == 2 || args.len() > 4 {
+        return Err(RustyAntError::WrongArity { command: "BITCOUNT".into() });
+    }
+    let key = arg_as_str(&args[0])?;
+    let Some(data) = state.storage.get_string(key).await? else {
+        return Ok(RespReply::Integer(0));
+    };
+    if args.len() == 1 {
+        let total: u32 = data.iter().map(|b| b.count_ones()).sum();
+        return Ok(RespReply::Integer(i64::from(total)));
+    }
+    let start = parse_i64(&args[1], "start")?;
+    let end = parse_i64(&args[2], "end")?;
+    let in_bits = parse_range_unit(args.get(3))?;
+    let len_units = if in_bits { data.len().saturating_mul(8) } else { data.len() };
+    let Some((s, e)) = resolve_inclusive_range(start, end, len_units) else {
+        return Ok(RespReply::Integer(0));
+    };
+    let count =
+        if in_bits { count_bits_bit_range(&data, s as u64, e as u64) } else { count_bits_byte_range(&data, s, e) };
+    Ok(RespReply::Integer(count))
+}
+
+/// Find the first bit `target` (0 or 1) in `data[start_bit..=end_bit]`,
+/// returning the absolute bit index, or `None` if not found.
+fn find_first_bit(data: &[u8], target: u8, start_bit: u64, end_bit: u64) -> Option<u64> {
+    (start_bit..=end_bit).find(|&bit| bit_at(data, bit) == target)
+}
+
+async fn handle_bitpos(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    // BITPOS key bit [start [end [BYTE|BIT]]]
+    if args.len() < 2 || args.len() > 5 {
+        return Err(RustyAntError::WrongArity { command: "BITPOS".into() });
+    }
+    let key = arg_as_str(&args[0])?;
+    let target = match parse_i64(&args[1], "bit")? {
+        0 => 0u8,
+        1 => 1u8,
+        _ => return Err(RustyAntError::Parse("bit must be 0 or 1".into())),
+    };
+    let data = state.storage.get_string(key).await?.unwrap_or_default();
+    if data.is_empty() {
+        // Empty / missing key: an all-zeros search lands at bit 0; an
+        // all-ones search has nothing to find.
+        return Ok(RespReply::Integer(if target == 0 { 0 } else { -1 }));
+    }
+    let total_bits = u64::try_from(data.len()).unwrap_or(u64::MAX).saturating_mul(8);
+    let end_explicit = args.len() >= 4;
+    let in_bits = parse_range_unit(args.get(4))?;
+
+    // Resolve byte- or bit-based range against the right unit count.
+    let (start_bit, end_bit) = if args.len() >= 3 {
+        let start = parse_i64(&args[2], "start")?;
+        let end_unit = if end_explicit { parse_i64(&args[3], "end")? } else { i64::MAX };
+        let len_units = if in_bits { data.len().saturating_mul(8) } else { data.len() };
+        let Some((s, e)) = resolve_inclusive_range(start, end_unit, len_units) else {
+            return Ok(RespReply::Integer(-1));
+        };
+        if in_bits { (s as u64, e as u64) } else { ((s as u64) * 8, ((e as u64) + 1) * 8 - 1) }
+    } else {
+        (0u64, total_bits - 1)
+    };
+
+    if let Some(pos) = find_first_bit(&data, target, start_bit, end_bit) {
+        return Ok(RespReply::Integer(i64::try_from(pos).unwrap_or(i64::MAX)));
+    }
+    // Asymmetry in Redis: when looking for a 0 bit and the user did NOT pin
+    // an explicit end, the trailing bits are treated as "infinite zeros" —
+    // return the position just past the end of the string. With an explicit
+    // end (or when looking for a 1), -1 is the right answer.
+    if target == 0 && !end_explicit {
+        return Ok(RespReply::Integer(i64::try_from(total_bits).unwrap_or(i64::MAX)));
+    }
+    Ok(RespReply::Integer(-1))
+}
+
+#[derive(Debug, Copy, Clone)]
+enum BitOp {
+    And,
+    Or,
+    Xor,
+    Not,
+}
+
+impl BitOp {
+    fn parse(s: &str) -> Result<Self, RustyAntError> {
+        match s.to_ascii_uppercase().as_str() {
+            "AND" => Ok(Self::And),
+            "OR" => Ok(Self::Or),
+            "XOR" => Ok(Self::Xor),
+            "NOT" => Ok(Self::Not),
+            other => Err(RustyAntError::Parse(format!("BITOP operation must be AND/OR/XOR/NOT, got {other}"))),
+        }
+    }
+}
+
+/// Combine `sources` byte-wise under `op`. AND/OR/XOR pad missing key bytes
+/// to zero up to the longest source's length; NOT inverts a single source.
+fn apply_bitop(op: BitOp, sources: &[Vec<u8>]) -> Vec<u8> {
+    if matches!(op, BitOp::Not) {
+        return sources.first().map(|s| s.iter().map(|b| !b).collect()).unwrap_or_default();
+    }
+    let max_len = sources.iter().map(Vec::len).max().unwrap_or(0);
+    let init = match op {
+        BitOp::And => 0xFFu8,
+        _ => 0x00u8,
+    };
+    let mut out = vec![init; max_len];
+    let mut first = true;
+    for src in sources {
+        for (i, slot) in out.iter_mut().enumerate() {
+            let b = src.get(i).copied().unwrap_or(0);
+            if first {
+                *slot = b;
+            } else {
+                match op {
+                    BitOp::And => *slot &= b,
+                    BitOp::Or => *slot |= b,
+                    BitOp::Xor => *slot ^= b,
+                    BitOp::Not => unreachable!(),
+                }
+            }
+        }
+        first = false;
+    }
+    out
+}
+
+async fn handle_bitop(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    if args.len() < 3 {
+        return Err(RustyAntError::WrongArity { command: "BITOP".into() });
+    }
+    let op = BitOp::parse(arg_as_str(&args[0])?)?;
+    let dest = arg_as_string(&args[1])?;
+    let src_keys: Vec<String> = args.iter().skip(2).map(arg_as_string).collect::<Result<_, _>>()?;
+    if matches!(op, BitOp::Not) && src_keys.len() != 1 {
+        return Err(RustyAntError::Parse("BITOP NOT takes exactly one source key".into()));
+    }
+    let mut sources: Vec<Vec<u8>> = Vec::with_capacity(src_keys.len());
+    for k in &src_keys {
+        let bytes = state.storage.get_string(k).await?.map_or_else(Vec::new, |b| b.to_vec());
+        sources.push(bytes);
+    }
+    let result = apply_bitop(op, &sources);
+    let len = i64::try_from(result.len()).unwrap_or(i64::MAX);
+    if result.is_empty() {
+        // Mirror Redis: empty result removes the destination instead of
+        // creating an empty-string entry.
+        state.storage.delete(&dest).await?;
+    } else {
+        state.storage.set_string(&dest, Bytes::from(result), None).await?;
+    }
+    Ok(RespReply::Integer(len))
 }
 
 async fn handle_copy(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -610,6 +610,53 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     /// already present without `replace`, or `from == to`. On S3 the two
     /// objects aren't modified atomically, same caveat as `RENAME`.
     async fn copy(&self, from: &str, to: &str, replace: bool) -> Result<bool, RustyAntError>;
+
+    /// Read a single bit (0 or 1) at the given offset. Bit 0 is the MSB of
+    /// byte 0, matching Redis's bit ordering. Out-of-range or missing key
+    /// returns 0. Default impl reads the whole string and indexes locally.
+    async fn getbit(&self, key: &str, offset: u64) -> Result<i64, RustyAntError> {
+        let Some(data) = self.get_string(key).await? else {
+            return Ok(0);
+        };
+        Ok(i64::from(bit_at(&data, offset)))
+    }
+
+    /// Set a single bit at `offset` to `value`, zero-padding the underlying
+    /// string if needed. Returns the previous bit value (0 or 1). Mutates
+    /// under CAS on the S3 backend.
+    async fn setbit(&self, key: &str, offset: u64, value: bool) -> Result<i64, RustyAntError>;
+}
+
+/// Read bit `offset` (Redis bit numbering: bit 0 = MSB of byte 0) from `data`.
+/// Returns 0 when the offset is beyond the string.
+pub fn bit_at(data: &[u8], offset: u64) -> u8 {
+    let byte_idx = offset / 8;
+    let Ok(byte_idx) = usize::try_from(byte_idx) else {
+        return 0;
+    };
+    if byte_idx >= data.len() {
+        return 0;
+    }
+    let bit_in_byte = 7 - (offset % 8) as u8;
+    (data[byte_idx] >> bit_in_byte) & 1
+}
+
+/// Mutate the bit at `offset` to `value` in `data`, zero-padding the buffer
+/// if `offset` lands past the current end. Returns the previous bit value.
+pub fn apply_setbit(data: &mut Vec<u8>, offset: u64, value: bool) -> u8 {
+    let byte_idx = usize::try_from(offset / 8).unwrap_or(usize::MAX);
+    if byte_idx >= data.len() {
+        data.resize(byte_idx + 1, 0);
+    }
+    let bit_in_byte = 7 - (offset % 8) as u8;
+    let mask: u8 = 1 << bit_in_byte;
+    let prev = (data[byte_idx] & mask) >> bit_in_byte;
+    if value {
+        data[byte_idx] |= mask;
+    } else {
+        data[byte_idx] &= !mask;
+    }
+    prev
 }
 
 // ---------------------------------------------------------------------------
@@ -1876,6 +1923,20 @@ impl Storage for S3Storage {
             Err(e) => Err(e),
         }
     }
+
+    async fn setbit(&self, key: &str, offset: u64, value: bool) -> Result<i64, RustyAntError> {
+        self.cas(key, move |entry| {
+            let (mut data, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::String(d), expires_at_ms }) => (d.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => (Vec::new(), None),
+            };
+            let prev = apply_setbit(&mut data, offset, value);
+            let new_entry = StoredValue { expires_at_ms, value: Value::String(data) };
+            Ok(CasAction::Write(new_entry, i64::from(prev)))
+        })
+        .await
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2926,6 +2987,20 @@ impl Storage for InMemoryStorage {
             store.insert(to.to_string(), entry);
         });
         Ok(true)
+    }
+
+    async fn setbit(&self, key: &str, offset: u64, value: bool) -> Result<i64, RustyAntError> {
+        let (mut data, expires_at_ms) = match self.load(key) {
+            Some(StoredValue { value: Value::String(d), expires_at_ms }) => (d, expires_at_ms),
+            Some(_) => return Err(wrong_type(key)),
+            None => (Vec::new(), None),
+        };
+        let prev = apply_setbit(&mut data, offset, value);
+        let entry = StoredValue { expires_at_ms, value: Value::String(data) };
+        self.with_entry_mut(|store| {
+            store.insert(key.to_string(), entry);
+        });
+        Ok(i64::from(prev))
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2005,6 +2005,263 @@ async fn copy_unknown_option_errors() {
     call(&state, &[b"COPY", b"src", b"dst", b"NUKE"]).await.expect_error_prefix("ERR");
 }
 
+// ---------------------------------------------------------------------------
+// Bit ops on Strings: GETBIT / SETBIT / BITCOUNT / BITPOS / BITOP
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn getbit_on_missing_key_returns_zero() {
+    let state = test_state();
+    call(&state, &[b"GETBIT", b"k", b"0"]).await.expect_integer(0);
+    call(&state, &[b"GETBIT", b"k", b"100"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn getbit_reads_msb_first_within_byte() {
+    let state = test_state();
+    // 0x80 = 1000_0000 — bit 0 is set, rest cleared.
+    call(&state, &[b"SET", b"k", b"\x80"]).await;
+    call(&state, &[b"GETBIT", b"k", b"0"]).await.expect_integer(1);
+    call(&state, &[b"GETBIT", b"k", b"1"]).await.expect_integer(0);
+    call(&state, &[b"GETBIT", b"k", b"7"]).await.expect_integer(0);
+    // Past end → 0, no error.
+    call(&state, &[b"GETBIT", b"k", b"100"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn getbit_on_wrong_type_errors() {
+    let state = test_state();
+    call(&state, &[b"LPUSH", b"l", b"x"]).await;
+    call(&state, &[b"GETBIT", b"l", b"0"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn setbit_creates_and_extends_string() {
+    let state = test_state();
+    // First SETBIT on a missing key creates the string and zero-pads.
+    call(&state, &[b"SETBIT", b"k", b"7", b"1"]).await.expect_integer(0);
+    call(&state, &[b"GET", b"k"]).await.expect_bulk(b"\x01");
+    call(&state, &[b"STRLEN", b"k"]).await.expect_integer(1);
+    // Setting bit 16 forces a 3-byte string with the new bit at MSB of byte 2.
+    call(&state, &[b"SETBIT", b"k", b"16", b"1"]).await.expect_integer(0);
+    call(&state, &[b"GET", b"k"]).await.expect_bulk(b"\x01\x00\x80");
+}
+
+#[tokio::test]
+async fn setbit_returns_previous_bit_value() {
+    let state = test_state();
+    call(&state, &[b"SETBIT", b"k", b"3", b"1"]).await.expect_integer(0);
+    // Setting the same bit again should report the previous value (1).
+    call(&state, &[b"SETBIT", b"k", b"3", b"1"]).await.expect_integer(1);
+    call(&state, &[b"SETBIT", b"k", b"3", b"0"]).await.expect_integer(1);
+    call(&state, &[b"SETBIT", b"k", b"3", b"0"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn setbit_rejects_invalid_bit_value() {
+    let state = test_state();
+    call(&state, &[b"SETBIT", b"k", b"0", b"2"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"SETBIT", b"k", b"0", b"-1"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn setbit_negative_offset_errors() {
+    let state = test_state();
+    call(&state, &[b"SETBIT", b"k", b"-1", b"1"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn setbit_on_wrong_type_errors() {
+    let state = test_state();
+    call(&state, &[b"LPUSH", b"l", b"x"]).await;
+    call(&state, &[b"SETBIT", b"l", b"0", b"1"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn bitcount_whole_key_counts_set_bits() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"foobar"]).await;
+    // Real Redis reports 26 set bits in "foobar".
+    call(&state, &[b"BITCOUNT", b"k"]).await.expect_integer(26);
+}
+
+#[tokio::test]
+async fn bitcount_byte_range_inclusive() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"foobar"]).await;
+    // Bytes 0..=0 = "f" (0x66 = 0110_0110) = 4 set bits.
+    call(&state, &[b"BITCOUNT", b"k", b"0", b"0"]).await.expect_integer(4);
+    // Negative indices: last two bytes = "ar" — 3 + 4 = 7 set bits.
+    call(&state, &[b"BITCOUNT", b"k", b"-2", b"-1"]).await.expect_integer(7);
+}
+
+#[tokio::test]
+async fn bitcount_bit_range_unit() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"\xff\x00"]).await;
+    // First 8 bits are all 1.
+    call(&state, &[b"BITCOUNT", b"k", b"0", b"7", b"BIT"]).await.expect_integer(8);
+    // Bits 8..=15 are all 0.
+    call(&state, &[b"BITCOUNT", b"k", b"8", b"15", b"BIT"]).await.expect_integer(0);
+    // Bits 4..=11 straddle the boundary: 4 ones then 4 zeros.
+    call(&state, &[b"BITCOUNT", b"k", b"4", b"11", b"BIT"]).await.expect_integer(4);
+}
+
+#[tokio::test]
+async fn bitcount_missing_key_returns_zero() {
+    let state = test_state();
+    call(&state, &[b"BITCOUNT", b"missing"]).await.expect_integer(0);
+    call(&state, &[b"BITCOUNT", b"missing", b"0", b"10"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn bitcount_empty_range_returns_zero() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"foo"]).await;
+    call(&state, &[b"BITCOUNT", b"k", b"5", b"10"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn bitcount_arity_errors() {
+    let state = test_state();
+    // Missing end argument when start is given.
+    call(&state, &[b"BITCOUNT", b"k", b"0"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn bitpos_finds_first_set_bit() {
+    let state = test_state();
+    // 0x00 0x0f 0xff — first set bit is at index 12.
+    call(&state, &[b"SET", b"k", b"\x00\x0f\xff"]).await;
+    call(&state, &[b"BITPOS", b"k", b"1"]).await.expect_integer(12);
+}
+
+#[tokio::test]
+async fn bitpos_finds_first_clear_bit() {
+    let state = test_state();
+    // 0xff 0xf0 — first clear bit is at index 12.
+    call(&state, &[b"SET", b"k", b"\xff\xf0"]).await;
+    call(&state, &[b"BITPOS", b"k", b"0"]).await.expect_integer(12);
+}
+
+#[tokio::test]
+async fn bitpos_zero_on_all_ones_with_no_end_returns_past_end() {
+    let state = test_state();
+    // Three bytes all 1s — Redis returns the position one past the last bit
+    // (24) when no end is pinned, treating the trailing string as zero-padded.
+    call(&state, &[b"SET", b"k", b"\xff\xff\xff"]).await;
+    call(&state, &[b"BITPOS", b"k", b"0"]).await.expect_integer(24);
+}
+
+#[tokio::test]
+async fn bitpos_zero_with_explicit_end_returns_minus_one_when_not_found() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"\xff\xff\xff"]).await;
+    // With an explicit end the trailing-zeros fiction does NOT apply.
+    call(&state, &[b"BITPOS", b"k", b"0", b"0", b"-1"]).await.expect_integer(-1);
+}
+
+#[tokio::test]
+async fn bitpos_one_on_all_zeros_returns_minus_one() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"\x00\x00"]).await;
+    call(&state, &[b"BITPOS", b"k", b"1"]).await.expect_integer(-1);
+}
+
+#[tokio::test]
+async fn bitpos_with_byte_range() {
+    let state = test_state();
+    // First set bit is in byte 0; restricting to byte 1 onward should skip it.
+    call(&state, &[b"SET", b"k", b"\x80\x40"]).await;
+    call(&state, &[b"BITPOS", b"k", b"1", b"1"]).await.expect_integer(9);
+}
+
+#[tokio::test]
+async fn bitpos_with_bit_range_unit() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"\x80\x40"]).await;
+    // Search bit-range 5..=15 — first 1-bit is at index 9 (MSB of byte 1 is
+    // clear, the set bit is the second-MSB).
+    call(&state, &[b"BITPOS", b"k", b"1", b"5", b"15", b"BIT"]).await.expect_integer(9);
+}
+
+#[tokio::test]
+async fn bitpos_missing_key() {
+    let state = test_state();
+    // Missing / empty key: searching for 0 starts at position 0; for 1, -1.
+    call(&state, &[b"BITPOS", b"missing", b"0"]).await.expect_integer(0);
+    call(&state, &[b"BITPOS", b"missing", b"1"]).await.expect_integer(-1);
+}
+
+#[tokio::test]
+async fn bitop_and_pads_shorter_with_zeros() {
+    let state = test_state();
+    call(&state, &[b"SET", b"a", b"\xff\xff"]).await;
+    call(&state, &[b"SET", b"b", b"\x0f"]).await;
+    // AND result is "\x0f\x00" (length 2, padded shorter with zeros).
+    call(&state, &[b"BITOP", b"AND", b"dst", b"a", b"b"]).await.expect_integer(2);
+    call(&state, &[b"GET", b"dst"]).await.expect_bulk(b"\x0f\x00");
+}
+
+#[tokio::test]
+async fn bitop_or_combines_sources() {
+    let state = test_state();
+    call(&state, &[b"SET", b"a", b"\xf0"]).await;
+    call(&state, &[b"SET", b"b", b"\x0f"]).await;
+    call(&state, &[b"BITOP", b"OR", b"dst", b"a", b"b"]).await.expect_integer(1);
+    call(&state, &[b"GET", b"dst"]).await.expect_bulk(b"\xff");
+}
+
+#[tokio::test]
+async fn bitop_xor_three_sources() {
+    let state = test_state();
+    call(&state, &[b"SET", b"a", b"\xff"]).await;
+    call(&state, &[b"SET", b"b", b"\x0f"]).await;
+    call(&state, &[b"SET", b"c", b"\xf0"]).await;
+    // 0xff ^ 0x0f ^ 0xf0 = 0x00
+    call(&state, &[b"BITOP", b"XOR", b"dst", b"a", b"b", b"c"]).await.expect_integer(1);
+    call(&state, &[b"GET", b"dst"]).await.expect_bulk(b"\x00");
+}
+
+#[tokio::test]
+async fn bitop_not_inverts_single_source() {
+    let state = test_state();
+    call(&state, &[b"SET", b"a", b"\x0f\x55"]).await;
+    call(&state, &[b"BITOP", b"NOT", b"dst", b"a"]).await.expect_integer(2);
+    call(&state, &[b"GET", b"dst"]).await.expect_bulk(b"\xf0\xaa");
+}
+
+#[tokio::test]
+async fn bitop_not_rejects_multiple_sources() {
+    let state = test_state();
+    call(&state, &[b"SET", b"a", b"\x0f"]).await;
+    call(&state, &[b"SET", b"b", b"\xf0"]).await;
+    call(&state, &[b"BITOP", b"NOT", b"dst", b"a", b"b"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn bitop_unknown_operation_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"a", b"v"]).await;
+    call(&state, &[b"BITOP", b"NUKE", b"dst", b"a"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn bitop_missing_sources_yield_empty_dest_and_delete() {
+    let state = test_state();
+    // Pre-existing dest should be removed when the result collapses to empty.
+    call(&state, &[b"SET", b"dst", b"old"]).await;
+    call(&state, &[b"BITOP", b"AND", b"dst", b"missing1", b"missing2"]).await.expect_integer(0);
+    call(&state, &[b"EXISTS", b"dst"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn bitop_on_wrong_type_errors() {
+    let state = test_state();
+    call(&state, &[b"LPUSH", b"l", b"x"]).await;
+    call(&state, &[b"BITOP", b"OR", b"dst", b"l"]).await.expect_error_prefix("ERR");
+}
+
 // Use RespReply publicly to check the crate re-export surface compiles.
 #[test]
 fn reply_encode_simple_works_from_tests() {

--- a/tests/redis_py_compat.rs
+++ b/tests/redis_py_compat.rs
@@ -387,6 +387,37 @@ print('ok')
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn redis_py_bit_ops() {
+    // Drive every new bit-op surface through redis-py so any encoding
+    // mismatch in GETBIT / SETBIT / BITCOUNT / BITPOS / BITOP shows up.
+    run_redis_py_script(
+        r"
+import redis
+r = redis.Redis(host='127.0.0.1', port={port}, socket_timeout=5)
+# SETBIT auto-creates and zero-pads; previous value reported.
+assert r.setbit('k', 7, 1) == 0
+assert r.setbit('k', 7, 1) == 1
+assert r.getbit('k', 7) == 1
+assert r.getbit('k', 0) == 0
+assert r.getbit('k', 100) == 0
+r.set('s', 'foobar')
+assert r.bitcount('s') == 26
+assert r.bitcount('s', 0, 0) == 4
+r.set('a', b'\xff\xff')
+r.set('b', b'\x0f')
+assert r.bitop('AND', 'dst', 'a', 'b') == 2
+assert r.get('dst') == b'\x0f\x00'
+assert r.bitop('NOT', 'inv', 'b') == 1
+assert r.get('inv') == b'\xf0'
+r.set('z', b'\xff\xf0')
+assert r.bitpos('z', 0) == 12
+print('ok')
+",
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn redis_py_pipeline() {
     // redis-py's pipeline batches commands and reads replies in order.
     // This exercises the TCP streaming path with multiple frames in flight.


### PR DESCRIPTION
## Summary

- **Strings (+5):** `GETBIT`, `SETBIT`, `BITCOUNT` (+ `BYTE` / `BIT`), `BITPOS` (+ `BYTE` / `BIT`), `BITOP` (`AND` / `OR` / `XOR` / `NOT`)

Bit numbering follows Redis: bit 0 is the MSB of byte 0. `SETBIT` zero-pads the underlying string to fit the requested offset and runs under the same CAS retry loop as other read-modify-write commands. The previous bit value is returned, matching Redis's `:0` / `:1` reply.

`BITPOS` keeps Redis's asymmetric "infinite trailing zeros" rule — when searching for a 0 bit without an explicit end, an all-ones string returns `strlen * 8` rather than `-1`. Pinning an explicit end suppresses that fiction (returns `-1` if no 0 found in range).

`BITCOUNT` and `BITPOS` accept the `BYTE` / `BIT` range modifier (Redis 7.0+); default is `BYTE`. Negative indices count from the end.

`BITOP` reads each source sequentially via `get_string`, pads shorter sources to the longest with zero bytes, and writes the result via `set_string`. `NOT` requires exactly one source. An empty result deletes the destination instead of writing an empty-string entry.

Storage trait gains `setbit` on both backends; `getbit` ships as a default trait method built on `get_string`. Helpers `bit_at` and `apply_setbit` are `pub` so the command layer can reuse them for `BITCOUNT` / `BITPOS`.

## Test plan

- [x] `just check` — fmt + clippy clean
- [x] `just test` — 275/275 passing (was 244 before; +31 new tests)
- [x] Integration suite covers: GETBIT MSB-first ordering + missing-key + wrong-type, SETBIT auto-extend / previous-value reporting / invalid bit-value / negative offset / wrong-type, BITCOUNT whole-key + byte-range + bit-range + missing + empty range + arity, BITPOS first-set / first-clear / all-ones-no-end vs explicit-end / all-zeros-target-1 / byte+bit ranges / missing key, BITOP AND/OR/XOR three-source / NOT single-source / NOT-rejects-multi / unknown op / empty-result-deletes-dest / wrong-type
- [x] redis-py compat: new `redis_py_bit_ops` exercises every command through real `redis.Redis` against the rustyant TCP harness