### PR TITLE
:memo: refresh README test counts (218→275)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,6 @@ The `rustyant` and `rustyant-ws` binaries emit structured JSON logs via `tracing
 
 ## Status
 
-Working: RESP over HTTP and WebSocket, full string/hash/list/set/zset command dispatch plus `KEYS` / `SCAN`, S3-backed storage with per-key TTL and conditional-write CAS on every read-modify-write, 218 Rust tests across 5 suites (18 lib units + 176 HTTP integration + 11 redis-py compat + 6 WebSocket E2E + 7 floci/S3) and 13 Python client tests, structured logs and CloudWatch EMF metrics, CI on GitHub Actions with floci as a service container, SAM template validated in CI.
+Working: RESP over HTTP and WebSocket, full string/hash/list/set/zset command dispatch plus `KEYS` / `SCAN`, S3-backed storage with per-key TTL and conditional-write CAS on every read-modify-write, 275 Rust tests across 5 suites (18 lib units + 231 HTTP integration + 13 redis-py compat + 6 WebSocket E2E + 7 floci/S3) and 13 Python client tests, structured logs and CloudWatch EMF metrics, CI on GitHub Actions with floci as a service container, SAM template validated in CI.
 
 Not wired: no end-to-end test driving a real WebSocket connection against a deployed binary in AWS; the `s3_concurrent_incr_converges` CAS test is gated behind `RUSTYANT_S3_CAS=1` because floci doesn't enforce `If-Match` headers.


### PR DESCRIPTION
## Summary

`Status` line on the README was 3 PRs stale. Refresh the test tallies to match `just test` on current `main`.

- Total: `218` → `275`
- HTTP integration: `176` → `231`
- redis-py compat: `11` → `13`

(Unchanged: 18 lib units, 6 WebSocket E2E, 7 floci/S3, 13 Python client tests.)

## Test plan

- [x] `just test` — 275/275 passing
- [x] Per-suite counts verified against `cargo nextest list`