### PR TITLE
:sparkles: add INFO/COMMAND server metadata + GETEX/EXPIRETIME/PEXPIRETIME

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Implemented:
 
 | Group | Commands |
 |---|---|
-| Server | `PING`, `ECHO`, `TIME`, `DBSIZE`, `FLUSHDB`, `FLUSHALL` |
-| Keyspace | `KEYS`, `SCAN` (+ `MATCH` / `COUNT` options), `TYPE`, `RENAME`, `RENAMENX`, `RANDOMKEY`, `UNLINK`, `COPY` (+ `REPLACE` / `DB 0`) |
-| Strings | `GET`, `SET` (+ `EX` / `PX` options), `GETSET`, `GETDEL`, `GETRANGE`, `SETRANGE`, `SETNX`, `SETEX`, `MGET`, `MSET`, `MSETNX`, `APPEND`, `STRLEN`, `DEL`, `EXISTS`, `EXPIRE`, `EXPIREAT`, `PEXPIRE`, `PEXPIREAT`, `PERSIST`, `TTL`, `PTTL`, `INCR`, `INCRBY`, `INCRBYFLOAT`, `DECR`, `DECRBY`, `GETBIT`, `SETBIT`, `BITCOUNT` (+ `BYTE` / `BIT`), `BITPOS` (+ `BYTE` / `BIT`), `BITOP` (`AND` / `OR` / `XOR` / `NOT`) |
+| Server | `PING`, `ECHO`, `TIME`, `INFO` (+ section filter), `COMMAND` (`COUNT` / `LIST` / `INFO`), `DBSIZE`, `FLUSHDB`, `FLUSHALL` |
+| Keyspace | `KEYS`, `SCAN` (+ `MATCH` / `COUNT` options), `TYPE`, `RENAME`, `RENAMENX`, `RANDOMKEY`, `UNLINK`, `COPY` (+ `REPLACE` / `DB 0`), `EXPIRETIME`, `PEXPIRETIME` |
+| Strings | `GET`, `GETEX` (+ `EX` / `PX` / `EXAT` / `PXAT` / `PERSIST`), `SET` (+ `EX` / `PX`), `GETSET`, `GETDEL`, `GETRANGE`, `SETRANGE`, `SETNX`, `SETEX`, `MGET`, `MSET`, `MSETNX`, `APPEND`, `STRLEN`, `DEL`, `EXISTS`, `EXPIRE`, `EXPIREAT`, `PEXPIRE`, `PEXPIREAT`, `PERSIST`, `TTL`, `PTTL`, `INCR`, `INCRBY`, `INCRBYFLOAT`, `DECR`, `DECRBY`, `GETBIT`, `SETBIT`, `BITCOUNT` (+ `BYTE` / `BIT`), `BITPOS` (+ `BYTE` / `BIT`), `BITOP` (`AND` / `OR` / `XOR` / `NOT`) |
 | Hashes | `HSET`, `HSETNX`, `HGET`, `HDEL`, `HGETALL`, `HLEN`, `HKEYS`, `HVALS`, `HEXISTS`, `HSTRLEN`, `HMGET`, `HINCRBY`, `HSCAN` (+ `MATCH` / `COUNT`) |
 | Lists | `LPUSH`, `RPUSH`, `LPUSHX`, `RPUSHX`, `LPOP` (+ count), `RPOP` (+ count), `LRANGE`, `LLEN`, `LINDEX`, `LSET`, `LREM`, `LINSERT`, `LTRIM`, `LMOVE`, `RPOPLPUSH`, `LPOS` (+ `RANK` / `COUNT` / `MAXLEN`) |
 | Sets | `SADD`, `SREM`, `SMEMBERS`, `SISMEMBER`, `SMISMEMBER`, `SCARD`, `SINTER`, `SUNION`, `SDIFF`, `SPOP` (+ count), `SRANDMEMBER` (+ count), `SSCAN` (+ `MATCH` / `COUNT`) |
@@ -78,6 +78,10 @@ Not implemented (PRs welcome): pub/sub, transactions, scripting, streams, geo.
 Bit operations follow Redis's bit numbering: bit 0 is the most significant bit of byte 0. `SETBIT` zero-pads the underlying string to fit the requested offset and runs under the same CAS as other read-modify-write commands. `BITPOS` keeps Redis's asymmetric "infinite trailing zeros" behavior — when searching for a 0 bit without an explicit end, an all-ones string returns `strlen * 8` rather than `-1`; pinning an explicit end suppresses that fiction. `BITOP` reads each source sequentially, pads shorter sources to the longest with zero bytes, and stores the result; an empty result removes the destination instead of writing an empty-string entry.
 
 `LMOVE` / `RPOPLPUSH` are fully atomic when source and destination are the same key (single CAS). Cross-key moves pop from source first, then push to destination — same best-effort guarantee as `RENAME` / `COPY` on the S3 backend. A type-mismatch on the destination is detected before the pop so the source stays intact; a concurrent writer swapping the destination's type between the check and the push can still surface an error after the element has been removed from source. `LPOS` follows Redis semantics: without `COUNT` the reply is the first matching index (`nil` when absent), with `COUNT` it is always an array. `RANK` may be negative (tail→head search) but not zero; `MAXLEN 0` scans the whole list.
+
+`INFO` emits `# Server`, `# Clients`, `# Stats`, and `# Keyspace` sections. `uptime_in_seconds` is measured from the container's cold start, so it resets on every Lambda cold boot rather than tracking a long-lived server process. `connected_clients` is a fixed `1` and `total_commands_processed` is a fixed `0` — there is no cross-invocation counter to report. `# Keyspace` uses `keyspace_stats`, which counts every live S3 object; `expires` is always `0` on the S3 backend because computing it exactly would require a GET per key (future backends can override). `COMMAND INFO` / `COMMAND LIST` / `COMMAND COUNT` return the classic 6-tuple metadata (`name`, `arity`, `flags`, `first_key`, `last_key`, `step`) for every implemented command; `COMMAND DOCS` and `COMMAND GETKEYS` are not implemented.
+
+`GETEX` resolves `EX` / `PX` / `EXAT` / `PXAT` to an absolute epoch-ms on the handler side, then runs one CAS against the key — so a concurrent writer can't race the expiry change with a write. `PERSIST` clears any existing TTL. `EXPIRETIME` / `PEXPIRETIME` return the absolute expiry (seconds / ms); `-1` for no TTL, `-2` for missing keys, matching Redis.
 
 ### Concurrency
 
