### PR TITLE
:sparkles: add TOUCH command

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -171,6 +171,7 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "MSET" => handle_mset(state, args).await,
         "MSETNX" => handle_msetnx(state, args).await,
         "EXISTS" => handle_exists(state, args).await,
+        "TOUCH" => handle_touch(state, args).await,
         "EXPIRE" => handle_expire(state, args).await,
         "EXPIREAT" => handle_expireat(state, args).await,
         "PEXPIRE" => handle_pexpire(state, args).await,
@@ -386,6 +387,25 @@ async fn handle_del(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyA
 
 async fn handle_exists(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
     arity("EXISTS", !args.is_empty())?;
+    let mut count: i64 = 0;
+    for arg in &args {
+        let key = arg_as_str(arg)?;
+        if state.storage.exists(key).await? {
+            count += 1;
+        }
+    }
+    Ok(RespReply::Integer(count))
+}
+
+/// Redis `TOUCH key [key ...]`.
+///
+/// Real Redis bumps LRU / LFU access counters as a side effect; rustyant has
+/// no access-time tracking on S3 (same reason `OBJECT IDLETIME` returns 0),
+/// so the reply is just the count of keys that exist — the externally
+/// observable part of the contract. Duplicates are counted per occurrence,
+/// matching Redis's `EXISTS` sibling.
+async fn handle_touch(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("TOUCH", !args.is_empty())?;
     let mut count: i64 = 0;
     for arg in &args {
         let key = arg_as_str(arg)?;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -176,6 +176,21 @@ async fn exists_counts_present_keys() {
 }
 
 #[tokio::test]
+async fn touch_counts_existing_keys() {
+    let state = test_state();
+    call(&state, &[b"SET", b"a", b"1"]).await;
+    call(&state, &[b"SET", b"b", b"2"]).await;
+    call(&state, &[b"TOUCH", b"a", b"b", b"missing", b"a"]).await.expect_integer(3);
+    call(&state, &[b"TOUCH", b"missing"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn touch_rejects_empty() {
+    let state = test_state();
+    call(&state, &[b"TOUCH"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
 async fn incr_on_missing_key_starts_at_one() {
     let state = test_state();
     call(&state, &[b"INCR", b"counter"]).await.expect_integer(1);


### PR DESCRIPTION
## Summary

- `TOUCH key [key ...]` returns the count of existing keys.
- Matches Redis's sibling-to-`EXISTS` shape including duplicate counting.

## Why

\`TOUCH\` is the access-time refresher that \`redis-cli --bigkeys\` and similar tools call. rustyant has no access-time tracking (same rationale as \`OBJECT IDLETIME\`), so the honest reply is the existence count. The side-effect is unobservable here.

Closes #62.

## Test plan

- [x] counts existing + duplicates, skips missing
- [x] empty arg list errors
- [x] lint / fmt clean