### PR TITLE
:sparkles: add LMOVE/RPOPLPUSH/LPOS on Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Implemented:
 | Keyspace | `KEYS`, `SCAN` (+ `MATCH` / `COUNT` options), `TYPE`, `RENAME`, `RENAMENX`, `RANDOMKEY`, `UNLINK`, `COPY` (+ `REPLACE` / `DB 0`) |
 | Strings | `GET`, `SET` (+ `EX` / `PX` options), `GETSET`, `GETDEL`, `GETRANGE`, `SETRANGE`, `SETNX`, `SETEX`, `MGET`, `MSET`, `MSETNX`, `APPEND`, `STRLEN`, `DEL`, `EXISTS`, `EXPIRE`, `EXPIREAT`, `PEXPIRE`, `PEXPIREAT`, `PERSIST`, `TTL`, `PTTL`, `INCR`, `INCRBY`, `INCRBYFLOAT`, `DECR`, `DECRBY`, `GETBIT`, `SETBIT`, `BITCOUNT` (+ `BYTE` / `BIT`), `BITPOS` (+ `BYTE` / `BIT`), `BITOP` (`AND` / `OR` / `XOR` / `NOT`) |
 | Hashes | `HSET`, `HSETNX`, `HGET`, `HDEL`, `HGETALL`, `HLEN`, `HKEYS`, `HVALS`, `HEXISTS`, `HSTRLEN`, `HMGET`, `HINCRBY`, `HSCAN` (+ `MATCH` / `COUNT`) |
-| Lists | `LPUSH`, `RPUSH`, `LPUSHX`, `RPUSHX`, `LPOP` (+ count), `RPOP` (+ count), `LRANGE`, `LLEN`, `LINDEX`, `LSET`, `LREM`, `LINSERT`, `LTRIM` |
+| Lists | `LPUSH`, `RPUSH`, `LPUSHX`, `RPUSHX`, `LPOP` (+ count), `RPOP` (+ count), `LRANGE`, `LLEN`, `LINDEX`, `LSET`, `LREM`, `LINSERT`, `LTRIM`, `LMOVE`, `RPOPLPUSH`, `LPOS` (+ `RANK` / `COUNT` / `MAXLEN`) |
 | Sets | `SADD`, `SREM`, `SMEMBERS`, `SISMEMBER`, `SMISMEMBER`, `SCARD`, `SINTER`, `SUNION`, `SDIFF`, `SPOP` (+ count), `SRANDMEMBER` (+ count), `SSCAN` (+ `MATCH` / `COUNT`) |
 | Sorted Sets | `ZADD`, `ZREM`, `ZINCRBY`, `ZRANGE`, `ZREVRANGE`, `ZRANGEBYSCORE`, `ZREVRANGEBYSCORE`, `ZREMRANGEBYRANK`, `ZREMRANGEBYSCORE`, `ZPOPMIN` (+ count), `ZPOPMAX` (+ count), `ZSCORE`, `ZMSCORE`, `ZCARD`, `ZCOUNT`, `ZRANK`, `ZREVRANK`, `ZSCAN` (+ `MATCH` / `COUNT`) |
 
@@ -76,6 +76,8 @@ Not implemented (PRs welcome): pub/sub, transactions, scripting, streams, geo.
 `MSET` is **not atomic across keys** — a failure partway through leaves earlier keys set. Real Redis is atomic here; rustyant's S3 backing makes the all-or-none semantic expensive, and the fire-and-forget variant is fine for most workloads. `MSETNX`, `RENAME` / `RENAMENX`, and `COPY` are similarly best-effort on the S3 backend: the in-memory path is fully atomic under its `Mutex`, but on S3 a concurrent writer landing between the existence check and the write can leak past the `NX` guard. `RENAMENX` and `COPY` (without `REPLACE`) use `If-None-Match: *` on the destination to shrink that window, so the failure mode is "operation reports 0 / error" rather than data loss.
 
 Bit operations follow Redis's bit numbering: bit 0 is the most significant bit of byte 0. `SETBIT` zero-pads the underlying string to fit the requested offset and runs under the same CAS as other read-modify-write commands. `BITPOS` keeps Redis's asymmetric "infinite trailing zeros" behavior — when searching for a 0 bit without an explicit end, an all-ones string returns `strlen * 8` rather than `-1`; pinning an explicit end suppresses that fiction. `BITOP` reads each source sequentially, pads shorter sources to the longest with zero bytes, and stores the result; an empty result removes the destination instead of writing an empty-string entry.
