### PR TITLE
:sparkles: add HINCRBYFLOAT

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -210,6 +210,7 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "HSTRLEN" => handle_hstrlen(state, args).await,
         "HMGET" => handle_hmget(state, args).await,
         "HINCRBY" => handle_hincrby(state, args).await,
+        "HINCRBYFLOAT" => handle_hincrbyfloat(state, args).await,
         "HSCAN" => handle_hscan(state, args).await,
         // Lists
         "LPUSH" => handle_push(state, args, true).await,
@@ -1411,6 +1412,20 @@ async fn handle_hincrby(state: &State, args: Vec<Bytes>) -> Result<RespReply, Ru
     let delta = parse_i64(&args[2], "increment")?;
     let new_val = state.storage.hincr_by(key, field, delta).await?;
     Ok(RespReply::Integer(new_val))
+}
+
+/// Redis `HINCRBYFLOAT key field increment`. Reply is the new value as a
+/// bulk string, matching Redis. Rejects NaN / infinity deltas and results.
+async fn handle_hincrbyfloat(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("HINCRBYFLOAT", args.len() == 3)?;
+    let key = arg_as_str(&args[0])?;
+    let field = arg_as_str(&args[1])?;
+    let delta = parse_f64(&args[2], "increment")?;
+    if delta.is_nan() || delta.is_infinite() {
+        return Err(RustyAntError::Parse("increment would produce NaN or infinity".into()));
+    }
+    let new_val = state.storage.hincr_by_float(key, field, delta).await?;
+    Ok(RespReply::BulkString(Some(Bytes::from(format_score(new_val).into_bytes()))))
 }
 
 async fn handle_srem(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -585,6 +585,7 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn hstrlen(&self, key: &str, field: &str) -> Result<i64, RustyAntError>;
     async fn hmget(&self, key: &str, fields: &[String]) -> Result<Vec<Option<Bytes>>, RustyAntError>;
     async fn hincr_by(&self, key: &str, field: &str, delta: i64) -> Result<i64, RustyAntError>;
+    async fn hincr_by_float(&self, key: &str, field: &str, delta: f64) -> Result<f64, RustyAntError>;
     /// Incremental iteration over a hash's `(field, value)` pairs. `cursor=0`
     /// starts a fresh scan; a non-zero return cursor means more pages remain,
     /// `0` means the scan is exhausted. `count` bounds the batch size; `MATCH`
@@ -2071,6 +2072,34 @@ impl Storage for S3Storage {
             let new_val =
                 current.checked_add(delta).ok_or_else(|| RustyAntError::Parse("increment overflow".into()))?;
             map.insert(field.clone(), new_val.to_string().into_bytes());
+            let new_entry = StoredValue { expires_at_ms, value: Value::Hash(map) };
+            Ok(CasAction::Write(new_entry, new_val))
+        })
+        .await
+    }
+
+    async fn hincr_by_float(&self, key: &str, field: &str, delta: f64) -> Result<f64, RustyAntError> {
+        let field = field.to_string();
+        self.cas(key, move |entry| {
+            let (mut map, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::Hash(m), expires_at_ms }) => (m.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => (BTreeMap::new(), None),
+            };
+            let current: f64 = map
+                .get(&field)
+                .map(|v| {
+                    let s =
+                        std::str::from_utf8(v).map_err(|_| RustyAntError::Parse("hash value is not a float".into()))?;
+                    s.parse::<f64>().map_err(|_| RustyAntError::Parse("hash value is not a float".into()))
+                })
+                .transpose()?
+                .unwrap_or(0.0);
+            let new_val = current + delta;
+            if new_val.is_nan() || new_val.is_infinite() {
+                return Err(RustyAntError::Parse("increment would produce NaN or infinity".into()));
+            }
+            map.insert(field.clone(), format_float(new_val).into_bytes());
             let new_entry = StoredValue { expires_at_ms, value: Value::Hash(map) };
             Ok(CasAction::Write(new_entry, new_val))
         })

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1010,6 +1010,42 @@ async fn hincrby_on_non_integer_field_errors() {
 }
 
 #[tokio::test]
+async fn hincrbyfloat_creates_field_at_zero() {
+    let state = test_state();
+    call(&state, &[b"HINCRBYFLOAT", b"h", b"bal", b"10.5"]).await.expect_bulk(b"10.5");
+    call(&state, &[b"HINCRBYFLOAT", b"h", b"bal", b"0.1"]).await.expect_bulk(b"10.6");
+    call(&state, &[b"HINCRBYFLOAT", b"h", b"bal", b"-10.6"]).await.expect_bulk(b"0");
+}
+
+#[tokio::test]
+async fn hincrbyfloat_on_existing_integer_field_works() {
+    let state = test_state();
+    call(&state, &[b"HSET", b"h", b"count", b"5"]).await;
+    call(&state, &[b"HINCRBYFLOAT", b"h", b"count", b"0.5"]).await.expect_bulk(b"5.5");
+}
+
+#[tokio::test]
+async fn hincrbyfloat_on_non_float_field_errors() {
+    let state = test_state();
+    call(&state, &[b"HSET", b"h", b"name", b"alice"]).await;
+    call(&state, &[b"HINCRBYFLOAT", b"h", b"name", b"1.0"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn hincrbyfloat_rejects_nan_or_inf_increment() {
+    let state = test_state();
+    call(&state, &[b"HINCRBYFLOAT", b"h", b"f", b"nan"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"HINCRBYFLOAT", b"h", b"f", b"inf"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn hincrbyfloat_on_wrong_type_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"HINCRBYFLOAT", b"k", b"f", b"1.0"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
 async fn srem_returns_count_removed() {
     let state = test_state();
     call(&state, &[b"SADD", b"s", b"a", b"b", b"c"]).await;


### PR DESCRIPTION
## Summary

- Adds `HINCRBYFLOAT key field increment` with full parity to `INCRBYFLOAT` on strings
- Reply is the new value as a bulk string (integer-valued results render without decimal)
- Rejects NaN / infinity on both input delta and computed result

## Why

Parity with the existing `HINCRBY` (integer) and `INCRBYFLOAT` (string-float) handlers. Used in any counter that tallies currency / ratios / probabilities inside a hash.

Closes #56.

## Test plan

- [x] creates field at zero, accumulates, handles negatives (`10.5 + 0.1 → 10.6`, then `-10.6 → 0`)
- [x] works on pre-existing integer field
- [x] errors on non-float field
- [x] errors on NaN / inf increment
- [x] errors on wrong-type key
- [x] lint / fmt clean