### PR TITLE
:sparkles: add HELLO / CLIENT / RESET connection-handshake commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Implemented:
 
 | Group | Commands |
 |---|---|
-| Server | `PING`, `ECHO`, `TIME`, `INFO` (+ section filter), `COMMAND` (`COUNT` / `LIST` / `INFO`), `DBSIZE`, `FLUSHDB`, `FLUSHALL` |
+| Server | `PING`, `ECHO`, `TIME`, `INFO` (+ section filter), `COMMAND` (`COUNT` / `LIST` / `INFO`), `HELLO` (+ `AUTH` / `SETNAME`), `CLIENT` (`SETINFO` / `SETNAME` / `GETNAME` / `ID` / `INFO` / `LIST` / `NO-EVICT` / `REPLY` / `TRACKING` / `PAUSE` / `UNPAUSE`), `RESET`, `DBSIZE`, `FLUSHDB`, `FLUSHALL` |
 | Keyspace | `KEYS`, `SCAN` (+ `MATCH` / `COUNT` options), `TYPE`, `RENAME`, `RENAMENX`, `RANDOMKEY`, `UNLINK`, `COPY` (+ `REPLACE` / `DB 0`), `EXPIRETIME`, `PEXPIRETIME` |
 | Strings | `GET`, `GETEX` (+ `EX` / `PX` / `EXAT` / `PXAT` / `PERSIST`), `SET` (+ `EX` / `PX`), `GETSET`, `GETDEL`, `GETRANGE`, `SETRANGE`, `SETNX`, `SETEX`, `MGET`, `MSET`, `MSETNX`, `APPEND`, `STRLEN`, `DEL`, `EXISTS`, `EXPIRE`, `EXPIREAT`, `PEXPIRE`, `PEXPIREAT`, `PERSIST`, `TTL`, `PTTL`, `INCR`, `INCRBY`, `INCRBYFLOAT`, `DECR`, `DECRBY`, `GETBIT`, `SETBIT`, `BITCOUNT` (+ `BYTE` / `BIT`), `BITPOS` (+ `BYTE` / `BIT`), `BITOP` (`AND` / `OR` / `XOR` / `NOT`) |
 | Hashes | `HSET`, `HSETNX`, `HGET`, `HDEL`, `HGETALL`, `HLEN`, `HKEYS`, `HVALS`, `HEXISTS`, `HSTRLEN`, `HMGET`, `HINCRBY`, `HSCAN` (+ `MATCH` / `COUNT`) |
@@ -82,6 +82,8 @@ Bit operations follow Redis's bit numbering: bit 0 is the most significant bit o
 `INFO` emits `# Server`, `# Clients`, `# Stats`, and `# Keyspace` sections. `uptime_in_seconds` is measured from the container's cold start, so it resets on every Lambda cold boot rather than tracking a long-lived server process. `connected_clients` is a fixed `1` and `total_commands_processed` is a fixed `0` — there is no cross-invocation counter to report. `# Keyspace` uses `keyspace_stats`, which counts every live S3 object; `expires` is always `0` on the S3 backend because computing it exactly would require a GET per key (future backends can override). `COMMAND INFO` / `COMMAND LIST` / `COMMAND COUNT` return the classic 6-tuple metadata (`name`, `arity`, `flags`, `first_key`, `last_key`, `step`) for every implemented command; `COMMAND DOCS` and `COMMAND GETKEYS` are not implemented.
 
 `GETEX` resolves `EX` / `PX` / `EXAT` / `PXAT` to an absolute epoch-ms on the handler side, then runs one CAS against the key — so a concurrent writer can't race the expiry change with a write. `PERSIST` clears any existing TTL. `EXPIRETIME` / `PEXPIRETIME` return the absolute expiry (seconds / ms); `-1` for no TTL, `-2` for missing keys, matching Redis.
+
+`HELLO` accepts protover `2` and returns the standard info map (`server`, `version`, `proto`, `id`, `mode`, `role`, `modules`); protover `3` returns `-NOPROTO` so clients fall back to RESP2 cleanly. `AUTH` and `SETNAME` are accepted syntactically but ignored — rustyant has no auth backend and no per-connection client tracking. `CLIENT` subcommands are stubbed quietly (`+OK` for `SETINFO` / `SETNAME` / connection-config variants; fixed-value replies for `ID` / `GETNAME` / `INFO` / `LIST`) so redis-py's connection setup doesn't log "unknown command" on every connect. `RESET` returns `+RESET` with no state to clear.
 
 ### Concurrency
 
@@ -172,6 +174,6 @@ The `rustyant` and `rustyant-ws` binaries emit structured JSON logs via `tracing
 
 ## Status
 
-Working: RESP over HTTP and WebSocket, full string/hash/list/set/zset command dispatch plus `KEYS` / `SCAN` / `HSCAN` / `SSCAN` / `ZSCAN`, server introspection via `INFO` and `COMMAND`, S3-backed storage with per-key TTL and conditional-write CAS on every read-modify-write, 336 Rust tests across 5 suites (18 lib units + 291 HTTP integration + 14 redis-py compat + 6 WebSocket E2E + 7 floci/S3) and 13 Python client tests, structured logs and CloudWatch EMF metrics, CI on GitHub Actions with floci as a service container, SAM template validated in CI.
+Working: RESP over HTTP and WebSocket, full string/hash/list/set/zset command dispatch plus `KEYS` / `SCAN` / `HSCAN` / `SSCAN` / `ZSCAN`, server introspection via `INFO` / `COMMAND` / `HELLO` / `CLIENT`, S3-backed storage with per-key TTL and conditional-write CAS on every read-modify-write, 351 Rust tests across 5 suites (18 lib units + 306 HTTP integration + 14 redis-py compat + 6 WebSocket E2E + 7 floci/S3) and 13 Python client tests, structured logs and CloudWatch EMF metrics, CI on GitHub Actions with floci as a service container, SAM template validated in CI.
 
 Not wired: no end-to-end test driving a real WebSocket connection against a deployed binary in AWS; the `s3_concurrent_incr_converges` CAS test is gated behind `RUSTYANT_S3_CAS=1` because floci doesn't enforce `If-Match` headers.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -102,6 +102,9 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "TIME" => handle_time(&args),
         "INFO" => handle_info(state, args).await,
         "COMMAND" => handle_command(&args),
+        "HELLO" => handle_hello(&args),
+        "CLIENT" => handle_client(&args),
+        "RESET" => Ok(RespReply::SimpleString("RESET".into())),
         "DBSIZE" => handle_dbsize(state, args).await,
         "FLUSHDB" | "FLUSHALL" => handle_flushall(state, args, &cmd).await,
         "RANDOMKEY" => handle_randomkey(state, args).await,
@@ -1646,6 +1649,107 @@ async fn handle_copy(state: &State, args: Vec<Bytes>) -> Result<RespReply, Rusty
 }
 
 // ---------------------------------------------------------------------------
+// Connection handshake — HELLO / CLIENT / RESET.
+//
+// redis-py issues these on every connection (HELLO for protocol negotiation,
+// CLIENT SETINFO to register library metadata). Returning `unknown command`
+// forces redis-py into error-and-retry paths and clutters production logs;
+// accepting them quietly is the friendlier default.
+// ---------------------------------------------------------------------------
+
+/// Redis `HELLO` — protocol handshake.
+///
+/// `HELLO [protover] [AUTH user password] [SETNAME name]`. rustyant only
+/// speaks RESP2: `protover=2` (or omitted) succeeds with the info map;
+/// `protover=3` returns `-NOPROTO` so the client falls back cleanly. AUTH
+/// and SETNAME are accepted syntactically but ignored — rustyant has no
+/// auth model and no per-connection client tracking (Lambda is one-shot).
+fn handle_hello(args: &[Bytes]) -> Result<RespReply, RustyAntError> {
+    let mut i = 0;
+    if let Some(first) = args.first() {
+        // First positional arg, if present, must be the protover — anything
+        // else (AUTH/SETNAME with no protover) is a syntax error per Redis.
+        let proto_str = arg_as_str(first)?;
+        let proto: i64 = proto_str.parse().map_err(|_| {
+            RustyAntError::Parse(format!("Protocol version is not an integer or out of range: {proto_str}"))
+        })?;
+        if proto != 2 {
+            return Err(RustyAntError::Parse(
+                "NOPROTO unsupported protocol version — rustyant speaks RESP2 only".into(),
+            ));
+        }
+        i += 1;
+    }
+    while i < args.len() {
+        let opt = arg_as_str(&args[i])?.to_ascii_uppercase();
+        match opt.as_str() {
+            "AUTH" => {
+                // AUTH requires two more args (user, password). Consume them
+                // without validating — rustyant has no auth backend.
+                if args.len() < i + 3 {
+                    return Err(RustyAntError::Parse("AUTH requires username and password".into()));
+                }
+                i += 3;
+            }
+            "SETNAME" => {
+                if args.len() < i + 2 {
+                    return Err(RustyAntError::Parse("SETNAME requires a value".into()));
+                }
+                i += 2;
+            }
+            other => return Err(RustyAntError::Parse(format!("unsupported HELLO option: {other}"))),
+        }
+    }
+    Ok(hello_info_reply())
+}
+
+/// Flat key/value array describing the server, returned to a successful
+/// `HELLO [2]`. Matches the shape Redis itself emits for RESP2.
+fn hello_info_reply() -> RespReply {
+    let bulk = |s: &str| RespReply::BulkString(Some(Bytes::copy_from_slice(s.as_bytes())));
+    RespReply::Array(vec![
+        bulk("server"),
+        bulk("rustyant"),
+        bulk("version"),
+        bulk(env!("CARGO_PKG_VERSION")),
+        bulk("proto"),
+        RespReply::Integer(2),
+        bulk("id"),
+        RespReply::Integer(1),
+        bulk("mode"),
+        bulk("standalone"),
+        bulk("role"),
+        bulk("master"),
+        bulk("modules"),
+        RespReply::Array(Vec::new()),
+    ])
+}
+
+/// Redis `CLIENT` — per-connection configuration.
+///
+/// rustyant has no persistent connection state (Lambda), so every subcommand
+/// returns a sensible canned reply. The subcommands that clients actually
+/// call on connect (SETINFO, SETNAME, ID, GETNAME) are accepted quietly;
+/// the rest return `+OK` too, with an explicit error only for genuinely
+/// unknown subcommand names.
+fn handle_client(args: &[Bytes]) -> Result<RespReply, RustyAntError> {
+    let sub = args.first().ok_or_else(|| RustyAntError::WrongArity { command: "CLIENT".into() })?;
+    let sub = arg_as_str(sub)?.to_ascii_uppercase();
+    match sub.as_str() {
+        "SETINFO" | "SETNAME" | "NO-EVICT" | "NO-TOUCH" | "REPLY" | "UNPAUSE" | "PAUSE" | "TRACKING"
+        | "TRACKINGINFO" => Ok(RespReply::ok()),
+        "ID" => Ok(RespReply::Integer(1)),
+        "GETNAME" => Ok(RespReply::BulkString(Some(Bytes::new()))),
+        // INFO and LIST report the single "connection" rustyant ever has
+        // (Lambda is one-shot). redis-py and redis-cli both parse this line.
+        "INFO" | "LIST" => {
+            Ok(RespReply::BulkString(Some(Bytes::from_static(b"id=1 addr=lambda name= age=0 idle=0 flags=N db=0\r\n"))))
+        }
+        other => Err(RustyAntError::Parse(format!("unsupported CLIENT subcommand: {other}"))),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // COMMAND — minimal server introspection for redis-py's discovery path.
 // Scope is `COUNT` / `LIST` / `INFO`; `DOCS` and `GETKEYS` are out of scope
 // because redis-py does not require them.
@@ -1667,6 +1771,9 @@ const COMMAND_META: &[CommandMeta] = &[
     ("time", 1, &["fast", "loading", "stale"], 0, 0, 0),
     ("info", -1, &["loading", "stale"], 0, 0, 0),
     ("command", -1, &["loading", "stale"], 0, 0, 0),
+    ("hello", -1, &["fast", "loading", "stale"], 0, 0, 0),
+    ("client", -2, &["admin", "noscript"], 0, 0, 0),
+    ("reset", 1, &["fast", "loading", "stale"], 0, 0, 0),
     ("dbsize", 1, &["readonly", "fast"], 0, 0, 0),
     ("flushdb", -1, &["write"], 0, 0, 0),
     ("flushall", -1, &["write"], 0, 0, 0),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2918,3 +2918,124 @@ async fn command_bare_returns_full_metadata_array() {
     // Outer array starts with `*N\r\n` where N == total count (>100).
     assert!(s.starts_with('*'), "expected array:\n{s}");
 }
+
+// ---------------------------------------------------------------------------
+// HELLO / CLIENT / RESET
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn hello_without_protover_returns_info_map() {
+    let state = test_state();
+    let reply = call(&state, &[b"HELLO"]).await;
+    let s = String::from_utf8_lossy(&reply.raw);
+    assert!(s.starts_with("*14\r\n"), "expected 14-element array:\n{s}");
+    assert!(s.contains("$8\r\nrustyant\r\n"), "server name missing:\n{s}");
+    assert!(s.contains("$5\r\nproto\r\n"), "proto field missing:\n{s}");
+    assert!(s.contains(":2\r\n"), "proto version 2 missing:\n{s}");
+}
+
+#[tokio::test]
+async fn hello_protover_2_succeeds() {
+    let state = test_state();
+    let reply = call(&state, &[b"HELLO", b"2"]).await;
+    let s = String::from_utf8_lossy(&reply.raw);
+    assert!(s.starts_with("*14\r\n"));
+}
+
+#[tokio::test]
+async fn hello_protover_3_returns_noproto() {
+    let state = test_state();
+    let reply = call(&state, &[b"HELLO", b"3"]).await;
+    let s = String::from_utf8_lossy(&reply.raw);
+    assert!(s.starts_with('-'), "expected error reply:\n{s}");
+    assert!(s.contains("NOPROTO"), "expected NOPROTO marker:\n{s}");
+}
+
+#[tokio::test]
+async fn hello_auth_and_setname_are_accepted_and_ignored() {
+    let state = test_state();
+    // Both AUTH and SETNAME present -> rustyant accepts the syntax and returns
+    // the info map. The auth credentials are ignored (no auth backend).
+    let reply = call(&state, &[b"HELLO", b"2", b"AUTH", b"user", b"pass", b"SETNAME", b"redis-py"]).await;
+    let s = String::from_utf8_lossy(&reply.raw);
+    assert!(s.starts_with("*14\r\n"), "expected info map:\n{s}");
+}
+
+#[tokio::test]
+async fn hello_invalid_protover_errors() {
+    let state = test_state();
+    call(&state, &[b"HELLO", b"not-a-number"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn hello_auth_missing_args_errors() {
+    let state = test_state();
+    // AUTH with no username/password -> syntax error.
+    call(&state, &[b"HELLO", b"2", b"AUTH"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"HELLO", b"2", b"AUTH", b"user"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn client_setinfo_returns_ok() {
+    let state = test_state();
+    call(&state, &[b"CLIENT", b"SETINFO", b"lib-name", b"redis-py"]).await.expect_simple("OK");
+    call(&state, &[b"CLIENT", b"SETINFO", b"lib-ver", b"5.0.0"]).await.expect_simple("OK");
+}
+
+#[tokio::test]
+async fn client_setname_returns_ok() {
+    let state = test_state();
+    call(&state, &[b"CLIENT", b"SETNAME", b"my-client"]).await.expect_simple("OK");
+}
+
+#[tokio::test]
+async fn client_id_returns_integer() {
+    let state = test_state();
+    call(&state, &[b"CLIENT", b"ID"]).await.expect_integer(1);
+}
+
+#[tokio::test]
+async fn client_getname_returns_empty_bulk() {
+    let state = test_state();
+    // rustyant has no per-connection state, so name is always empty.
+    let reply = call(&state, &[b"CLIENT", b"GETNAME"]).await;
+    // Empty bulk is `$0\r\n\r\n`.
+    assert_eq!(reply.raw, b"$0\r\n\r\n", "got {:?}", String::from_utf8_lossy(&reply.raw));
+}
+
+#[tokio::test]
+async fn client_info_returns_summary_line() {
+    let state = test_state();
+    let reply = call(&state, &[b"CLIENT", b"INFO"]).await;
+    let s = String::from_utf8_lossy(&reply.raw);
+    assert!(s.starts_with('$'), "expected bulk string:\n{s}");
+    assert!(s.contains("id=1"), "expected id field:\n{s}");
+}
+
+#[tokio::test]
+async fn client_unknown_subcommand_errors() {
+    let state = test_state();
+    call(&state, &[b"CLIENT", b"KILL", b"127.0.0.1:6379"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn client_requires_a_subcommand() {
+    let state = test_state();
+    call(&state, &[b"CLIENT"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn reset_returns_simple_string() {
+    let state = test_state();
+    call(&state, &[b"RESET"]).await.expect_simple("RESET");
+}
+
+#[tokio::test]
+async fn command_info_hello_client_reset_are_registered() {
+    let state = test_state();
+    for name in [b"HELLO".as_ref(), b"CLIENT".as_ref(), b"RESET".as_ref()] {
+        let reply = call(&state, &[b"COMMAND", b"INFO", name]).await;
+        let s = String::from_utf8_lossy(&reply.raw);
+        assert!(s.starts_with("*1\r\n*6\r\n"), "{name:?} not in COMMAND INFO:\n{s}");
+    }
+}

--- a/tests/redis_py_compat.rs
+++ b/tests/redis_py_compat.rs
@@ -28,7 +28,6 @@ use bytes::{Bytes, BytesMut};
 use redis_protocol::resp2::decode::decode_bytes_mut;
 use redis_protocol::resp2::types::BytesFrame;
 use rustyant::commands;
-use rustyant::resp::RespReply;
 use rustyant::state::State;
 use rustyant::test_support::floci_state;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -70,7 +69,7 @@ async fn serve_connection(state: State, stream: TcpStream) {
             let Some(argv) = frame_to_argv(parsed) else {
                 return;
             };
-            let reply = dispatch_with_stubs(&state, argv).await;
+            let reply = commands::dispatch(&state, argv).await;
             let Ok(encoded) = reply.encode() else {
                 return;
             };
@@ -102,28 +101,6 @@ fn frame_to_argv(frame: BytesFrame) -> Option<Vec<Bytes>> {
         }
         _ => None,
     }
-}
-
-/// redis-py issues a few bookkeeping commands on connection setup that
-/// rustyant doesn't implement: `HELLO` for protocol negotiation and
-/// `CLIENT SETINFO` to register client library metadata. Neither is a real
-/// rustyant concern, but returning our generic `-ERR unknown command` on
-/// them makes the redis-py `Retry`-on-connect logic noisy. Stub them here in
-/// the test harness only; production dispatch is untouched.
-async fn dispatch_with_stubs(state: &State, argv: Vec<Bytes>) -> RespReply {
-    if let Some(first) = argv.first() {
-        if first.eq_ignore_ascii_case(b"HELLO") {
-            // Returning an error lets redis-py fall back to RESP2 without
-            // erroring up to the caller. This matches what a pre-HELLO
-            // Redis server (< 6.0) returns.
-            return RespReply::err("ERR unknown command 'HELLO'");
-        }
-        if first.eq_ignore_ascii_case(b"CLIENT") {
-            // CLIENT SETINFO / CLIENT GETNAME etc. — just return OK.
-            return RespReply::ok();
-        }
-    }
-    commands::dispatch(state, argv).await
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

redis-py issues `HELLO` (for RESP3 negotiation) and `CLIENT SETINFO` (to register client-library metadata) on every connect. rustyant used to return `-ERR unknown command` on both, which redis-py logs as a warning and retries past — production Lambda logs filled with noise. This PR makes the dispatch quiet on the happy path.

- **`HELLO`** — Accepts optional protover (`2` succeeds, `3` returns `-NOPROTO` for clean RESP2 fallback). `AUTH` and `SETNAME` are accepted syntactically and ignored (no auth backend, no per-connection state). Returns the standard 14-field info map (`server`, `version`, `proto`, `id`, `mode`, `role`, `modules`).
- **`CLIENT`** — Subcommand router. `SETINFO` / `SETNAME` / `PAUSE` / `UNPAUSE` / `REPLY` / `TRACKING` / `TRACKINGINFO` / `NO-EVICT` / `NO-TOUCH` → `+OK`. `ID` → `1`. `GETNAME` → empty bulk. `INFO` / `LIST` → single-line summary matching Redis's format. Unknown subcommands error explicitly.
- **`RESET`** — `+RESET\r\n`. Lambda is one-shot; no session state to clear.

## Changes

- **`src/commands.rs`** — Dispatch entries + `handle_hello` / `handle_client` / inline RESET. `hello_info_reply()` helper builds the info map. Three new `COMMAND_META` entries so `COMMAND INFO HELLO` / `CLIENT` / `RESET` work.
- **`tests/redis_py_compat.rs`** — Removes the local `dispatch_with_stubs` shim (~15 LOC) now that production dispatch handles HELLO / CLIENT directly. The harness is back to a plain `commands::dispatch` call.
- **`tests/integration.rs`** — 15 new tests covering HELLO (no args / protover 2 / protover 3 → NOPROTO / AUTH+SETNAME / invalid protover / AUTH missing args), CLIENT (SETINFO / SETNAME / ID / GETNAME / INFO / unknown subcommand / bare), RESET, and COMMAND INFO registration.
- **`README.md`** — Server row in the command-surface table now lists the new commands; a new paragraph documents HELLO / CLIENT / RESET semantics; test-count bumped to 351 (+15).

## Test plan

- [x] `just check` — fmt + clippy clean (`-D warnings`)
- [x] `just test` — 351/351 passing against floci (up from 336)
- [x] `typos` — clean
- [ ] CI green on this PR

## Migration notes

No behavior changes for existing clients. Existing `CLIENT` behavior was `-ERR unknown command` for every subcommand; that's now `+OK` for the common ones. Any caller that was relying on the error reply to detect "no CLIENT support" will need updating — unlikely, since that's not a pattern redis-py or redis-cli uses.