+
+`LMOVE` / `RPOPLPUSH` are fully atomic when source and destination are the same key (single CAS). Cross-key moves pop from source first, then push to destination — same best-effort guarantee as `RENAME` / `COPY` on the S3 backend. A type-mismatch on the destination is detected before the pop so the source stays intact; a concurrent writer swapping the destination's type between the check and the push can still surface an error after the element has been removed from source. `LPOS` follows Redis semantics: without `COUNT` the reply is the first matching index (`nil` when absent), with `COUNT` it is always an array. `RANK` may be negative (tail→head search) but not zero; `MAXLEN 0` scans the whole list.
 
 ### Concurrency
 
@@ -160,6 +162,6 @@ The `rustyant` and `rustyant-ws` binaries emit structured JSON logs via `tracing
 
 ## Status
 
-Working: RESP over HTTP and WebSocket, full string/hash/list/set/zset command dispatch plus `KEYS` / `SCAN` / `HSCAN` / `SSCAN` / `ZSCAN`, S3-backed storage with per-key TTL and conditional-write CAS on every read-modify-write, 287 Rust tests across 5 suites (18 lib units + 242 HTTP integration + 14 redis-py compat + 6 WebSocket E2E + 7 floci/S3) and 13 Python client tests, structured logs and CloudWatch EMF metrics, CI on GitHub Actions with floci as a service container, SAM template validated in CI.
+Working: RESP over HTTP and WebSocket, full string/hash/list/set/zset command dispatch plus `KEYS` / `SCAN` / `HSCAN` / `SSCAN` / `ZSCAN`, S3-backed storage with per-key TTL and conditional-write CAS on every read-modify-write, 309 Rust tests across 5 suites (18 lib units + 264 HTTP integration + 14 redis-py compat + 6 WebSocket E2E + 7 floci/S3) and 13 Python client tests, structured logs and CloudWatch EMF metrics, CI on GitHub Actions with floci as a service container, SAM template validated in CI.
 
 Not wired: no end-to-end test driving a real WebSocket connection against a deployed binary in AWS; the `s3_concurrent_incr_converges` CAS test is gated behind `RUSTYANT_S3_CAS=1` because floci doesn't enforce `If-Match` headers.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -180,6 +180,9 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "LREM" => handle_lrem(state, args).await,
         "LINSERT" => handle_linsert(state, args).await,
         "LTRIM" => handle_ltrim(state, args).await,
+        "LMOVE" => handle_lmove(state, args).await,
+        "RPOPLPUSH" => handle_rpoplpush(state, args).await,
+        "LPOS" => handle_lpos(state, args).await,
         // Sets
         "SADD" => handle_sadd(state, args).await,
         "SREM" => handle_srem(state, args).await,
@@ -807,6 +810,83 @@ async fn handle_pushx(state: &State, args: Vec<Bytes>, left: bool) -> Result<Res
     let values: Vec<Bytes> = args.into_iter().skip(1).collect();
     let len = state.storage.list_pushx(&key, values, left).await?;
     Ok(RespReply::Integer(len))
+}
+
+fn parse_side(arg: &Bytes, label: &str) -> Result<bool, RustyAntError> {
+    match arg_as_str(arg)?.to_ascii_uppercase().as_str() {
+        "LEFT" => Ok(true),
+        "RIGHT" => Ok(false),
+        other => Err(RustyAntError::Parse(format!("{label} must be LEFT or RIGHT, got {other}"))),
+    }
+}
+
+async fn handle_lmove(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("LMOVE", args.len() == 4)?;
+    let from = arg_as_str(&args[0])?;
+    let to = arg_as_str(&args[1])?;
+    let from_left = parse_side(&args[2], "LMOVE source side")?;
+    let to_left = parse_side(&args[3], "LMOVE destination side")?;
+    let moved = state.storage.list_move(from, to, from_left, to_left).await?;
+    Ok(moved.map_or(RespReply::Nil, |b| RespReply::BulkString(Some(b))))
+}
+
+async fn handle_rpoplpush(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("RPOPLPUSH", args.len() == 2)?;
+    let from = arg_as_str(&args[0])?;
+    let to = arg_as_str(&args[1])?;
+    // RPOPLPUSH = LMOVE src dst RIGHT LEFT.
+    let moved = state.storage.list_move(from, to, false, true).await?;
+    Ok(moved.map_or(RespReply::Nil, |b| RespReply::BulkString(Some(b))))
+}
+
+async fn handle_lpos(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("LPOS", args.len() >= 2)?;
+    let key = arg_as_str(&args[0])?;
+    let element = args[1].clone();
+    let mut rank: i64 = 1;
+    let mut count: Option<usize> = None;
+    let mut maxlen: usize = 0;
+    let mut i = 2;
+    while i < args.len() {
+        let opt = arg_as_str(&args[i])?.to_ascii_uppercase();
+        match opt.as_str() {
+            "RANK" => {
+                let v = args.get(i + 1).ok_or_else(|| RustyAntError::Parse("RANK requires a value".into()))?;
+                rank = parse_i64(v, "RANK")?;
+                if rank == 0 {
+                    return Err(RustyAntError::Parse("RANK can't be zero".into()));
+                }
+                i += 2;
+            }
+            "COUNT" => {
+                let v = args.get(i + 1).ok_or_else(|| RustyAntError::Parse("COUNT requires a value".into()))?;
+                let n = parse_i64(v, "COUNT")?;
+                if n < 0 {
+                    return Err(RustyAntError::Parse("COUNT can't be negative".into()));
+                }
+                count = Some(usize::try_from(n).unwrap_or(0));
+                i += 2;
+            }
+            "MAXLEN" => {
+                let v = args.get(i + 1).ok_or_else(|| RustyAntError::Parse("MAXLEN requires a value".into()))?;
+                let n = parse_i64(v, "MAXLEN")?;
+                if n < 0 {
+                    return Err(RustyAntError::Parse("MAXLEN can't be negative".into()));
+                }
+                maxlen = usize::try_from(n).unwrap_or(0);
+                i += 2;
+            }
+            other => return Err(RustyAntError::Parse(format!("unsupported LPOS option: {other}"))),
+        }
+    }
+    let hits = state.storage.lpos(key, &element, rank, count, maxlen).await?;
+    // Without COUNT: first match as integer, or nil when none found.
+    // With COUNT: always an array (possibly empty).
+    if count.is_some() {
+        Ok(RespReply::Array(hits.into_iter().map(RespReply::Integer).collect()))
+    } else {
+        Ok(hits.into_iter().next().map_or(RespReply::Nil, RespReply::Integer))
+    }
 }
 
 async fn handle_smismember(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -557,6 +557,31 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn lrem(&self, key: &str, count: i64, value: Bytes) -> Result<i64, RustyAntError>;
     async fn linsert(&self, key: &str, before: bool, pivot: Bytes, value: Bytes) -> Result<i64, RustyAntError>;
     async fn ltrim(&self, key: &str, start: i64, stop: i64) -> Result<(), RustyAntError>;
+    /// Atomically pop one element from `from` (head if `from_left`, else tail)
+    /// and push it onto `to` (head if `to_left`, else tail). Returns the moved
+    /// element, or `None` when `from` is missing / empty. Same-key moves run
+    /// under a single CAS; cross-key moves are two-step on S3 (pop first, then
+    /// push) — same best-effort guarantee as `RENAME` / `COPY`.
+    async fn list_move(
+        &self,
+        from: &str,
+        to: &str,
+        from_left: bool,
+        to_left: bool,
+    ) -> Result<Option<Bytes>, RustyAntError>;
+    /// Return zero-based positions of `element` inside the list at `key`.
+    /// `rank` picks the k-th match (`1` = first forward, `-1` = first backward,
+    /// never `0`); `count` = `None` means "return the first match only",
+    /// `Some(0)` means "all matches", `Some(n)` means "up to n matches".
+    /// `maxlen` bounds how many elements are compared (`0` = unlimited).
+    async fn lpos(
+        &self,
+        key: &str,
+        element: &[u8],
+        rank: i64,
+        count: Option<usize>,
+        maxlen: usize,
+    ) -> Result<Vec<i64>, RustyAntError>;
 
     async fn sadd(&self, key: &str, members: Vec<String>) -> Result<i64, RustyAntError>;
     async fn srem(&self, key: &str, members: &[String]) -> Result<i64, RustyAntError>;
@@ -705,6 +730,44 @@ where
         _ => batch.collect(),
     };
     (next_cursor, filtered)
+}
+
+/// Collect zero-based positions of `element` inside `list` for `LPOS`.
+///
+/// `rank` selects the k-th occurrence in the search direction (positive =
+/// head→tail, negative = tail→head). `wanted` is the maximum number of
+/// positions to return — the handler maps `LPOS`'s `COUNT 0` to `usize::MAX`
+/// ("all matches") and `COUNT` absent to `1` ("single match"). `limit` is
+/// `MAXLEN`; `0` means unlimited.
+pub fn scan_list_positions(list: &[Vec<u8>], element: &[u8], rank: i64, wanted: usize, limit: usize) -> Vec<i64> {
+    if rank == 0 || list.is_empty() || wanted == 0 {
+        return Vec::new();
+    }
+    let forward = rank > 0;
+    let skip = usize::try_from(rank.unsigned_abs()).unwrap_or(usize::MAX).saturating_sub(1);
+    let cap = if limit == 0 { usize::MAX } else { limit };
+
+    let mut hits: Vec<i64> = Vec::new();
+    let mut seen = 0_usize;
+    let indices: Box<dyn Iterator<Item = usize>> =
+        if forward { Box::new(0..list.len()) } else { Box::new((0..list.len()).rev()) };
+
+    for (compared, idx) in indices.enumerate() {
+        if compared >= cap {
+            break;
+        }
+        if list[idx].as_slice() == element {
+            if seen < skip {
+                seen += 1;
+                continue;
+            }
+            hits.push(i64::try_from(idx).unwrap_or(i64::MAX));
+            if hits.len() >= wanted {
+                break;
+            }
+        }
+    }
+    hits
 }
 
 /// Mutate the bit at `offset` to `value` in `data`, zero-padding the buffer
@@ -1613,6 +1676,102 @@ impl Storage for S3Storage {
             Ok(CasAction::Write(new_entry, len))
         })
         .await
+    }
+
+    async fn list_move(
+        &self,
+        from: &str,
+        to: &str,
+        from_left: bool,
+        to_left: bool,
+    ) -> Result<Option<Bytes>, RustyAntError> {
+        if from == to {
+            return self
+                .cas(from, move |entry| {
+                    let (mut list, expires_at_ms) = match entry {
+                        Some(StoredValue { value: Value::List(l), expires_at_ms }) => (l.clone(), *expires_at_ms),
+                        Some(_) => return Err(wrong_type(from)),
+                        None => return Ok(CasAction::NoOp(None)),
+                    };
+                    if list.is_empty() {
+                        return Ok(CasAction::NoOp(None));
+                    }
+                    let popped = if from_left { list.remove(0) } else { list.pop().expect("non-empty") };
+                    if to_left {
+                        list.insert(0, popped.clone());
+                    } else {
+                        list.push(popped.clone());
+                    }
+                    let new_entry = StoredValue { expires_at_ms, value: Value::List(list) };
+                    Ok(CasAction::Write(new_entry, Some(Bytes::from(popped))))
+                })
+                .await;
+        }
+        // Pre-check dst type so we don't pop from src just to discover dst is
+        // the wrong type. TOCTOU: a concurrent writer could still swap dst to
+        // a non-list between here and the push — the push CAS closure will
+        // surface that as wrong_type, after the pop has already landed. Same
+        // best-effort guarantee as RENAME/COPY on S3.
+        match self.load(to).await? {
+            Some(StoredValue { value: Value::List(_), .. }) | None => {}
+            Some(_) => return Err(wrong_type(to)),
+        }
+        let popped: Option<Vec<u8>> = self
+            .cas(from, move |entry| {
+                let (mut list, expires_at_ms) = match entry {
+                    Some(StoredValue { value: Value::List(l), expires_at_ms }) => (l.clone(), *expires_at_ms),
+                    Some(_) => return Err(wrong_type(from)),
+                    None => return Ok(CasAction::NoOp(None)),
+                };
+                if list.is_empty() {
+                    return Ok(CasAction::NoOp(None));
+                }
+                let popped = if from_left { list.remove(0) } else { list.pop().expect("non-empty") };
+                if list.is_empty() {
+                    Ok(CasAction::Delete(Some(popped)))
+                } else {
+                    let new_entry = StoredValue { expires_at_ms, value: Value::List(list) };
+                    Ok(CasAction::Write(new_entry, Some(popped)))
+                }
+            })
+            .await?;
+        let Some(popped) = popped else {
+            return Ok(None);
+        };
+        let out = popped.clone();
+        self.cas(to, move |entry| {
+            let (mut list, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::List(l), expires_at_ms }) => (l.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(to)),
+                None => (Vec::new(), None),
+            };
+            if to_left {
+                list.insert(0, popped.clone());
+            } else {
+                list.push(popped.clone());
+            }
+            let new_entry = StoredValue { expires_at_ms, value: Value::List(list) };
+            Ok(CasAction::Write(new_entry, ()))
+        })
+        .await?;
+        Ok(Some(Bytes::from(out)))
+    }
+
+    async fn lpos(
+        &self,
+        key: &str,
+        element: &[u8],
+        rank: i64,
+        count: Option<usize>,
+        maxlen: usize,
+    ) -> Result<Vec<i64>, RustyAntError> {
+        let list = match self.load(key).await? {
+            Some(StoredValue { value: Value::List(l), .. }) => l,
+            Some(_) => return Err(wrong_type(key)),
+            None => return Ok(Vec::new()),
+        };
+        let wanted = count.map_or(1, |c| if c == 0 { usize::MAX } else { c });
+        Ok(scan_list_positions(&list, element, rank, wanted, maxlen))
     }
 
     async fn zrangebyscore(&self, key: &str, min: ScoreBound, max: ScoreBound) -> Result<Vec<String>, RustyAntError> {
@@ -2838,6 +2997,86 @@ impl Storage for InMemoryStorage {
             store.insert(key.to_string(), entry);
         });
         Ok(len)
+    }
+
+    async fn list_move(
+        &self,
+        from: &str,
+        to: &str,
+        from_left: bool,
+        to_left: bool,
+    ) -> Result<Option<Bytes>, RustyAntError> {
+        // Expire-on-read both sides so a ghost entry doesn't block the move.
+        let _ = self.load(from);
+        if from != to {
+            let _ = self.load(to);
+        }
+        self.with_entry_mut(|store| {
+            if from != to {
+                match store.get(to) {
+                    Some(v) if !matches!(v.value, Value::List(_)) => return Err(wrong_type(to)),
+                    _ => {}
+                }
+            }
+            let (mut src_list, src_expires_at) = match store.get(from) {
+                Some(StoredValue { value: Value::List(l), expires_at_ms }) => (l.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(from)),
+                None => return Ok(None),
+            };
+            if src_list.is_empty() {
+                return Ok(None);
+            }
+            let popped = if from_left { src_list.remove(0) } else { src_list.pop().expect("non-empty") };
+            if from == to {
+                if to_left {
+                    src_list.insert(0, popped.clone());
+                } else {
+                    src_list.push(popped.clone());
+                }
+                store.insert(
+                    from.to_string(),
+                    StoredValue { expires_at_ms: src_expires_at, value: Value::List(src_list) },
+                );
+                return Ok(Some(Bytes::from(popped)));
+            }
+            if src_list.is_empty() {
+                store.remove(from);
+            } else {
+                store.insert(
+                    from.to_string(),
+                    StoredValue { expires_at_ms: src_expires_at, value: Value::List(src_list) },
+                );
+            }
+            let (mut dst_list, dst_expires_at) = match store.get(to) {
+                Some(StoredValue { value: Value::List(l), expires_at_ms }) => (l.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(to)),
+                None => (Vec::new(), None),
+            };
+            if to_left {
+                dst_list.insert(0, popped.clone());
+            } else {
+                dst_list.push(popped.clone());
+            }
+            store.insert(to.to_string(), StoredValue { expires_at_ms: dst_expires_at, value: Value::List(dst_list) });
+            Ok(Some(Bytes::from(popped)))
+        })
+    }
+
+    async fn lpos(
+        &self,
+        key: &str,
+        element: &[u8],
+        rank: i64,
+        count: Option<usize>,
+        maxlen: usize,
+    ) -> Result<Vec<i64>, RustyAntError> {
+        let list = match self.load(key) {
+            Some(StoredValue { value: Value::List(l), .. }) => l,
+            Some(_) => return Err(wrong_type(key)),
+            None => return Ok(Vec::new()),
+        };
+        let wanted = count.map_or(1, |c| if c == 0 { usize::MAX } else { c });
+        Ok(scan_list_positions(&list, element, rank, wanted, maxlen))
     }
 
     async fn zrangebyscore(&self, key: &str, min: ScoreBound, max: ScoreBound) -> Result<Vec<String>, RustyAntError> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1486,6 +1486,216 @@ async fn pushx_on_wrong_type_errors() {
 }
 
 // ---------------------------------------------------------------------------
+// LMOVE / RPOPLPUSH / LPOS
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn lmove_right_to_left_moves_element() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"src", b"a", b"b", b"c"]).await;
+    call(&state, &[b"RPUSH", b"dst", b"x", b"y"]).await;
+    call(&state, &[b"LMOVE", b"src", b"dst", b"RIGHT", b"LEFT"]).await.expect_bulk(b"c");
+    let src = call(&state, &[b"LRANGE", b"src", b"0", b"-1"]).await.into_bulk_array();
+    assert_eq!(bulks_to_strs(&src), vec!["a", "b"]);
+    let dst = call(&state, &[b"LRANGE", b"dst", b"0", b"-1"]).await.into_bulk_array();
+    assert_eq!(bulks_to_strs(&dst), vec!["c", "x", "y"]);
+}
+
+#[tokio::test]
+async fn lmove_all_direction_combos() {
+    let state = test_state();
+    // LEFT → LEFT: pop head of src, push head of dst.
+    call(&state, &[b"RPUSH", b"s1", b"a", b"b"]).await;
+    call(&state, &[b"RPUSH", b"d1", b"y"]).await;
+    call(&state, &[b"LMOVE", b"s1", b"d1", b"LEFT", b"LEFT"]).await.expect_bulk(b"a");
+    let d1 = call(&state, &[b"LRANGE", b"d1", b"0", b"-1"]).await.into_bulk_array();
+    assert_eq!(bulks_to_strs(&d1), vec!["a", "y"]);
+    // LEFT → RIGHT
+    call(&state, &[b"RPUSH", b"s2", b"a", b"b"]).await;
+    call(&state, &[b"RPUSH", b"d2", b"y"]).await;
+    call(&state, &[b"LMOVE", b"s2", b"d2", b"LEFT", b"RIGHT"]).await.expect_bulk(b"a");
+    let d2 = call(&state, &[b"LRANGE", b"d2", b"0", b"-1"]).await.into_bulk_array();
+    assert_eq!(bulks_to_strs(&d2), vec!["y", "a"]);
+    // RIGHT → RIGHT
+    call(&state, &[b"RPUSH", b"s3", b"a", b"b"]).await;
+    call(&state, &[b"RPUSH", b"d3", b"y"]).await;
+    call(&state, &[b"LMOVE", b"s3", b"d3", b"RIGHT", b"RIGHT"]).await.expect_bulk(b"b");
+    let d3 = call(&state, &[b"LRANGE", b"d3", b"0", b"-1"]).await.into_bulk_array();
+    assert_eq!(bulks_to_strs(&d3), vec!["y", "b"]);
+}
+
+#[tokio::test]
+async fn lmove_same_key_rotates() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"l", b"a", b"b", b"c"]).await;
+    // RIGHT → LEFT rotates: c becomes new head.
+    call(&state, &[b"LMOVE", b"l", b"l", b"RIGHT", b"LEFT"]).await.expect_bulk(b"c");
+    let items = call(&state, &[b"LRANGE", b"l", b"0", b"-1"]).await.into_bulk_array();
+    assert_eq!(bulks_to_strs(&items), vec!["c", "a", "b"]);
+}
+
+#[tokio::test]
+async fn lmove_creates_missing_destination() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"src", b"a", b"b"]).await;
+    call(&state, &[b"LMOVE", b"src", b"newdst", b"LEFT", b"RIGHT"]).await.expect_bulk(b"a");
+    call(&state, &[b"TYPE", b"newdst"]).await.expect_simple("list");
+    let dst = call(&state, &[b"LRANGE", b"newdst", b"0", b"-1"]).await.into_bulk_array();
+    assert_eq!(bulks_to_strs(&dst), vec!["a"]);
+}
+
+#[tokio::test]
+async fn lmove_empty_source_returns_nil_and_leaves_dst() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"dst", b"y"]).await;
+    call(&state, &[b"LMOVE", b"missing", b"dst", b"LEFT", b"LEFT"]).await.expect_nil();
+    let dst = call(&state, &[b"LRANGE", b"dst", b"0", b"-1"]).await.into_bulk_array();
+    assert_eq!(bulks_to_strs(&dst), vec!["y"]);
+}
+
+#[tokio::test]
+async fn lmove_wrong_source_type_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"s", b"v"]).await;
+    call(&state, &[b"RPUSH", b"d", b"x"]).await;
+    call(&state, &[b"LMOVE", b"s", b"d", b"LEFT", b"LEFT"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn lmove_wrong_destination_type_errors_without_popping() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"src", b"a", b"b"]).await;
+    call(&state, &[b"SET", b"dst", b"v"]).await;
+    call(&state, &[b"LMOVE", b"src", b"dst", b"LEFT", b"LEFT"]).await.expect_error_prefix("ERR");
+    // Source untouched.
+    let src = call(&state, &[b"LRANGE", b"src", b"0", b"-1"]).await.into_bulk_array();
+    assert_eq!(bulks_to_strs(&src), vec!["a", "b"]);
+}
+
+#[tokio::test]
+async fn lmove_rejects_invalid_side() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"l", b"a"]).await;
+    call(&state, &[b"LMOVE", b"l", b"l", b"UP", b"LEFT"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn rpoplpush_moves_tail_to_head() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"src", b"a", b"b", b"c"]).await;
+    call(&state, &[b"RPUSH", b"dst", b"y"]).await;
+    call(&state, &[b"RPOPLPUSH", b"src", b"dst"]).await.expect_bulk(b"c");
+    let dst = call(&state, &[b"LRANGE", b"dst", b"0", b"-1"]).await.into_bulk_array();
+    assert_eq!(bulks_to_strs(&dst), vec!["c", "y"]);
+}
+
+#[tokio::test]
+async fn rpoplpush_same_key_rotates() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"l", b"a", b"b", b"c"]).await;
+    call(&state, &[b"RPOPLPUSH", b"l", b"l"]).await.expect_bulk(b"c");
+    let items = call(&state, &[b"LRANGE", b"l", b"0", b"-1"]).await.into_bulk_array();
+    assert_eq!(bulks_to_strs(&items), vec!["c", "a", "b"]);
+}
+
+#[tokio::test]
+async fn rpoplpush_missing_source_returns_nil() {
+    let state = test_state();
+    call(&state, &[b"RPOPLPUSH", b"ghost", b"dst"]).await.expect_nil();
+    call(&state, &[b"EXISTS", b"dst"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn lpos_returns_first_match_index() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"l", b"a", b"b", b"c", b"b", b"d"]).await;
+    call(&state, &[b"LPOS", b"l", b"b"]).await.expect_integer(1);
+}
+
+#[tokio::test]
+async fn lpos_missing_element_returns_nil() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"l", b"a", b"b"]).await;
+    call(&state, &[b"LPOS", b"l", b"z"]).await.expect_nil();
+}
+
+#[tokio::test]
+async fn lpos_missing_key_returns_nil() {
+    let state = test_state();
+    call(&state, &[b"LPOS", b"ghost", b"x"]).await.expect_nil();
+}
+
+#[tokio::test]
+async fn lpos_with_rank_skips_occurrences() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"l", b"a", b"b", b"c", b"b", b"d", b"b"]).await;
+    // 2nd occurrence forward.
+    call(&state, &[b"LPOS", b"l", b"b", b"RANK", b"2"]).await.expect_integer(3);
+    // 1st occurrence backward.
+    call(&state, &[b"LPOS", b"l", b"b", b"RANK", b"-1"]).await.expect_integer(5);
+    // 2nd occurrence backward.
+    call(&state, &[b"LPOS", b"l", b"b", b"RANK", b"-2"]).await.expect_integer(3);
+}
+
+#[tokio::test]
+async fn lpos_rank_zero_errors() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"l", b"a"]).await;
+    call(&state, &[b"LPOS", b"l", b"a", b"RANK", b"0"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn lpos_with_count_zero_returns_all_matches() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"l", b"a", b"b", b"a", b"c", b"a"]).await;
+    let reply = call(&state, &[b"LPOS", b"l", b"a", b"COUNT", b"0"]).await;
+    // Array of integers :0 :2 :4.
+    assert_eq!(reply.raw, b"*3\r\n:0\r\n:2\r\n:4\r\n");
+}
+
+#[tokio::test]
+async fn lpos_with_count_n_limits_output() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"l", b"a", b"b", b"a", b"c", b"a"]).await;
+    let reply = call(&state, &[b"LPOS", b"l", b"a", b"COUNT", b"2"]).await;
+    assert_eq!(reply.raw, b"*2\r\n:0\r\n:2\r\n");
+}
+
+#[tokio::test]
+async fn lpos_count_with_no_matches_returns_empty_array() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"l", b"a", b"b"]).await;
+    let reply = call(&state, &[b"LPOS", b"l", b"z", b"COUNT", b"0"]).await;
+    assert_eq!(reply.raw, b"*0\r\n");
+}
+
+#[tokio::test]
+async fn lpos_count_with_negative_rank_returns_backward_order() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"l", b"a", b"b", b"a", b"c", b"a"]).await;
+    let reply = call(&state, &[b"LPOS", b"l", b"a", b"RANK", b"-1", b"COUNT", b"0"]).await;
+    // Backward walk yields indices 4, 2, 0.
+    assert_eq!(reply.raw, b"*3\r\n:4\r\n:2\r\n:0\r\n");
+}
+
+#[tokio::test]
+async fn lpos_maxlen_bounds_the_scan() {
+    let state = test_state();
+    call(&state, &[b"RPUSH", b"l", b"a", b"b", b"c", b"d", b"b"]).await;
+    // MAXLEN 2 only looks at indices 0 and 1 — finds b at 1.
+    call(&state, &[b"LPOS", b"l", b"b", b"MAXLEN", b"2"]).await.expect_integer(1);
+    // MAXLEN 1 only looks at index 0 — no match.
+    call(&state, &[b"LPOS", b"l", b"b", b"MAXLEN", b"1"]).await.expect_nil();
+}
+
+#[tokio::test]
+async fn lpos_on_wrong_type_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"LPOS", b"k", b"v"]).await.expect_error_prefix("ERR");
+}
+
+// ---------------------------------------------------------------------------
 // SINTER / SUNION / SDIFF / SMISMEMBER / SPOP / SRANDMEMBER
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `LMOVE src dst <LEFT|RIGHT> <LEFT|RIGHT>` — pop from one end of `src`, push to one end of `dst`. Atomic single-CAS when `src == dst`; cross-key is pop-then-push (best-effort, same guarantee as `RENAME`/`COPY` on S3). Destination type is pre-checked so a non-list dst fails before the source is popped.
- `RPOPLPUSH src dst` — equivalent to `LMOVE src dst RIGHT LEFT`, kept for clients still wired to the pre-6.2 command.
- `LPOS key element [RANK rank] [COUNT n] [MAXLEN len]` — returns match positions. `RANK` may be negative (tail→head search) but not zero; `COUNT` absent returns a single integer / nil, `COUNT 0` returns all matches, `COUNT n` caps the array; `MAXLEN 0` scans the full list.

## Test plan

- [x] 22 new HTTP integration tests (LMOVE direction combos + same-key rotate + missing src + wrong-type src/dst; RPOPLPUSH basic + rotate + missing; LPOS basic / rank / count / maxlen / wrong-type)
- [x] `just check` — fmt + clippy clean
- [x] `just test` — 309/309 pass (18 lib + 264 HTTP integration + 14 redis-py + 6 WS + 7 floci)