### PR TITLE
:sparkles: add HSCAN/SSCAN/ZSCAN on Hash/Set/ZSet collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,14 @@ Implemented:
 | Server | `PING`, `ECHO`, `TIME`, `DBSIZE`, `FLUSHDB`, `FLUSHALL` |
 | Keyspace | `KEYS`, `SCAN` (+ `MATCH` / `COUNT` options), `TYPE`, `RENAME`, `RENAMENX`, `RANDOMKEY`, `UNLINK`, `COPY` (+ `REPLACE` / `DB 0`) |
 | Strings | `GET`, `SET` (+ `EX` / `PX` options), `GETSET`, `GETDEL`, `GETRANGE`, `SETRANGE`, `SETNX`, `SETEX`, `MGET`, `MSET`, `MSETNX`, `APPEND`, `STRLEN`, `DEL`, `EXISTS`, `EXPIRE`, `EXPIREAT`, `PEXPIRE`, `PEXPIREAT`, `PERSIST`, `TTL`, `PTTL`, `INCR`, `INCRBY`, `INCRBYFLOAT`, `DECR`, `DECRBY`, `GETBIT`, `SETBIT`, `BITCOUNT` (+ `BYTE` / `BIT`), `BITPOS` (+ `BYTE` / `BIT`), `BITOP` (`AND` / `OR` / `XOR` / `NOT`) |
-| Hashes | `HSET`, `HSETNX`, `HGET`, `HDEL`, `HGETALL`, `HLEN`, `HKEYS`, `HVALS`, `HEXISTS`, `HSTRLEN`, `HMGET`, `HINCRBY` |
+| Hashes | `HSET`, `HSETNX`, `HGET`, `HDEL`, `HGETALL`, `HLEN`, `HKEYS`, `HVALS`, `HEXISTS`, `HSTRLEN`, `HMGET`, `HINCRBY`, `HSCAN` (+ `MATCH` / `COUNT`) |
 | Lists | `LPUSH`, `RPUSH`, `LPUSHX`, `RPUSHX`, `LPOP` (+ count), `RPOP` (+ count), `LRANGE`, `LLEN`, `LINDEX`, `LSET`, `LREM`, `LINSERT`, `LTRIM` |
-| Sets | `SADD`, `SREM`, `SMEMBERS`, `SISMEMBER`, `SMISMEMBER`, `SCARD`, `SINTER`, `SUNION`, `SDIFF`, `SPOP` (+ count), `SRANDMEMBER` (+ count) |
-| Sorted Sets | `ZADD`, `ZREM`, `ZINCRBY`, `ZRANGE`, `ZREVRANGE`, `ZRANGEBYSCORE`, `ZREVRANGEBYSCORE`, `ZREMRANGEBYRANK`, `ZREMRANGEBYSCORE`, `ZPOPMIN` (+ count), `ZPOPMAX` (+ count), `ZSCORE`, `ZMSCORE`, `ZCARD`, `ZCOUNT`, `ZRANK`, `ZREVRANK` |
+| Sets | `SADD`, `SREM`, `SMEMBERS`, `SISMEMBER`, `SMISMEMBER`, `SCARD`, `SINTER`, `SUNION`, `SDIFF`, `SPOP` (+ count), `SRANDMEMBER` (+ count), `SSCAN` (+ `MATCH` / `COUNT`) |
+| Sorted Sets | `ZADD`, `ZREM`, `ZINCRBY`, `ZRANGE`, `ZREVRANGE`, `ZRANGEBYSCORE`, `ZREVRANGEBYSCORE`, `ZREMRANGEBYRANK`, `ZREMRANGEBYSCORE`, `ZPOPMIN` (+ count), `ZPOPMAX` (+ count), `ZSCORE`, `ZMSCORE`, `ZCARD`, `ZCOUNT`, `ZRANK`, `ZREVRANK`, `ZSCAN` (+ `MATCH` / `COUNT`) |
 
 `KEYS` paginates through `ListObjectsV2` in full and filters by the wildmatch pattern — O(n) over the keyspace, safe at low cardinality, proportionally slower for larger buckets. `SCAN` delegates the page boundary to S3 via a continuation token, returning one `ListObjectsV2` page per call; `MATCH` is applied client-side, so the per-page yield may be smaller than `COUNT` when a pattern is narrow.