@@ -168,6 +172,6 @@ The `rustyant` and `rustyant-ws` binaries emit structured JSON logs via `tracing
 
 ## Status
 
-Working: RESP over HTTP and WebSocket, full string/hash/list/set/zset command dispatch plus `KEYS` / `SCAN` / `HSCAN` / `SSCAN` / `ZSCAN`, S3-backed storage with per-key TTL and conditional-write CAS on every read-modify-write, 309 Rust tests across 5 suites (18 lib units + 264 HTTP integration + 14 redis-py compat + 6 WebSocket E2E + 7 floci/S3) and 13 Python client tests, structured logs and CloudWatch EMF metrics, CI on GitHub Actions with floci as a service container, SAM template validated in CI.
+Working: RESP over HTTP and WebSocket, full string/hash/list/set/zset command dispatch plus `KEYS` / `SCAN` / `HSCAN` / `SSCAN` / `ZSCAN`, server introspection via `INFO` and `COMMAND`, S3-backed storage with per-key TTL and conditional-write CAS on every read-modify-write, 336 Rust tests across 5 suites (18 lib units + 291 HTTP integration + 14 redis-py compat + 6 WebSocket E2E + 7 floci/S3) and 13 Python client tests, structured logs and CloudWatch EMF metrics, CI on GitHub Actions with floci as a service container, SAM template validated in CI.
 
 Not wired: no end-to-end test driving a real WebSocket connection against a deployed binary in AWS; the `s3_concurrent_incr_converges` CAS test is gated behind `RUSTYANT_S3_CAS=1` because floci doesn't enforce `If-Match` headers.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -7,7 +7,7 @@ use crate::error::RustyAntError;
 use crate::metrics;
 use crate::resp::RespReply;
 use crate::state::State;
-use crate::storage::{ScoreBound, TtlResult, bit_at, now_ms};
+use crate::storage::{GetExOp, ScoreBound, TtlResult, bit_at, now_ms};
 
 /// Coarse classification of a dispatch result, emitted as a structured log
 /// field so `CloudWatch` queries can count/alert by outcome without string
@@ -100,6 +100,8 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "PING" => Ok(RespReply::SimpleString("PONG".into())),
         "ECHO" => handle_echo(&args),
         "TIME" => handle_time(&args),
+        "INFO" => handle_info(state, args).await,
+        "COMMAND" => handle_command(&args),
         "DBSIZE" => handle_dbsize(state, args).await,
         "FLUSHDB" | "FLUSHALL" => handle_flushall(state, args, &cmd).await,
         "RANDOMKEY" => handle_randomkey(state, args).await,
@@ -115,6 +117,7 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "BITOP" => handle_bitop(state, args).await,
         // Strings
         "GET" => handle_get(state, args).await,
+        "GETEX" => handle_getex(state, args).await,
         "GETSET" => handle_getset(state, args).await,
         "GETDEL" => handle_getdel(state, args).await,
         "GETRANGE" => handle_getrange(state, args).await,
@@ -135,6 +138,8 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "PERSIST" => handle_persist(state, args).await,
         "TTL" => handle_ttl(state, args).await,
         "PTTL" => handle_pttl(state, args).await,
+        "EXPIRETIME" => handle_expiretime(state, args).await,
+        "PEXPIRETIME" => handle_pexpiretime(state, args).await,
         "RENAME" => handle_rename(state, args).await,
         "RENAMENX" => handle_renamenx(state, args).await,
         "KEYS" => handle_keys(state, args).await,
@@ -252,6 +257,39 @@ async fn handle_get(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyA
     arity("GET", args.len() == 1)?;
     let key = arg_as_str(&args[0])?;
     Ok(state.storage.get_string(key).await?.map_or(RespReply::Nil, |v| RespReply::BulkString(Some(v))))
+}
+
+async fn handle_getex(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("GETEX", !args.is_empty() && args.len() <= 3)?;
+    let key = arg_as_string(&args[0])?;
+    let op = parse_getex_op(&args[1..])?;
+    Ok(state.storage.get_string_with_ttl(&key, op).await?.map_or(RespReply::Nil, |v| RespReply::BulkString(Some(v))))
+}
+
+fn parse_getex_op(opts: &[Bytes]) -> Result<GetExOp, RustyAntError> {
+    if opts.is_empty() {
+        return Ok(GetExOp::Leave);
+    }
+    let name = arg_as_str(&opts[0])?.to_ascii_uppercase();
+    if name == "PERSIST" {
+        if opts.len() != 1 {
+            return Err(RustyAntError::Parse("PERSIST takes no value".into()));
+        }
+        return Ok(GetExOp::Persist);
+    }
+    let value = opts.get(1).ok_or_else(|| RustyAntError::Parse(format!("{name} requires a value")))?;
+    if opts.len() > 2 {
+        return Err(RustyAntError::Parse(format!("GETEX accepts at most one option; extra args after {name}")));
+    }
+    let n = parse_i64(value, name.as_str())?;
+    let at_ms = match name.as_str() {
+        "EX" => now_ms() + n.saturating_mul(1000),
+        "PX" => now_ms() + n,
+        "EXAT" => n.saturating_mul(1000),
+        "PXAT" => n,
+        other => return Err(RustyAntError::Parse(format!("unsupported GETEX option: {other}"))),
+    };
+    Ok(GetExOp::SetExpireAtMs(at_ms))
 }
 
 async fn handle_set(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
@@ -1089,6 +1127,26 @@ async fn handle_pttl(state: &State, args: Vec<Bytes>) -> Result<RespReply, Rusty
     })
 }
 
+async fn handle_expiretime(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("EXPIRETIME", args.len() == 1)?;
+    let key = arg_as_str(&args[0])?;
+    Ok(match state.storage.expire_time_ms(key).await? {
+        TtlResult::NoKey => RespReply::Integer(-2),
+        TtlResult::NoExpire => RespReply::Integer(-1),
+        TtlResult::Ms(ms) => RespReply::Integer(ms / 1000),
+    })
+}
+
+async fn handle_pexpiretime(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("PEXPIRETIME", args.len() == 1)?;
+    let key = arg_as_str(&args[0])?;
+    Ok(match state.storage.expire_time_ms(key).await? {
+        TtlResult::NoKey => RespReply::Integer(-2),
+        TtlResult::NoExpire => RespReply::Integer(-1),
+        TtlResult::Ms(ms) => RespReply::Integer(ms),
+    })
+}
+
 async fn handle_rename(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
     arity("RENAME", args.len() == 2)?;
     let from = arg_as_str(&args[0])?;
@@ -1241,6 +1299,66 @@ async fn handle_dbsize(state: &State, args: Vec<Bytes>) -> Result<RespReply, Rus
     arity("DBSIZE", args.is_empty())?;
     let n = state.storage.dbsize().await?;
     Ok(RespReply::Integer(n))
+}
+
+/// Redis `INFO` — multi-section bulk string, CRLF-separated.
+///
+/// rustyant emits four sections (`server`, `clients`, `stats`, `keyspace`).
+/// An optional single-section argument filters the output; `everything` /
+/// `default` / `all` are accepted as synonyms for "all sections" (Redis 7).
+async fn handle_info(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    use std::fmt::Write as _;
+
+    let section = match args.len() {
+        0 => None,
+        1 => Some(arg_as_str(&args[0])?.to_ascii_lowercase()),
+        _ => return Err(RustyAntError::WrongArity { command: "INFO".into() }),
+    };
+    let mut out = String::new();
+    if info_section_included(section.as_deref(), "server") {
+        let uptime = (now_ms().saturating_sub(state.started_at_ms)) / 1000;
+        out.push_str("# Server\r\n");
+        // Report a real Redis version so clients that gate on it (redis-py
+        // HELLO, etc.) treat rustyant as compatible. Actual package version
+        // lives under `rustyant_version`.
+        out.push_str("redis_version:7.4.0\r\n");
+        let _ = writeln!(out, "rustyant_version:{}\r", env!("CARGO_PKG_VERSION"));
+        let _ = writeln!(out, "process_id:{}\r", std::process::id());
+        let _ = writeln!(out, "uptime_in_seconds:{uptime}\r");
+        out.push_str("os:Linux-lambda\r\n");
+        out.push_str("arch_bits:64\r\n");
+        out.push_str("\r\n");
+    }
+    if info_section_included(section.as_deref(), "clients") {
+        // Lambda serves one request per invocation — there's no persistent
+        // client pool to report on. Fixed at 1 so clients that check this
+        // field don't trip on a zero.
+        out.push_str("# Clients\r\n");
+        out.push_str("connected_clients:1\r\n");
+        out.push_str("\r\n");
+    }
+    if info_section_included(section.as_deref(), "stats") {
+        // No cross-invocation counter to report; Lambda cold-starts reset it.
+        // Emit the fields so tools don't explode on missing keys, with zeros.
+        out.push_str("# Stats\r\n");
+        out.push_str("total_connections_received:0\r\n");
+        out.push_str("total_commands_processed:0\r\n");
+        out.push_str("instantaneous_ops_per_sec:0\r\n");
+        out.push_str("\r\n");
+    }
+    if info_section_included(section.as_deref(), "keyspace") {
+        let ks = state.storage.keyspace_stats().await?;
+        out.push_str("# Keyspace\r\n");
+        if ks.total_keys > 0 {
+            let _ = writeln!(out, "db0:keys={},expires={},avg_ttl=0\r", ks.total_keys, ks.keys_with_expire);
+        }
+        out.push_str("\r\n");
+    }
+    Ok(RespReply::BulkString(Some(Bytes::from(out))))
+}
+
+fn info_section_included(requested: Option<&str>, section: &str) -> bool {
+    requested.is_none_or(|r| r == section || matches!(r, "everything" | "default" | "all"))
 }
 
 async fn handle_flushall(state: &State, args: Vec<Bytes>, cmd: &str) -> Result<RespReply, RustyAntError> {
@@ -1525,4 +1643,200 @@ async fn handle_copy(state: &State, args: Vec<Bytes>) -> Result<RespReply, Rusty
     }
     let copied = state.storage.copy(from, to, replace).await?;
     Ok(RespReply::Integer(i64::from(copied)))
+}
+
+// ---------------------------------------------------------------------------
+// COMMAND — minimal server introspection for redis-py's discovery path.
+// Scope is `COUNT` / `LIST` / `INFO`; `DOCS` and `GETKEYS` are out of scope
+// because redis-py does not require them.
+// ---------------------------------------------------------------------------
+
+/// `(name, arity, flags, first_key, last_key, step)` — the classic Redis
+/// 6-tuple shape that powers `COMMAND INFO`.
+///
+/// Arity is positive for exact argument count (including the command name)
+/// and negative for "at least |n|". `first_key` / `last_key` / `step`
+/// describe key extraction in RESP terms: `0` means no keys (server
+/// commands); `-1` as `last_key` means "to the last argument".
+type CommandMeta = (&'static str, i64, &'static [&'static str], i64, i64, i64);
+
+const COMMAND_META: &[CommandMeta] = &[
+    // Connection / server
+    ("ping", -1, &["fast"], 0, 0, 0),
+    ("echo", 2, &["fast"], 0, 0, 0),
+    ("time", 1, &["fast", "loading", "stale"], 0, 0, 0),
+    ("info", -1, &["loading", "stale"], 0, 0, 0),
+    ("command", -1, &["loading", "stale"], 0, 0, 0),
+    ("dbsize", 1, &["readonly", "fast"], 0, 0, 0),
+    ("flushdb", -1, &["write"], 0, 0, 0),
+    ("flushall", -1, &["write"], 0, 0, 0),
+    ("randomkey", 1, &["readonly"], 0, 0, 0),
+    // Generic / keyspace
+    ("del", -2, &["write"], 1, -1, 1),
+    ("unlink", -2, &["write", "fast"], 1, -1, 1),
+    ("copy", -3, &["write"], 1, 2, 1),
+    ("exists", -2, &["readonly", "fast"], 1, -1, 1),
+    ("expire", -3, &["write", "fast"], 1, 1, 1),
+    ("expireat", -3, &["write", "fast"], 1, 1, 1),
+    ("pexpire", -3, &["write", "fast"], 1, 1, 1),
+    ("pexpireat", -3, &["write", "fast"], 1, 1, 1),
+    ("persist", 2, &["write", "fast"], 1, 1, 1),
+    ("ttl", 2, &["readonly", "fast"], 1, 1, 1),
+    ("pttl", 2, &["readonly", "fast"], 1, 1, 1),
+    ("expiretime", 2, &["readonly", "fast"], 1, 1, 1),
+    ("pexpiretime", 2, &["readonly", "fast"], 1, 1, 1),
+    ("keys", 2, &["readonly"], 0, 0, 0),
+    ("scan", -2, &["readonly"], 0, 0, 0),
+    ("type", 2, &["readonly", "fast"], 1, 1, 1),
+    ("rename", 3, &["write"], 1, 2, 1),
+    ("renamenx", 3, &["write", "fast"], 1, 2, 1),
+    // Strings
+    ("get", 2, &["readonly", "fast"], 1, 1, 1),
+    ("getex", -2, &["write", "fast"], 1, 1, 1),
+    ("getset", 3, &["write", "fast"], 1, 1, 1),
+    ("getdel", 2, &["write", "fast"], 1, 1, 1),
+    ("getrange", 4, &["readonly"], 1, 1, 1),
+    ("setrange", 4, &["write", "denyoom"], 1, 1, 1),
+    ("strlen", 2, &["readonly", "fast"], 1, 1, 1),
+    ("append", 3, &["write", "denyoom", "fast"], 1, 1, 1),
+    ("set", -3, &["write", "denyoom"], 1, 1, 1),
+    ("setnx", 3, &["write", "denyoom", "fast"], 1, 1, 1),
+    ("setex", 4, &["write", "denyoom"], 1, 1, 1),
+    ("mget", -2, &["readonly", "fast"], 1, -1, 1),
+    ("mset", -3, &["write", "denyoom"], 1, -1, 2),
+    ("msetnx", -3, &["write", "denyoom"], 1, -1, 2),
+    ("incr", 2, &["write", "denyoom", "fast"], 1, 1, 1),
+    ("incrby", 3, &["write", "denyoom", "fast"], 1, 1, 1),
+    ("incrbyfloat", 3, &["write", "denyoom", "fast"], 1, 1, 1),
+    ("decr", 2, &["write", "denyoom", "fast"], 1, 1, 1),
+    ("decrby", 3, &["write", "denyoom", "fast"], 1, 1, 1),
+    // Bit ops
+    ("getbit", 3, &["readonly", "fast"], 1, 1, 1),
+    ("setbit", 4, &["write", "denyoom"], 1, 1, 1),
+    ("bitcount", -2, &["readonly"], 1, 1, 1),
+    ("bitpos", -3, &["readonly"], 1, 1, 1),
+    ("bitop", -4, &["write", "denyoom"], 2, -1, 1),
+    // Hashes
+    ("hset", -4, &["write", "denyoom", "fast"], 1, 1, 1),
+    ("hsetnx", 4, &["write", "denyoom", "fast"], 1, 1, 1),
+    ("hget", 3, &["readonly", "fast"], 1, 1, 1),
+    ("hdel", -3, &["write", "fast"], 1, 1, 1),
+    ("hexists", 3, &["readonly", "fast"], 1, 1, 1),
+    ("hgetall", 2, &["readonly"], 1, 1, 1),
+    ("hincrby", 4, &["write", "denyoom", "fast"], 1, 1, 1),
+    ("hkeys", 2, &["readonly"], 1, 1, 1),
+    ("hlen", 2, &["readonly", "fast"], 1, 1, 1),
+    ("hmget", -3, &["readonly", "fast"], 1, 1, 1),
+    ("hscan", -3, &["readonly"], 1, 1, 1),
+    ("hstrlen", 3, &["readonly", "fast"], 1, 1, 1),
+    ("hvals", 2, &["readonly"], 1, 1, 1),
+    // Lists
+    ("lpush", -3, &["write", "denyoom", "fast"], 1, 1, 1),
+    ("lpushx", -3, &["write", "denyoom", "fast"], 1, 1, 1),
+    ("rpush", -3, &["write", "denyoom", "fast"], 1, 1, 1),
+    ("rpushx", -3, &["write", "denyoom", "fast"], 1, 1, 1),
+    ("lpop", -2, &["write", "fast"], 1, 1, 1),
+    ("rpop", -2, &["write", "fast"], 1, 1, 1),
+    ("lrange", 4, &["readonly"], 1, 1, 1),
+    ("lindex", 3, &["readonly"], 1, 1, 1),
+    ("llen", 2, &["readonly", "fast"], 1, 1, 1),
+    ("lset", 4, &["write", "denyoom"], 1, 1, 1),
+    ("ltrim", 4, &["write"], 1, 1, 1),
+    ("linsert", 5, &["write", "denyoom"], 1, 1, 1),
+    ("lrem", 4, &["write"], 1, 1, 1),
+    ("lmove", 5, &["write"], 1, 2, 1),
+    ("rpoplpush", 3, &["write", "denyoom"], 1, 2, 1),
+    ("lpos", -3, &["readonly"], 1, 1, 1),
+    // Sets
+    ("sadd", -3, &["write", "denyoom", "fast"], 1, 1, 1),
+    ("srem", -3, &["write", "fast"], 1, 1, 1),
+    ("scard", 2, &["readonly", "fast"], 1, 1, 1),
+    ("sismember", 3, &["readonly", "fast"], 1, 1, 1),
+    ("smismember", -3, &["readonly", "fast"], 1, 1, 1),
+    ("smembers", 2, &["readonly"], 1, 1, 1),
+    ("srandmember", -2, &["readonly"], 1, 1, 1),
+    ("spop", -2, &["write", "fast"], 1, 1, 1),
+    ("sinter", -2, &["readonly"], 1, -1, 1),
+    ("sunion", -2, &["readonly"], 1, -1, 1),
+    ("sdiff", -2, &["readonly"], 1, -1, 1),
+    ("sscan", -3, &["readonly"], 1, 1, 1),
+    // Sorted sets
+    ("zadd", -4, &["write", "denyoom", "fast"], 1, 1, 1),
+    ("zrem", -3, &["write", "fast"], 1, 1, 1),
+    ("zcard", 2, &["readonly", "fast"], 1, 1, 1),
+    ("zcount", 4, &["readonly", "fast"], 1, 1, 1),
+    ("zrange", -4, &["readonly"], 1, 1, 1),
+    ("zrevrange", -4, &["readonly"], 1, 1, 1),
+    ("zrangebyscore", -4, &["readonly"], 1, 1, 1),
+    ("zrevrangebyscore", -4, &["readonly"], 1, 1, 1),
+    ("zscore", 3, &["readonly", "fast"], 1, 1, 1),
+    ("zmscore", -3, &["readonly", "fast"], 1, 1, 1),
+    ("zrank", -3, &["readonly", "fast"], 1, 1, 1),
+    ("zrevrank", -3, &["readonly", "fast"], 1, 1, 1),
+    ("zincrby", 4, &["write", "denyoom", "fast"], 1, 1, 1),
+    ("zpopmin", -2, &["write", "fast"], 1, 1, 1),
+    ("zpopmax", -2, &["write", "fast"], 1, 1, 1),
+    ("zremrangebyrank", 4, &["write"], 1, 1, 1),
+    ("zremrangebyscore", 4, &["write"], 1, 1, 1),
+    ("zscan", -3, &["readonly"], 1, 1, 1),
+];
+
+fn handle_command(args: &[Bytes]) -> Result<RespReply, RustyAntError> {
+    if args.is_empty() {
+        // Plain `COMMAND` returns metadata for every known command — same as
+        // `COMMAND INFO` with no filter. redis-cli relies on this.
+        return Ok(RespReply::Array(COMMAND_META.iter().map(command_meta_reply).collect()));
+    }
+    let sub = arg_as_str(&args[0])?.to_ascii_uppercase();
+    match sub.as_str() {
+        "COUNT" => {
+            if args.len() != 1 {
+                return Err(RustyAntError::WrongArity { command: "COMMAND COUNT".into() });
+            }
+            Ok(RespReply::Integer(i64::try_from(COMMAND_META.len()).unwrap_or(i64::MAX)))
+        }
+        "LIST" => {
+            if args.len() != 1 {
+                return Err(RustyAntError::WrongArity { command: "COMMAND LIST".into() });
+            }
+            Ok(RespReply::Array(
+                COMMAND_META
+                    .iter()
+                    .map(|(name, ..)| RespReply::BulkString(Some(Bytes::copy_from_slice(name.as_bytes()))))
+                    .collect(),
+            ))
+        }
+        "INFO" => {
+            // `COMMAND INFO` with no filter → all; otherwise filter by name
+            // (case-insensitive). Unknown names return Nil at the matching
+            // array position, matching Redis.
+            if args.len() == 1 {
+                return Ok(RespReply::Array(COMMAND_META.iter().map(command_meta_reply).collect()));
+            }
+            let mut out = Vec::with_capacity(args.len() - 1);
+            for want in args.iter().skip(1) {
+                let want_str = arg_as_str(want)?.to_ascii_lowercase();
+                match COMMAND_META.iter().find(|(name, ..)| *name == want_str) {
+                    Some(meta) => out.push(command_meta_reply(meta)),
+                    None => out.push(RespReply::Nil),
+                }
+            }
+            Ok(RespReply::Array(out))
+        }
+        other => Err(RustyAntError::Parse(format!("unsupported COMMAND subcommand: {other}"))),
+    }
+}
+
+fn command_meta_reply(meta: &CommandMeta) -> RespReply {
+    let (name, arity, flags, first_key, last_key, step) = *meta;
+    RespReply::Array(vec![
+        RespReply::BulkString(Some(Bytes::copy_from_slice(name.as_bytes()))),
+        RespReply::Integer(arity),
+        RespReply::Array(
+            flags.iter().map(|f| RespReply::BulkString(Some(Bytes::copy_from_slice(f.as_bytes())))).collect(),
+        ),
+        RespReply::Integer(first_key),
+        RespReply::Integer(last_key),
+        RespReply::Integer(step),
+    ])
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,12 +3,16 @@ use std::sync::Arc;
 use aws_sdk_s3::Client as S3Client;
 
 use crate::Settings;
-use crate::storage::{S3Storage, Storage};
+use crate::storage::{S3Storage, Storage, now_ms};
 
 #[derive(Debug, Clone)]
 pub struct State {
     pub settings: Arc<Settings>,
     pub storage: Arc<dyn Storage>,
+    /// Wall-clock epoch ms captured when this `State` was constructed. Drives
+    /// `INFO`'s `uptime_in_seconds` field so the number stays consistent across
+    /// Lambda invocations served by the same container.
+    pub started_at_ms: i64,
 }
 
 impl State {
@@ -21,11 +25,11 @@ impl State {
         }
         let s3 = S3Client::from_conf(builder.build());
         let storage = S3Storage::new(s3, settings.bucket.clone(), settings.key_prefix.clone());
-        Ok(Self { settings: Arc::new(settings), storage: Arc::new(storage) })
+        Ok(Self { settings: Arc::new(settings), storage: Arc::new(storage), started_at_ms: now_ms() })
     }
 
     #[must_use]
     pub fn with_storage(settings: Settings, storage: Arc<dyn Storage>) -> Self {
-        Self { settings: Arc::new(settings), storage }
+        Self { settings: Arc::new(settings), storage, started_at_ms: now_ms() }
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -34,6 +34,30 @@ pub enum TtlResult {
     Ms(i64),
 }
 
+/// TTL mutation requested by a `GETEX`.
+///
+/// `Leave` is the option-less call (pure GET), `SetExpireAtMs` is any of
+/// `EX`/`PX`/`EXAT`/`PXAT` (pre-resolved to an absolute unix-time in ms by
+/// the handler), and `Persist` clears any existing expiry.
+#[derive(Debug, Copy, Clone)]
+pub enum GetExOp {
+    Leave,
+    SetExpireAtMs(i64),
+    Persist,
+}
+
+/// Keyspace summary for `INFO keyspace`.
+///
+/// `keys_with_expire` is reported as `0` by the default trait impl —
+/// computing it exactly over S3 would require a GET per object, which the
+/// keyspace page doesn't justify. A backend that can answer cheaply may
+/// override [`Storage::keyspace_stats`].
+#[derive(Debug, Clone, Copy)]
+pub struct KeyspaceStats {
+    pub total_keys: i64,
+    pub keys_with_expire: i64,
+}
+
 /// Score-bound for `ZRANGEBYSCORE` matching Redis's syntax: bare number is
 /// inclusive, `(N` is exclusive, `+inf` / `-inf` are the extremes.
 #[derive(Debug, Clone, Copy)]
@@ -478,11 +502,18 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn exists(&self, key: &str) -> Result<bool, RustyAntError>;
     async fn expire_at(&self, key: &str, expires_at_ms: i64) -> Result<bool, RustyAntError>;
     async fn ttl_ms(&self, key: &str) -> Result<TtlResult, RustyAntError>;
+    /// Absolute expiry — like [`Self::ttl_ms`] but returns the stored epoch-ms
+    /// instead of a delta from "now". Drives `EXPIRETIME` / `PEXPIRETIME`.
+    async fn expire_time_ms(&self, key: &str) -> Result<TtlResult, RustyAntError>;
     /// Redis `TYPE` — returns the value-kind tag (`"string"`, `"hash"`,
     /// `"list"`, `"set"`, `"zset"`) or `None` when the key is missing/expired.
     async fn kind(&self, key: &str) -> Result<Option<&'static str>, RustyAntError>;
 
     async fn get_string(&self, key: &str) -> Result<Option<Bytes>, RustyAntError>;
+    /// `GETEX`: return the string value (`None` when missing / wrong type is an
+    /// error) and atomically adjust its TTL per `op` in the same read-modify-
+    /// write. Same CAS window as every other string mutation on the S3 backend.
+    async fn get_string_with_ttl(&self, key: &str, op: GetExOp) -> Result<Option<Bytes>, RustyAntError>;
     async fn set_string(&self, key: &str, value: Bytes, expires_at_ms: Option<i64>) -> Result<(), RustyAntError>;
     async fn set_string_nx(&self, key: &str, value: Bytes, expires_at_ms: Option<i64>) -> Result<bool, RustyAntError>;
     async fn getset(&self, key: &str, value: Bytes) -> Result<Option<Bytes>, RustyAntError>;
@@ -651,6 +682,14 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     /// not yet been GC'd are still counted, matching Redis's lazy-expiry
     /// behavior.
     async fn dbsize(&self) -> Result<i64, RustyAntError>;
+
+    /// Counts for `INFO keyspace`. Default routes through [`Self::dbsize`] and
+    /// reports `keys_with_expire = 0` — the in-memory backend overrides this
+    /// with an exact count, but S3 would need a GET per object, which the
+    /// keyspace page doesn't justify.
+    async fn keyspace_stats(&self) -> Result<KeyspaceStats, RustyAntError> {
+        Ok(KeyspaceStats { total_keys: self.dbsize().await?, keys_with_expire: 0 })
+    }
 
     /// Wipe every key in the namespace. Drives both `FLUSHDB` and `FLUSHALL`
     /// — rustyant has only one logical database, so the two commands collapse
@@ -1017,12 +1056,40 @@ impl Storage for S3Storage {
         Ok(v.expires_at_ms.map_or(TtlResult::NoExpire, |exp| TtlResult::Ms((exp - now_ms()).max(0))))
     }
 
+    async fn expire_time_ms(&self, key: &str) -> Result<TtlResult, RustyAntError> {
+        let Some(v) = self.load(key).await? else {
+            return Ok(TtlResult::NoKey);
+        };
+        Ok(v.expires_at_ms.map_or(TtlResult::NoExpire, TtlResult::Ms))
+    }
+
     async fn get_string(&self, key: &str) -> Result<Option<Bytes>, RustyAntError> {
         match self.load(key).await? {
             Some(StoredValue { value: Value::String(data), .. }) => Ok(Some(Bytes::from(data))),
             Some(_) => Err(wrong_type(key)),
             None => Ok(None),
         }
+    }
+
+    async fn get_string_with_ttl(&self, key: &str, op: GetExOp) -> Result<Option<Bytes>, RustyAntError> {
+        if matches!(op, GetExOp::Leave) {
+            return self.get_string(key).await;
+        }
+        self.cas(key, move |entry| {
+            let (data, _old_expires_at) = match entry {
+                Some(StoredValue { value: Value::String(d), expires_at_ms }) => (d.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => return Ok(CasAction::NoOp(None)),
+            };
+            let new_expires_at = match op {
+                GetExOp::Leave => unreachable!("leave handled above"),
+                GetExOp::SetExpireAtMs(t) => Some(t),
+                GetExOp::Persist => None,
+            };
+            let new_entry = StoredValue { expires_at_ms: new_expires_at, value: Value::String(data.clone()) };
+            Ok(CasAction::Write(new_entry, Some(Bytes::from(data))))
+        })
+        .await
     }
 
     async fn set_string(&self, key: &str, value: Bytes, expires_at_ms: Option<i64>) -> Result<(), RustyAntError> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2643,3 +2643,278 @@ fn reply_encode_simple_works_from_tests() {
     let enc = r.encode().expect("encode");
     assert_eq!(&enc[..], b"+OK\r\n");
 }
+
+// ---------------------------------------------------------------------------
+// EXPIRETIME / PEXPIRETIME
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn expiretime_missing_key_returns_minus_two() {
+    let state = test_state();
+    call(&state, &[b"EXPIRETIME", b"missing"]).await.expect_integer(-2);
+}
+
+#[tokio::test]
+async fn expiretime_no_expire_returns_minus_one() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"EXPIRETIME", b"k"]).await.expect_integer(-1);
+}
+
+#[tokio::test]
+async fn expiretime_returns_absolute_unix_seconds() {
+    let state = test_state();
+    let target_sec = rustyant::storage::now_ms() / 1000 + 60;
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"EXPIREAT", b"k", target_sec.to_string().as_bytes()]).await;
+    let reply = call(&state, &[b"EXPIRETIME", b"k"]).await;
+    let got: i64 = String::from_utf8_lossy(&reply.raw).trim_start_matches(':').trim_end().parse().expect("int");
+    assert_eq!(got, target_sec, "EXPIRETIME should echo the absolute epoch-seconds we set");
+}
+
+#[tokio::test]
+async fn pexpiretime_returns_absolute_unix_milliseconds() {
+    let state = test_state();
+    let target_ms = rustyant::storage::now_ms() + 60_000;
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"PEXPIREAT", b"k", target_ms.to_string().as_bytes()]).await;
+    let reply = call(&state, &[b"PEXPIRETIME", b"k"]).await;
+    let got: i64 = String::from_utf8_lossy(&reply.raw).trim_start_matches(':').trim_end().parse().expect("int");
+    assert_eq!(got, target_ms);
+}
+
+#[tokio::test]
+async fn pexpiretime_missing_key_returns_minus_two() {
+    let state = test_state();
+    call(&state, &[b"PEXPIRETIME", b"missing"]).await.expect_integer(-2);
+}
+
+// ---------------------------------------------------------------------------
+// GETEX
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn getex_bare_returns_value_leaves_ttl() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v", b"EX", b"60"]).await;
+    call(&state, &[b"GETEX", b"k"]).await.expect_bulk(b"v");
+    // TTL untouched.
+    let reply = call(&state, &[b"TTL", b"k"]).await;
+    let n: i64 = String::from_utf8_lossy(&reply.raw).trim_start_matches(':').trim_end().parse().expect("int");
+    assert!((1..=60).contains(&n), "TTL changed: {n}");
+}
+
+#[tokio::test]
+async fn getex_missing_key_returns_nil() {
+    let state = test_state();
+    call(&state, &[b"GETEX", b"missing"]).await.expect_nil();
+    // With an option too.
+    call(&state, &[b"GETEX", b"missing", b"EX", b"30"]).await.expect_nil();
+}
+
+#[tokio::test]
+async fn getex_ex_sets_ttl() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"GETEX", b"k", b"EX", b"120"]).await.expect_bulk(b"v");
+    let reply = call(&state, &[b"TTL", b"k"]).await;
+    let n: i64 = String::from_utf8_lossy(&reply.raw).trim_start_matches(':').trim_end().parse().expect("int");
+    assert!((1..=120).contains(&n), "unexpected TTL: {n}");
+}
+
+#[tokio::test]
+async fn getex_px_sets_ms_ttl() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"GETEX", b"k", b"PX", b"90000"]).await.expect_bulk(b"v");
+    let reply = call(&state, &[b"PTTL", b"k"]).await;
+    let n: i64 = String::from_utf8_lossy(&reply.raw).trim_start_matches(':').trim_end().parse().expect("int");
+    assert!((1..=90_000).contains(&n), "unexpected PTTL: {n}");
+}
+
+#[tokio::test]
+async fn getex_exat_sets_absolute_expiry() {
+    let state = test_state();
+    let target_sec = rustyant::storage::now_ms() / 1000 + 120;
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"GETEX", b"k", b"EXAT", target_sec.to_string().as_bytes()]).await.expect_bulk(b"v");
+    call(&state, &[b"EXPIRETIME", b"k"]).await.expect_integer(target_sec);
+}
+
+#[tokio::test]
+async fn getex_pxat_sets_absolute_ms_expiry() {
+    let state = test_state();
+    let target_ms = rustyant::storage::now_ms() + 120_000;
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"GETEX", b"k", b"PXAT", target_ms.to_string().as_bytes()]).await.expect_bulk(b"v");
+    call(&state, &[b"PEXPIRETIME", b"k"]).await.expect_integer(target_ms);
+}
+
+#[tokio::test]
+async fn getex_persist_clears_ttl() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v", b"EX", b"60"]).await;
+    call(&state, &[b"GETEX", b"k", b"PERSIST"]).await.expect_bulk(b"v");
+    call(&state, &[b"TTL", b"k"]).await.expect_integer(-1);
+}
+
+#[tokio::test]
+async fn getex_wrong_type_errors() {
+    let state = test_state();
+    call(&state, &[b"LPUSH", b"l", b"x"]).await;
+    call(&state, &[b"GETEX", b"l"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"GETEX", b"l", b"EX", b"10"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn getex_rejects_multiple_options() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"GETEX", b"k", b"EX", b"10", b"PX", b"500"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn getex_unknown_option_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"GETEX", b"k", b"FOO", b"1"]).await.expect_error_prefix("ERR");
+}
+
+// ---------------------------------------------------------------------------
+// INFO
+// ---------------------------------------------------------------------------
+
+fn info_as_string(reply: &DecodedReply) -> String {
+    // Strip the bulk-string header `$N\r\n` and trailing `\r\n`.
+    let raw = String::from_utf8_lossy(&reply.raw);
+    let body = raw.split_once("\r\n").map_or(&raw[..], |(_, rest)| rest);
+    body.trim_end_matches("\r\n").to_string()
+}
+
+#[tokio::test]
+async fn info_returns_all_sections_by_default() {
+    let state = test_state();
+    let reply = call(&state, &[b"INFO"]).await;
+    let body = info_as_string(&reply);
+    for header in ["# Server", "# Clients", "# Stats", "# Keyspace"] {
+        assert!(body.contains(header), "missing section {header:?} in:\n{body}");
+    }
+}
+
+#[tokio::test]
+async fn info_server_reports_uptime_and_versions() {
+    let state = test_state();
+    tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+    let body = info_as_string(&call(&state, &[b"INFO", b"server"]).await);
+    assert!(body.contains("# Server"));
+    assert!(body.contains("redis_version:"), "missing redis_version");
+    assert!(body.contains("rustyant_version:"), "missing rustyant_version");
+    let uptime = body
+        .lines()
+        .find_map(|l| l.strip_prefix("uptime_in_seconds:"))
+        .and_then(|s| s.parse::<i64>().ok())
+        .expect("uptime field");
+    assert!(uptime >= 1, "uptime should be at least 1s, got {uptime}");
+}
+
+#[tokio::test]
+async fn info_keyspace_reflects_stored_keys() {
+    let state = test_state();
+    // Empty keyspace → no db0 line.
+    let empty = info_as_string(&call(&state, &[b"INFO", b"keyspace"]).await);
+    assert!(empty.contains("# Keyspace"));
+    assert!(!empty.contains("db0:"));
+    // After a SET, db0 should report at least one key.
+    call(&state, &[b"SET", b"a", b"1"]).await;
+    call(&state, &[b"SET", b"b", b"2"]).await;
+    let populated = info_as_string(&call(&state, &[b"INFO", b"keyspace"]).await);
+    assert!(populated.contains("db0:keys="), "expected db0 line:\n{populated}");
+}
+
+#[tokio::test]
+async fn info_single_section_filters_output() {
+    let state = test_state();
+    let body = info_as_string(&call(&state, &[b"INFO", b"clients"]).await);
+    assert!(body.contains("# Clients"));
+    assert!(!body.contains("# Server"), "clients section should not leak Server:\n{body}");
+}
+
+#[tokio::test]
+async fn info_everything_is_full_output() {
+    let state = test_state();
+    let body = info_as_string(&call(&state, &[b"INFO", b"everything"]).await);
+    for header in ["# Server", "# Clients", "# Stats", "# Keyspace"] {
+        assert!(body.contains(header));
+    }
+}
+
+#[tokio::test]
+async fn info_rejects_extra_args() {
+    let state = test_state();
+    call(&state, &[b"INFO", b"server", b"clients"]).await.expect_error_prefix("ERR");
+}
+
+// ---------------------------------------------------------------------------
+// COMMAND
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn command_count_returns_registered_command_count() {
+    let state = test_state();
+    let reply = call(&state, &[b"COMMAND", b"COUNT"]).await;
+    let n: i64 = String::from_utf8_lossy(&reply.raw).trim_start_matches(':').trim_end().parse().expect("int");
+    assert!(n > 100, "COMMAND COUNT unexpectedly small: {n}");
+}
+
+#[tokio::test]
+async fn command_list_returns_all_names() {
+    let state = test_state();
+    let reply = call(&state, &[b"COMMAND", b"LIST"]).await;
+    let names: Vec<String> =
+        reply.into_bulk_array().into_iter().map(|b| String::from_utf8_lossy(&b).into_owned()).collect();
+    for expected in ["get", "set", "info", "command", "getex", "expiretime"] {
+        assert!(names.iter().any(|n| n == expected), "COMMAND LIST missing {expected}; got {names:?}");
+    }
+}
+
+#[tokio::test]
+async fn command_info_get_returns_expected_metadata() {
+    let state = test_state();
+    // Parse the full reply as raw bytes and eyeball the frame since
+    // `into_bulk_array` flattens nested arrays. `COMMAND INFO GET` returns
+    // an outer array of one element; that element is a 6-tuple starting
+    // with the bulk string "get" and the integer 2 (exact arity).
+    let reply = call(&state, &[b"COMMAND", b"INFO", b"GET"]).await;
+    let raw = reply.raw;
+    let s = String::from_utf8_lossy(&raw);
+    // Outer array length 1 → `*1\r\n`; inner array length 6 → `*6\r\n`.
+    assert!(s.starts_with("*1\r\n*6\r\n"), "unexpected frame header:\n{s}");
+    assert!(s.contains("$3\r\nget\r\n"), "missing bulk 'get' in reply:\n{s}");
+    assert!(s.contains(":2\r\n"), "missing integer 2 (arity) in reply:\n{s}");
+}
+
+#[tokio::test]
+async fn command_info_unknown_command_returns_nil_slot() {
+    let state = test_state();
+    let reply = call(&state, &[b"COMMAND", b"INFO", b"NOPE"]).await;
+    let s = String::from_utf8_lossy(&reply.raw);
+    // Redis: each unknown-name slot is a bulk-string nil. Frame is `*1\r\n$-1\r\n`.
+    assert!(s.starts_with("*1\r\n"), "outer frame wrong:\n{s}");
+    assert!(s.contains("$-1\r\n"), "expected nil slot:\n{s}");
+}
+
+#[tokio::test]
+async fn command_unknown_subcommand_errors() {
+    let state = test_state();
+    call(&state, &[b"COMMAND", b"DOCS"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn command_bare_returns_full_metadata_array() {
+    let state = test_state();
+    // Plain `COMMAND` is an alias for `COMMAND INFO` (no filter).
+    let reply = call(&state, &[b"COMMAND"]).await;
+    let s = String::from_utf8_lossy(&reply.raw);
+    // Outer array starts with `*N\r\n` where N == total count (>100).
+    assert!(s.starts_with('*'), "expected array:\n{s}");
+}

--- a/typos.toml
+++ b/typos.toml
@@ -13,3 +13,9 @@ extend-ignore-re = [
 
 [default.extend-identifiers]
 # Add project-specific identifiers that look like typos here.
+
+[default.extend-words]
+# Redis option names — absolute-timestamp variants of EX/PX. Typos hears
+# "EXAT" as a misspelling of "EXACT".
+exat = "exat"
+EXAT = "EXAT"


### PR DESCRIPTION
## Summary

- **`INFO`** — four sections (server/clients/stats/keyspace) with optional single-section filter and `everything`/`default`/`all` synonyms. `uptime_in_seconds` comes from `State::started_at_ms`, captured on container start. Reports `redis_version:7.4.0` as a compatibility signal for clients that gate on it (e.g. redis-py's HELLO); actual package version lives under `rustyant_version`. `# Keyspace` pulls `db0:keys=N,expires=M` from a new `Storage::keyspace_stats` trait method.
- **`COMMAND`** — `COUNT` / `LIST` / `INFO` subcommands. Returns the classic 6-tuple metadata (`name`, `arity`, `flags`, `first_key`, `last_key`, `step`) for all ~110 implemented commands from a single `const COMMAND_META` table. `DOCS` and `GETKEYS` are out of scope (redis-py doesn't need them).
- **`GETEX`** — Accepts `EX`/`PX`/`EXAT`/`PXAT`/`PERSIST`. Handler resolves to an absolute epoch-ms, then one CAS against the key via the new `Storage::get_string_with_ttl` trait method — so a concurrent writer can't race the expiry change with a write.
- **`EXPIRETIME` / `PEXPIRETIME`** — Return the absolute expiry (seconds / ms) via a new `Storage::expire_time_ms` trait method. Returning the stored epoch directly instead of deriving from `ttl_ms + now` avoids millisecond drift at the boundaries.

## Changes

- **`src/storage.rs`** — New types `GetExOp`, `KeyspaceStats`. New trait methods `expire_time_ms`, `get_string_with_ttl`, `keyspace_stats` (with a default impl that reports `keys_with_expire=0`; a backend that can answer cheaply may override). S3Storage impls for the two required methods.
- **`src/state.rs`** — `State::started_at_ms` captured in both constructors, feeding INFO's uptime.
- **`src/commands.rs`** — Dispatch entries + handlers for INFO / COMMAND / GETEX / EXPIRETIME / PEXPIRETIME. `COMMAND_META` const table with 110 entries.
- **`tests/integration.rs`** — 27 new tests covering the new commands, including TTL handoff (GETEX EX/PX/EXAT/PXAT/PERSIST), INFO section filtering and uptime monotonicity, COMMAND metadata shape, and arity/type error paths.
- **`README.md`** — Command surface table updated; new section documenting `INFO`/`COMMAND`/`GETEX`/`EXPIRETIME` semantics; test-count bump to 336 (18 lib + 291 HTTP integration + 14 redis-py + 6 WS + 7 floci).

## Test plan

- [x] `just check` — fmt + clippy clean (`-D warnings`)
- [x] `just test` — 336/336 passing against floci
- [x] `just test-doc` — clean
- [ ] CI green on this PR

## Known limitation

`# Keyspace` reports `expires=0` on the S3 backend because computing an accurate `keys_with_expire` would require a GET per key. The default trait impl matches this — a future backend (e.g. DynamoDB, tracked in #37) can override `keyspace_stats` to return an exact count cheaply.