### PR TITLE
:sparkles: add SELECT (single-namespace stub)

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -110,6 +110,7 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
             arity("QUIT", args.is_empty())?;
             Ok(RespReply::ok())
         }
+        "SELECT" => handle_select(&args),
         "AUTH" => handle_auth(&args),
         "WAIT" => handle_wait(&args),
         "SAVE" => {
@@ -2492,6 +2493,18 @@ fn handle_client(args: &[Bytes]) -> Result<RespReply, RustyAntError> {
 fn handle_auth(args: &[Bytes]) -> Result<RespReply, RustyAntError> {
     arity("AUTH", matches!(args.len(), 1 | 2))?;
     Ok(RespReply::ok())
+}
+
+/// Redis `SELECT index`.
+///
+/// rustyant is single-namespace by construction (one S3 prefix, `CONFIG GET
+/// databases` reports `1`). `SELECT 0` succeeds so clients that probe for
+/// db 0 on connection setup stay quiet; any other index errors with Redis's
+/// standard out-of-range message.
+fn handle_select(args: &[Bytes]) -> Result<RespReply, RustyAntError> {
+    arity("SELECT", args.len() == 1)?;
+    let idx = parse_i64(&args[0], "DB index")?;
+    if idx == 0 { Ok(RespReply::ok()) } else { Err(RustyAntError::Parse("DB index is out of range".into())) }
 }
 
 /// Redis `WAIT numreplicas timeout`.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -133,6 +133,25 @@ async fn quit_rejects_args() {
 }
 
 #[tokio::test]
+async fn select_zero_returns_ok() {
+    let state = test_state();
+    call(&state, &[b"SELECT", b"0"]).await.expect_simple("OK");
+}
+
+#[tokio::test]
+async fn select_non_zero_errors() {
+    let state = test_state();
+    call(&state, &[b"SELECT", b"1"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn select_non_numeric_errors() {
+    let state = test_state();
+    call(&state, &[b"SELECT", b"abc"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"SELECT"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
 async fn malformed_body_returns_parse_error() {
     let state = test_state();
     let resp = handle(


### PR DESCRIPTION
## Summary

- `SELECT 0` → `+OK`
- `SELECT n` (n ≠ 0) → `-ERR DB index is out of range`
- Missing / non-numeric arg → standard parse/arity error

## Why

Most clients emit `SELECT 0` on connect even when they only use the default db. Returning `unknown command` logs noisily. rustyant is single-namespace by construction, so honoring `0` and erroring otherwise is the honest shape.

Closes #60.

## Test plan

- [x] `SELECT 0` succeeds
- [x] `SELECT 1` errors
- [x] `SELECT abc` / `SELECT` (no arg) error
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean