### PR TITLE
:sparkles: add QUIT command

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -106,6 +106,10 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "HELLO" => handle_hello(&args),
         "CLIENT" => handle_client(&args),
         "RESET" => Ok(RespReply::SimpleString("RESET".into())),
+        "QUIT" => {
+            arity("QUIT", args.is_empty())?;
+            Ok(RespReply::ok())
+        }
         "AUTH" => handle_auth(&args),
         "WAIT" => handle_wait(&args),
         "SAVE" => {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -121,6 +121,18 @@ async fn unknown_command_returns_error() {
 }
 
 #[tokio::test]
+async fn quit_returns_ok() {
+    let state = test_state();
+    call(&state, &[b"QUIT"]).await.expect_simple("OK");
+}
+
+#[tokio::test]
+async fn quit_rejects_args() {
+    let state = test_state();
+    call(&state, &[b"QUIT", b"extra"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
 async fn malformed_body_returns_parse_error() {
     let state = test_state();
     let resp = handle(


### PR DESCRIPTION
## Summary

- Adds `QUIT` as a trivial `+OK` reply
- Rejects arguments with the standard wrong-arity error

## Why

Some pooled / older clients (redis-py < 4.5, node-redis) still emit `QUIT` during orderly shutdown. Returning `unknown command` surfaces noisily in logs for no gain. The connection-close semantic is a no-op on rustyant — one command per request over HTTP/WS, the transport closes on its own terms — but the reply is the same.

Closes #67.

## Test plan

- [x] `cargo nextest run ... quit_returns_ok quit_rejects_args` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean