### PR TITLE
:sparkles: add SMOVE command

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -249,6 +249,7 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "SINTERSTORE" => handle_sstore(state, args, SetOp::Inter).await,
         "SUNIONSTORE" => handle_sstore(state, args, SetOp::Union).await,
         "SDIFFSTORE" => handle_sstore(state, args, SetOp::Diff).await,
+        "SMOVE" => handle_smove(state, args).await,
         "SPOP" => handle_spop(state, args).await,
         "SRANDMEMBER" => handle_srandmember(state, args).await,
         "SSCAN" => handle_sscan(state, args).await,
@@ -1806,6 +1807,42 @@ async fn handle_srem(state: &State, args: Vec<Bytes>) -> Result<RespReply, Rusty
     let members: Vec<String> = args.iter().skip(1).map(arg_as_string).collect::<Result<_, _>>()?;
     let removed = state.storage.srem(key, &members).await?;
     Ok(RespReply::Integer(removed))
+}
+
+/// Redis `SMOVE source destination member`.
+///
+/// Cross-key move is best-effort on the S3 backend (same guarantee as
+/// `RENAME` / `COPY`): a concurrent writer landing between the `SREM` and
+/// `SADD` can surface an error after the element has already left the
+/// source. The destination type is pre-checked so a WRONGTYPE on dst
+/// cannot cost the source its member. Same-key short-circuits to a
+/// membership check and returns `1` without writing.
+async fn handle_smove(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("SMOVE", args.len() == 3)?;
+    let source = arg_as_string(&args[0])?;
+    let destination = arg_as_string(&args[1])?;
+    let member = arg_as_string(&args[2])?;
+
+    // Pre-check destination: must be a set or missing, else WRONGTYPE without
+    // touching the source.
+    match state.storage.kind(&destination).await? {
+        Some("set") | None => {}
+        Some(_) => return Err(RustyAntError::WrongType { key: destination }),
+    }
+
+    // Membership check on source (propagates WRONGTYPE on non-set sources).
+    if !state.storage.sismember(&source, &member).await? {
+        return Ok(RespReply::Integer(0));
+    }
+
+    if source == destination {
+        // Member already lives in the set; no write needed.
+        return Ok(RespReply::Integer(1));
+    }
+
+    state.storage.srem(&source, std::slice::from_ref(&member)).await?;
+    state.storage.sadd(&destination, vec![member]).await?;
+    Ok(RespReply::Integer(1))
 }
 
 async fn handle_zrem(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2589,6 +2589,66 @@ async fn smismember_on_wrong_type_errors() {
 }
 
 #[tokio::test]
+async fn smove_transfers_member() {
+    let state = test_state();
+    call(&state, &[b"SADD", b"src", b"a", b"b", b"c"]).await;
+    call(&state, &[b"SADD", b"dst", b"x"]).await;
+    call(&state, &[b"SMOVE", b"src", b"dst", b"a"]).await.expect_integer(1);
+    // Member removed from source, added to dest.
+    call(&state, &[b"SISMEMBER", b"src", b"a"]).await.expect_integer(0);
+    call(&state, &[b"SISMEMBER", b"dst", b"a"]).await.expect_integer(1);
+}
+
+#[tokio::test]
+async fn smove_missing_member_returns_zero() {
+    let state = test_state();
+    call(&state, &[b"SADD", b"src", b"a"]).await;
+    call(&state, &[b"SADD", b"dst", b"x"]).await;
+    call(&state, &[b"SMOVE", b"src", b"dst", b"missing"]).await.expect_integer(0);
+    call(&state, &[b"SISMEMBER", b"dst", b"missing"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn smove_missing_source_returns_zero() {
+    let state = test_state();
+    call(&state, &[b"SMOVE", b"nope", b"dst", b"a"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn smove_same_key_is_noop_when_member_present() {
+    let state = test_state();
+    call(&state, &[b"SADD", b"s", b"a"]).await;
+    call(&state, &[b"SMOVE", b"s", b"s", b"a"]).await.expect_integer(1);
+    call(&state, &[b"SCARD", b"s"]).await.expect_integer(1);
+}
+
+#[tokio::test]
+async fn smove_wrong_type_source_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"src", b"v"]).await;
+    call(&state, &[b"SADD", b"dst", b"x"]).await;
+    call(&state, &[b"SMOVE", b"src", b"dst", b"a"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn smove_wrong_type_destination_preserves_source() {
+    let state = test_state();
+    call(&state, &[b"SADD", b"src", b"a"]).await;
+    call(&state, &[b"SET", b"dst", b"v"]).await;
+    call(&state, &[b"SMOVE", b"src", b"dst", b"a"]).await.expect_error_prefix("ERR");
+    // Source is unchanged — the pre-check caught the bad dst before the SREM.
+    call(&state, &[b"SISMEMBER", b"src", b"a"]).await.expect_integer(1);
+}
+
+#[tokio::test]
+async fn smove_empties_source_removes_key() {
+    let state = test_state();
+    call(&state, &[b"SADD", b"src", b"only"]).await;
+    call(&state, &[b"SMOVE", b"src", b"dst", b"only"]).await.expect_integer(1);
+    call(&state, &[b"EXISTS", b"src"]).await.expect_integer(0);
+}
+
+#[tokio::test]
 async fn spop_single_removes_and_returns_member() {
     let state = test_state();
     call(&state, &[b"SADD", b"s", b"only"]).await;

--- a/typos.toml
+++ b/typos.toml
@@ -19,3 +19,6 @@ extend-ignore-re = [
 # "EXAT" as a misspelling of "EXACT".
 exat = "exat"
 EXAT = "EXAT"
+# SMOVE — Redis set-move command; typos hears it as `move`.
+smove = "smove"
+SMOVE = "SMOVE"


### PR DESCRIPTION
## Summary

- Adds `SMOVE source destination member`
- Destination type pre-checked before `SREM` on source (cross-key safety)
- Same-key short-circuits to a membership check
- Seven integration tests covering transfer / missing / wrong-type / empties-source paths

## Why

Classic set primitive for workflow patterns (move item from "inbox" to "processing"). Matches the existing `RENAME` / `COPY` best-effort guarantee across keys on the S3 backend.

Closes #55.

## Test plan

- [x] transfer / missing-member / missing-source / same-key / wrong-type src / wrong-type dst / empties-source
- [x] lint / fmt clean