+
+`HSCAN` / `SSCAN` / `ZSCAN` paginate inside a single collection. The cursor is an integer offset into the caller's iteration and `0` means "start / done", matching Redis. Because each collection is one S3 object, every call loads the full value — pagination is a client-side ergonomic, not a server-side cost saving. `MATCH` is applied after the batch is sliced (Redis semantics), so a narrow pattern can yield fewer than `COUNT` items per page.
 
 `DBSIZE` and `RANDOMKEY` walk the same `ListObjectsV2` pagination: O(n) on the S3 backend, instant on the in-memory backend. Recently-expired keys that haven't been GC'd yet still count toward `DBSIZE`, matching Redis's lazy-expiry semantics. `FLUSHDB` and `FLUSHALL` are aliases here — rustyant exposes one logical namespace — and batch-delete a page (up to 1000 objects) per `DeleteObjects` call. The optional `ASYNC` / `SYNC` modifier is accepted but ignored: the flush is always synchronous over S3. `UNLINK` shares the synchronous `DEL` path; rustyant has no background freer thread.
 
@@ -158,6 +160,6 @@ The `rustyant` and `rustyant-ws` binaries emit structured JSON logs via `tracing
 
 ## Status
 
-Working: RESP over HTTP and WebSocket, full string/hash/list/set/zset command dispatch plus `KEYS` / `SCAN`, S3-backed storage with per-key TTL and conditional-write CAS on every read-modify-write, 275 Rust tests across 5 suites (18 lib units + 231 HTTP integration + 13 redis-py compat + 6 WebSocket E2E + 7 floci/S3) and 13 Python client tests, structured logs and CloudWatch EMF metrics, CI on GitHub Actions with floci as a service container, SAM template validated in CI.
+Working: RESP over HTTP and WebSocket, full string/hash/list/set/zset command dispatch plus `KEYS` / `SCAN` / `HSCAN` / `SSCAN` / `ZSCAN`, S3-backed storage with per-key TTL and conditional-write CAS on every read-modify-write, 287 Rust tests across 5 suites (18 lib units + 242 HTTP integration + 14 redis-py compat + 6 WebSocket E2E + 7 floci/S3) and 13 Python client tests, structured logs and CloudWatch EMF metrics, CI on GitHub Actions with floci as a service container, SAM template validated in CI.
 
 Not wired: no end-to-end test driving a real WebSocket connection against a deployed binary in AWS; the `s3_concurrent_incr_converges` CAS test is gated behind `RUSTYANT_S3_CAS=1` because floci doesn't enforce `If-Match` headers.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -165,6 +165,7 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "HSTRLEN" => handle_hstrlen(state, args).await,
         "HMGET" => handle_hmget(state, args).await,
         "HINCRBY" => handle_hincrby(state, args).await,
+        "HSCAN" => handle_hscan(state, args).await,
         // Lists
         "LPUSH" => handle_push(state, args, true).await,
         "RPUSH" => handle_push(state, args, false).await,
@@ -191,6 +192,7 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "SDIFF" => handle_sdiff(state, args).await,
         "SPOP" => handle_spop(state, args).await,
         "SRANDMEMBER" => handle_srandmember(state, args).await,
+        "SSCAN" => handle_sscan(state, args).await,
         // Sorted sets
         "ZADD" => handle_zadd(state, args).await,
         "ZREM" => handle_zrem(state, args).await,
@@ -209,6 +211,7 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "ZREVRANK" => handle_zrank(state, args, true).await,
         "ZCOUNT" => handle_zcount(state, args).await,
         "ZMSCORE" => handle_zmscore(state, args).await,
+        "ZSCAN" => handle_zscan(state, args).await,
         other => Err(RustyAntError::UnknownCommand(other.to_string())),
     }
 }
@@ -656,10 +659,23 @@ async fn handle_scan(state: &State, args: Vec<Bytes>) -> Result<RespReply, Rusty
     let cursor_arg = arg_as_str(&args[0])?;
     // Redis convention: "0" means start / done.
     let cursor: Option<String> = if cursor_arg == "0" { None } else { Some(cursor_arg.to_string()) };
+    let (pattern, count) = parse_scan_opts(&args, 1, "SCAN")?;
 
+    let (keys, next) = state.storage.scan(cursor.as_deref(), pattern.as_deref(), count).await?;
+    let cursor_out = next.unwrap_or_else(|| "0".to_string());
+    Ok(RespReply::Array(vec![
+        RespReply::BulkString(Some(Bytes::from(cursor_out.into_bytes()))),
+        RespReply::Array(keys.into_iter().map(|k| RespReply::BulkString(Some(Bytes::from(k.into_bytes())))).collect()),
+    ]))
+}
+
+/// Parse the trailing `[MATCH pattern] [COUNT n]` options common to SCAN /
+/// HSCAN / SSCAN / ZSCAN. `from` is the arg index to start at (past the
+/// command's fixed prefix — `1` for SCAN, `2` for collection scans).
+fn parse_scan_opts(args: &[Bytes], from: usize, cmd: &str) -> Result<(Option<String>, usize), RustyAntError> {
     let mut pattern: Option<String> = None;
-    let mut count: usize = 10; // Redis default
-    let mut i = 1;
+    let mut count: usize = 10;
+    let mut i = from;
     while i < args.len() {
         let opt = arg_as_str(&args[i])?.to_ascii_uppercase();
         match opt.as_str() {
@@ -678,17 +694,62 @@ async fn handle_scan(state: &State, args: Vec<Bytes>) -> Result<RespReply, Rusty
                 i += 2;
             }
             other => {
-                return Err(RustyAntError::Parse(format!("unsupported SCAN option: {other}")));
+                return Err(RustyAntError::Parse(format!("unsupported {cmd} option: {other}")));
             }
         }
     }
+    Ok((pattern, count))
+}
 
-    let (keys, next) = state.storage.scan(cursor.as_deref(), pattern.as_deref(), count).await?;
-    let cursor_out = next.unwrap_or_else(|| "0".to_string());
-    Ok(RespReply::Array(vec![
-        RespReply::BulkString(Some(Bytes::from(cursor_out.into_bytes()))),
-        RespReply::Array(keys.into_iter().map(|k| RespReply::BulkString(Some(Bytes::from(k.into_bytes())))).collect()),
-    ]))
+fn parse_scan_cursor(arg: &Bytes) -> Result<u64, RustyAntError> {
+    let n = parse_i64(arg, "cursor")?;
+    u64::try_from(n).map_err(|_| RustyAntError::Parse("cursor must be >= 0".into()))
+}
+
+fn scan_reply(next_cursor: u64, items: Vec<RespReply>) -> RespReply {
+    RespReply::Array(vec![
+        RespReply::BulkString(Some(Bytes::from(next_cursor.to_string().into_bytes()))),
+        RespReply::Array(items),
+    ])
+}
+
+async fn handle_hscan(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("HSCAN", args.len() >= 2)?;
+    let key = arg_as_str(&args[0])?;
+    let cursor = parse_scan_cursor(&args[1])?;
+    let (pattern, count) = parse_scan_opts(&args, 2, "HSCAN")?;
+    let (next, pairs) = state.storage.hscan(key, cursor, pattern.as_deref(), count).await?;
+    let mut flat: Vec<RespReply> = Vec::with_capacity(pairs.len() * 2);
+    for (field, value) in pairs {
+        flat.push(RespReply::BulkString(Some(Bytes::from(field.into_bytes()))));
+        flat.push(RespReply::BulkString(Some(value)));
+    }
+    Ok(scan_reply(next, flat))
+}
+
+async fn handle_sscan(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("SSCAN", args.len() >= 2)?;
+    let key = arg_as_str(&args[0])?;
+    let cursor = parse_scan_cursor(&args[1])?;
+    let (pattern, count) = parse_scan_opts(&args, 2, "SSCAN")?;
+    let (next, members) = state.storage.sscan(key, cursor, pattern.as_deref(), count).await?;
+    let items: Vec<RespReply> =
+        members.into_iter().map(|m| RespReply::BulkString(Some(Bytes::from(m.into_bytes())))).collect();
+    Ok(scan_reply(next, items))
+}
+
+async fn handle_zscan(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("ZSCAN", args.len() >= 2)?;
+    let key = arg_as_str(&args[0])?;
+    let cursor = parse_scan_cursor(&args[1])?;
+    let (pattern, count) = parse_scan_opts(&args, 2, "ZSCAN")?;
+    let (next, pairs) = state.storage.zscan(key, cursor, pattern.as_deref(), count).await?;
+    let mut flat: Vec<RespReply> = Vec::with_capacity(pairs.len() * 2);
+    for (member, score) in pairs {
+        flat.push(RespReply::BulkString(Some(Bytes::from(member.into_bytes()))));
+        flat.push(RespReply::BulkString(Some(Bytes::from(format_score(score).into_bytes()))));
+    }
+    Ok(scan_reply(next, flat))
 }
 
 async fn handle_lindex(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -532,6 +532,20 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn hstrlen(&self, key: &str, field: &str) -> Result<i64, RustyAntError>;
     async fn hmget(&self, key: &str, fields: &[String]) -> Result<Vec<Option<Bytes>>, RustyAntError>;
     async fn hincr_by(&self, key: &str, field: &str, delta: i64) -> Result<i64, RustyAntError>;
+    /// Incremental iteration over a hash's `(field, value)` pairs. `cursor=0`
+    /// starts a fresh scan; a non-zero return cursor means more pages remain,
+    /// `0` means the scan is exhausted. `count` bounds the batch size; `MATCH`
+    /// filtering runs after the batch is sliced, matching Redis's "COUNT is
+    /// advisory, MATCH can shrink a page" semantic. Both backends load the
+    /// full hash per call — pagination is a client-side ergonomic, not a
+    /// server-side cost saving, because the collection is one S3 object.
+    async fn hscan(
+        &self,
+        key: &str,
+        cursor: u64,
+        pattern: Option<&str>,
+        count: usize,
+    ) -> Result<(u64, Vec<(String, Bytes)>), RustyAntError>;
 
     async fn list_push(&self, key: &str, values: Vec<Bytes>, left: bool) -> Result<i64, RustyAntError>;
     async fn list_pushx(&self, key: &str, values: Vec<Bytes>, left: bool) -> Result<i64, RustyAntError>;
@@ -555,6 +569,14 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn sdiff(&self, keys: &[String]) -> Result<Vec<String>, RustyAntError>;
     async fn spop(&self, key: &str, count: usize) -> Result<Vec<String>, RustyAntError>;
     async fn srandmember(&self, key: &str, count: i64, allow_duplicates: bool) -> Result<Vec<String>, RustyAntError>;
+    /// See [`Self::hscan`] for `cursor` / `count` / `pattern` semantics.
+    async fn sscan(
+        &self,
+        key: &str,
+        cursor: u64,
+        pattern: Option<&str>,
+        count: usize,
+    ) -> Result<(u64, Vec<String>), RustyAntError>;
 
     async fn zadd(&self, key: &str, pairs: Vec<(f64, String)>) -> Result<i64, RustyAntError>;
     async fn zrem(&self, key: &str, members: &[String]) -> Result<i64, RustyAntError>;
@@ -574,6 +596,16 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn zrevrank(&self, key: &str, member: &str) -> Result<Option<i64>, RustyAntError>;
     async fn zcount(&self, key: &str, min: ScoreBound, max: ScoreBound) -> Result<i64, RustyAntError>;
     async fn zmscore(&self, key: &str, members: &[String]) -> Result<Vec<Option<f64>>, RustyAntError>;
+    /// See [`Self::hscan`] for pagination semantics. Iteration order follows
+    /// member lex order under the backing `BTreeMap`; Redis doesn't pin an
+    /// order, so callers that care must sort the accumulated result.
+    async fn zscan(
+        &self,
+        key: &str,
+        cursor: u64,
+        pattern: Option<&str>,
+        count: usize,
+    ) -> Result<(u64, Vec<(String, f64)>), RustyAntError>;
 
     /// Return every key matching `pattern` (Redis-style glob: `*`, `?`).
     /// On S3 this fans out to repeated `ListObjectsV2` calls until the
@@ -639,6 +671,40 @@ pub fn bit_at(data: &[u8], offset: u64) -> u8 {
     }
     let bit_in_byte = 7 - (offset % 8) as u8;
     (data[byte_idx] >> bit_in_byte) & 1
+}
+
+/// Paginate a deterministic collection for `HSCAN` / `SSCAN` / `ZSCAN`.
+/// `cursor` is an integer offset into the caller's sorted iteration; `count`
+/// bounds the batch before `MATCH` filtering is applied — Redis applies the
+/// pattern after the batch is sliced, so a single page can return fewer
+/// items than `count`.
+fn apply_collection_scan<T, F>(
+    items: Vec<T>,
+    cursor: u64,
+    count: usize,
+    pattern: Option<&str>,
+    extract_name: F,
+) -> (u64, Vec<T>)
+where
+    F: Fn(&T) -> &str,
+{
+    let total = items.len();
+    let offset = usize::try_from(cursor).unwrap_or(total);
+    if offset >= total {
+        return (0, Vec::new());
+    }
+    let end = offset.saturating_add(count).min(total);
+    let next_cursor = if end >= total { 0 } else { u64::try_from(end).unwrap_or(0) };
+    let batch = items.into_iter().skip(offset).take(end - offset);
+    // `*` matches everything — skip the WildMatch compile + per-item check.
+    let filtered: Vec<T> = match pattern {
+        Some(p) if p != "*" => {
+            let wm = wildmatch::WildMatch::new(p);
+            batch.filter(|x| wm.matches(extract_name(x))).collect()
+        }
+        _ => batch.collect(),
+    };
+    (next_cursor, filtered)
 }
 
 /// Mutate the bit at `offset` to `value` in `data`, zero-padding the buffer
@@ -1013,6 +1079,23 @@ impl Storage for S3Storage {
         }
     }
 
+    async fn hscan(
+        &self,
+        key: &str,
+        cursor: u64,
+        pattern: Option<&str>,
+        count: usize,
+    ) -> Result<(u64, Vec<(String, Bytes)>), RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::Hash(m), .. }) => {
+                let items: Vec<(String, Bytes)> = m.into_iter().map(|(k, v)| (k, Bytes::from(v))).collect();
+                Ok(apply_collection_scan(items, cursor, count, pattern, |(f, _)| f.as_str()))
+            }
+            Some(_) => Err(wrong_type(key)),
+            None => Ok((0, Vec::new())),
+        }
+    }
+
     async fn list_push(&self, key: &str, values: Vec<Bytes>, left: bool) -> Result<i64, RustyAntError> {
         self.cas(key, move |entry| {
             let (mut list, expires_at_ms) = match entry {
@@ -1195,6 +1278,23 @@ impl Storage for S3Storage {
         }
     }
 
+    async fn sscan(
+        &self,
+        key: &str,
+        cursor: u64,
+        pattern: Option<&str>,
+        count: usize,
+    ) -> Result<(u64, Vec<String>), RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::Set(s), .. }) => {
+                let items: Vec<String> = s.into_iter().collect();
+                Ok(apply_collection_scan(items, cursor, count, pattern, String::as_str))
+            }
+            Some(_) => Err(wrong_type(key)),
+            None => Ok((0, Vec::new())),
+        }
+    }
+
     async fn sismember(&self, key: &str, member: &str) -> Result<bool, RustyAntError> {
         match self.load(key).await? {
             Some(StoredValue { value: Value::Set(s), .. }) => Ok(s.contains(member)),
@@ -1261,6 +1361,23 @@ impl Storage for S3Storage {
             }
             Some(_) => Err(wrong_type(key)),
             None => Ok(members.iter().map(|_| None).collect()),
+        }
+    }
+
+    async fn zscan(
+        &self,
+        key: &str,
+        cursor: u64,
+        pattern: Option<&str>,
+        count: usize,
+    ) -> Result<(u64, Vec<(String, f64)>), RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::ZSet(m), .. }) => {
+                let items: Vec<(String, f64)> = m.into_iter().collect();
+                Ok(apply_collection_scan(items, cursor, count, pattern, |(mem, _)| mem.as_str()))
+            }
+            Some(_) => Err(wrong_type(key)),
+            None => Ok((0, Vec::new())),
         }
     }
 
@@ -2142,6 +2259,23 @@ impl Storage for InMemoryStorage {
         }
     }
 
+    async fn hscan(
+        &self,
+        key: &str,
+        cursor: u64,
+        pattern: Option<&str>,
+        count: usize,
+    ) -> Result<(u64, Vec<(String, Bytes)>), RustyAntError> {
+        match self.load(key) {
+            Some(StoredValue { value: Value::Hash(m), .. }) => {
+                let items: Vec<(String, Bytes)> = m.into_iter().map(|(k, v)| (k, Bytes::from(v))).collect();
+                Ok(apply_collection_scan(items, cursor, count, pattern, |(f, _)| f.as_str()))
+            }
+            Some(_) => Err(wrong_type(key)),
+            None => Ok((0, Vec::new())),
+        }
+    }
+
     async fn list_push(&self, key: &str, values: Vec<Bytes>, left: bool) -> Result<i64, RustyAntError> {
         let (mut list, expires_at_ms) = match self.load(key) {
             Some(StoredValue { value: Value::List(l), expires_at_ms }) => (l, expires_at_ms),
@@ -2326,6 +2460,23 @@ impl Storage for InMemoryStorage {
         }
     }
 
+    async fn sscan(
+        &self,
+        key: &str,
+        cursor: u64,
+        pattern: Option<&str>,
+        count: usize,
+    ) -> Result<(u64, Vec<String>), RustyAntError> {
+        match self.load(key) {
+            Some(StoredValue { value: Value::Set(s), .. }) => {
+                let items: Vec<String> = s.into_iter().collect();
+                Ok(apply_collection_scan(items, cursor, count, pattern, String::as_str))
+            }
+            Some(_) => Err(wrong_type(key)),
+            None => Ok((0, Vec::new())),
+        }
+    }
+
     async fn sismember(&self, key: &str, member: &str) -> Result<bool, RustyAntError> {
         match self.load(key) {
             Some(StoredValue { value: Value::Set(s), .. }) => Ok(s.contains(member)),
@@ -2381,6 +2532,23 @@ impl Storage for InMemoryStorage {
             }
             Some(_) => Err(wrong_type(key)),
             None => Ok(members.iter().map(|_| None).collect()),
+        }
+    }
+
+    async fn zscan(
+        &self,
+        key: &str,
+        cursor: u64,
+        pattern: Option<&str>,
+        count: usize,
+    ) -> Result<(u64, Vec<(String, f64)>), RustyAntError> {
+        match self.load(key) {
+            Some(StoredValue { value: Value::ZSet(m), .. }) => {
+                let items: Vec<(String, f64)> = m.into_iter().collect();
+                Ok(apply_collection_scan(items, cursor, count, pattern, |(mem, _)| mem.as_str()))
+            }
+            Some(_) => Err(wrong_type(key)),
+            None => Ok((0, Vec::new())),
         }
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1173,6 +1173,161 @@ async fn scan_empty_store_returns_done() {
     assert!(next.is_none());
 }
 
+// ---------------------------------------------------------------------------
+// HSCAN / SSCAN / ZSCAN
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn hscan_paginates_full_hash() {
+    let state = test_state();
+    let mut args: Vec<&[u8]> = vec![b"HSET", b"h"];
+    let pairs: Vec<(String, String)> = (0..12).map(|i| (format!("f{i:02}"), format!("v{i:02}"))).collect();
+    let owned: Vec<Vec<u8>> = pairs.iter().flat_map(|(k, v)| [k.as_bytes().to_vec(), v.as_bytes().to_vec()]).collect();
+    for b in &owned {
+        args.push(b.as_slice());
+    }
+    call(&state, &args).await;
+
+    let mut seen: Vec<(String, Bytes)> = Vec::new();
+    let mut cursor: u64 = 0;
+    loop {
+        let (next, batch) = state.storage.hscan("h", cursor, None, 5).await.expect("hscan");
+        seen.extend(batch);
+        if next == 0 {
+            break;
+        }
+        cursor = next;
+    }
+    seen.sort_by(|a, b| a.0.cmp(&b.0));
+    let want: Vec<(String, Bytes)> = pairs.into_iter().map(|(k, v)| (k, Bytes::from(v.into_bytes()))).collect();
+    assert_eq!(seen, want);
+}
+
+#[tokio::test]
+async fn hscan_match_filter_narrows_batch() {
+    let state = test_state();
+    call(&state, &[b"HSET", b"h", b"user:1", b"a", b"user:2", b"b", b"other", b"c"]).await;
+    let (next, batch) = state.storage.hscan("h", 0, Some("user:*"), 100).await.expect("hscan");
+    assert_eq!(next, 0);
+    let mut fields: Vec<String> = batch.into_iter().map(|(f, _)| f).collect();
+    fields.sort();
+    assert_eq!(fields, vec!["user:1".to_string(), "user:2".to_string()]);
+}
+
+#[tokio::test]
+async fn hscan_missing_key_returns_done() {
+    let state = test_state();
+    let (next, batch) = state.storage.hscan("nope", 0, None, 10).await.expect("hscan");
+    assert_eq!(next, 0);
+    assert!(batch.is_empty());
+}
+
+#[tokio::test]
+async fn hscan_wrong_type_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"s", b"v"]).await;
+    let res = state.storage.hscan("s", 0, None, 10).await;
+    assert!(res.is_err(), "expected WRONGTYPE, got {res:?}");
+}
+
+#[tokio::test]
+async fn sscan_paginates_full_set() {
+    let state = test_state();
+    let mut args: Vec<&[u8]> = vec![b"SADD", b"s"];
+    let members: Vec<String> = (0..12).map(|i| format!("m{i:02}")).collect();
+    let owned: Vec<Vec<u8>> = members.iter().map(|m| m.as_bytes().to_vec()).collect();
+    for b in &owned {
+        args.push(b.as_slice());
+    }
+    call(&state, &args).await;
+
+    let mut seen: Vec<String> = Vec::new();
+    let mut cursor: u64 = 0;
+    loop {
+        let (next, batch) = state.storage.sscan("s", cursor, None, 5).await.expect("sscan");
+        seen.extend(batch);
+        if next == 0 {
+            break;
+        }
+        cursor = next;
+    }
+    seen.sort();
+    let mut want = members;
+    want.sort();
+    assert_eq!(seen, want);
+}
+
+#[tokio::test]
+async fn sscan_match_filter_narrows_batch() {
+    let state = test_state();
+    call(&state, &[b"SADD", b"s", b"user:1", b"user:2", b"other"]).await;
+    let (next, batch) = state.storage.sscan("s", 0, Some("user:*"), 100).await.expect("sscan");
+    assert_eq!(next, 0);
+    let mut m = batch;
+    m.sort();
+    assert_eq!(m, vec!["user:1".to_string(), "user:2".to_string()]);
+}
+
+#[tokio::test]
+async fn zscan_paginates_with_scores() {
+    let state = test_state();
+    for (score, member) in [(1, "a"), (2, "b"), (3, "c"), (4, "d"), (5, "e"), (6, "f")] {
+        call(&state, &[b"ZADD", b"z", score.to_string().as_bytes(), member.as_bytes()]).await;
+    }
+    let mut seen: Vec<(String, f64)> = Vec::new();
+    let mut cursor: u64 = 0;
+    loop {
+        let (next, batch) = state.storage.zscan("z", cursor, None, 2).await.expect("zscan");
+        seen.extend(batch);
+        if next == 0 {
+            break;
+        }
+        cursor = next;
+    }
+    seen.sort_by(|a, b| a.0.cmp(&b.0));
+    let want: Vec<(String, f64)> = vec![("a", 1.0), ("b", 2.0), ("c", 3.0), ("d", 4.0), ("e", 5.0), ("f", 6.0)]
+        .into_iter()
+        .map(|(m, s)| (m.to_string(), s))
+        .collect();
+    assert_eq!(seen, want);
+}
+
+#[tokio::test]
+async fn hscan_wire_reply_has_cursor_and_pairs() {
+    // End-to-end wire check: a single-page HSCAN must return
+    // `[b"0", [field, value, field, value, ...]]` as a nested array.
+    let state = test_state();
+    call(&state, &[b"HSET", b"h", b"f1", b"v1", b"f2", b"v2"]).await;
+    let decoded = call(&state, &[b"HSCAN", b"h", b"0"]).await;
+    // Reply shape: *2\r\n$1\r\n0\r\n*4\r\n$...
+    assert!(
+        decoded.raw.starts_with(b"*2\r\n$1\r\n0\r\n*4\r\n"),
+        "unexpected wire: {:?}",
+        String::from_utf8_lossy(&decoded.raw)
+    );
+}
+
+#[tokio::test]
+async fn sscan_wrong_arity_errors() {
+    let state = test_state();
+    call(&state, &[b"SSCAN"]).await.expect_error_prefix("wrong number");
+    call(&state, &[b"SSCAN", b"k"]).await.expect_error_prefix("wrong number");
+}
+
+#[tokio::test]
+async fn zscan_negative_cursor_rejected() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"a"]).await;
+    call(&state, &[b"ZSCAN", b"z", b"-1"]).await.expect_error_prefix("cursor");
+}
+
+#[tokio::test]
+async fn hscan_unknown_option_rejected() {
+    let state = test_state();
+    call(&state, &[b"HSET", b"h", b"f", b"v"]).await;
+    call(&state, &[b"HSCAN", b"h", b"0", b"NOVALUES"]).await.expect_error_prefix("unsupported HSCAN");
+}
+
 #[tokio::test]
 async fn type_returns_none_for_missing_key() {
     let state = test_state();

--- a/tests/redis_py_compat.rs
+++ b/tests/redis_py_compat.rs
@@ -418,6 +418,36 @@ print('ok')
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn redis_py_collection_scans() {
+    // redis-py's `*scan_iter` helpers call the underlying command until the
+    // cursor returns to 0 — the contract we implement. Running through them
+    // catches cursor-string / pair-flattening / score-formatting mismatches
+    // that a unit test against our own parser would miss.
+    run_redis_py_script(
+        r"
+import redis
+r = redis.Redis(host='127.0.0.1', port={port}, socket_timeout=5)
+
+r.hset('h', mapping={'user:1': 'a', 'user:2': 'b', 'other': 'c'})
+assert dict(r.hscan_iter('h')) == {b'user:1': b'a', b'user:2': b'b', b'other': b'c'}
+assert dict(r.hscan_iter('h', match='user:*')) == {b'user:1': b'a', b'user:2': b'b'}
+cursor, page = r.hscan('h', 0, count=100)
+assert cursor == 0
+assert dict(zip(page.keys(), page.values())) == {b'user:1': b'a', b'user:2': b'b', b'other': b'c'}
+
+r.sadd('s', 'alpha', 'beta', 'gamma')
+assert set(r.sscan_iter('s')) == {b'alpha', b'beta', b'gamma'}
+assert set(r.sscan_iter('s', match='a*')) == {b'alpha'}
+
+r.zadd('z', {'alice': 1.5, 'bob': 2, 'carol': 3.25})
+assert dict(r.zscan_iter('z')) == {b'alice': 1.5, b'bob': 2.0, b'carol': 3.25}
+print('ok')
+",
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn redis_py_pipeline() {
     // redis-py's pipeline batches commands and reads replies in order.
     // This exercises the TCP streaming path with multiple frames in flight.


### PR DESCRIPTION
## Summary

- Adds HSCAN / SSCAN / ZSCAN with MATCH + COUNT, returning the standard Redis `[cursor, [items...]]` envelope. ZSCAN interleaves `(member, score)` pairs via the shared \`format_score\` helper.
- Pagination is client-side ergonomics only: each call loads the full S3 object for the collection, because the collection is one object. Cursor stability across calls is guaranteed by the `BTreeMap` / `BTreeSet` backing.
- Refactors SCAN to share the new `parse_scan_opts` helper (drops ~20 lines of duplicated MATCH/COUNT parsing).

## Test plan

- [x] 12 new Rust tests (11 integration + 1 redis-py compat): pagination across multiple pages, MATCH filtering, missing key, wrong-type, wrong-arity, negative cursor, unknown option, wire-shape smoke, and end-to-end via real `hscan_iter` / `sscan_iter` / `zscan_iter` from redis-py.
- [x] Full suite green: 287 passed (18 lib + 242 integration + 14 redis-py + 6 ws + 7 floci).
- [x] `just check` clean (fmt + clippy `-D warnings`, `--all-targets --all-features`).