### PR TITLE
:sparkles: add ZRANDMEMBER (random sampling on sorted sets)

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -265,6 +265,7 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "ZREVRANK" => handle_zrank(state, args, true).await,
         "ZCOUNT" => handle_zcount(state, args).await,
         "ZMSCORE" => handle_zmscore(state, args).await,
+        "ZRANDMEMBER" => handle_zrandmember(state, args).await,
         "ZSCAN" => handle_zscan(state, args).await,
         other => Err(RustyAntError::UnknownCommand(other.to_string())),
     }
@@ -1346,6 +1347,52 @@ async fn handle_srandmember(state: &State, args: Vec<Bytes>) -> Result<RespReply
     } else {
         let mut picked = state.storage.srandmember(key, 1, false).await?;
         Ok(picked.pop().map_or(RespReply::Nil, |m| RespReply::BulkString(Some(Bytes::from(m.into_bytes())))))
+    }
+}
+
+/// Redis `ZRANDMEMBER key [count [WITHSCORES]]`.
+///
+/// No-count form: one random member as a bulk string, or nil for missing
+/// key. With `count`, returns an array — positive count means distinct
+/// members (capped at zset size), negative means exactly `|count|` with
+/// duplicates allowed. `WITHSCORES` interleaves `member, score` pairs;
+/// requires an explicit count. Scores use the same formatter as ZRANGE.
+async fn handle_zrandmember(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("ZRANDMEMBER", matches!(args.len(), 1..=3))?;
+    let key = arg_as_str(&args[0])?;
+
+    // No-count form: single-member bulk reply (nil on missing key).
+    if args.len() == 1 {
+        let mut picked = state.storage.zrandmember(key, 1, false).await?;
+        return Ok(picked
+            .pop()
+            .map_or(RespReply::Nil, |(m, _)| RespReply::BulkString(Some(Bytes::from(m.into_bytes())))));
+    }
+
+    let count = parse_i64(&args[1], "count")?;
+    let with_scores = if args.len() == 3 {
+        if !arg_as_str(&args[2])?.eq_ignore_ascii_case("WITHSCORES") {
+            return Err(RustyAntError::Parse("syntax error".into()));
+        }
+        true
+    } else {
+        false
+    };
+
+    let allow_duplicates = count < 0;
+    let abs_count = count.checked_abs().ok_or_else(|| RustyAntError::Parse("count overflow".into()))?;
+    let picked = state.storage.zrandmember(key, abs_count, allow_duplicates).await?;
+    if with_scores {
+        let mut out = Vec::with_capacity(picked.len() * 2);
+        for (m, s) in picked {
+            out.push(RespReply::BulkString(Some(Bytes::from(m.into_bytes()))));
+            out.push(RespReply::BulkString(Some(Bytes::from(format_score(s).into_bytes()))));
+        }
+        Ok(RespReply::Array(out))
+    } else {
+        Ok(RespReply::Array(
+            picked.into_iter().map(|(m, _)| RespReply::BulkString(Some(Bytes::from(m.into_bytes())))).collect(),
+        ))
     }
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -472,6 +472,36 @@ fn pick_random(set: &BTreeSet<String>, count: i64, allow_duplicates: bool) -> Ve
         .collect()
 }
 
+/// `ZRANDMEMBER` sampler: uniform over members (Redis ignores scores for
+/// weighting). Returns `(member, score)` pairs so the handler can format
+/// with or without scores. Mirrors `pick_random`'s positive/negative count
+/// semantics.
+fn pick_random_from_zset(map: &BTreeMap<String, f64>, count: i64, allow_duplicates: bool) -> Vec<(String, f64)> {
+    if map.is_empty() || count == 0 {
+        return Vec::new();
+    }
+    let ordered: Vec<(&String, &f64)> = map.iter().collect();
+    let len = ordered.len();
+    if !allow_duplicates {
+        // Positive count: up to `count` distinct members.
+        let take = usize::try_from(count).unwrap_or(0).min(len);
+        let start = usize::try_from(pseudo_rand_u64() % (len as u64)).unwrap_or(0);
+        return (0..take).map(|i| (ordered[(start + i) % len].0.clone(), *ordered[(start + i) % len].1)).collect();
+    }
+    // Negative count: exactly |count| samples, duplicates allowed.
+    let take = usize::try_from(count.unsigned_abs()).unwrap_or(0);
+    let mut rng = pseudo_rand_u64();
+    (0..take)
+        .map(|_| {
+            rng ^= rng << 13;
+            rng ^= rng >> 7;
+            rng ^= rng << 17;
+            let idx = usize::try_from(rng % (len as u64)).unwrap_or(0);
+            (ordered[idx].0.clone(), *ordered[idx].1)
+        })
+        .collect()
+}
+
 // ---------------------------------------------------------------------------
 // S3 optimistic-locking primitives.
 //
@@ -695,6 +725,17 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn zrevrank(&self, key: &str, member: &str) -> Result<Option<i64>, RustyAntError>;
     async fn zcount(&self, key: &str, min: ScoreBound, max: ScoreBound) -> Result<i64, RustyAntError>;
     async fn zmscore(&self, key: &str, members: &[String]) -> Result<Vec<Option<f64>>, RustyAntError>;
+    /// Redis `ZRANDMEMBER` sampler: uniform over members (scores do not bias
+    /// the pick, per Redis). Positive `count` returns up to `count` distinct
+    /// members; negative `count` returns exactly `|count|` with duplicates
+    /// allowed. Returns `(member, score)` pairs — the handler decides whether
+    /// to serialize scores.
+    async fn zrandmember(
+        &self,
+        key: &str,
+        count: i64,
+        allow_duplicates: bool,
+    ) -> Result<Vec<(String, f64)>, RustyAntError>;
     /// See [`Self::hscan`] for pagination semantics. Iteration order follows
     /// member lex order under the backing `BTreeMap`; Redis doesn't pin an
     /// order, so callers that care must sort the accumulated result.
@@ -1634,6 +1675,19 @@ impl Storage for S3Storage {
             }
             Some(_) => Err(wrong_type(key)),
             None => Ok(members.iter().map(|_| None).collect()),
+        }
+    }
+
+    async fn zrandmember(
+        &self,
+        key: &str,
+        count: i64,
+        allow_duplicates: bool,
+    ) -> Result<Vec<(String, f64)>, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::ZSet(m), .. }) => Ok(pick_random_from_zset(&m, count, allow_duplicates)),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(Vec::new()),
         }
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -888,6 +888,74 @@ async fn zcard_counts_members() {
 }
 
 #[tokio::test]
+async fn zrandmember_no_count_returns_bulk_or_nil() {
+    let state = test_state();
+    // Missing key → nil bulk.
+    call(&state, &[b"ZRANDMEMBER", b"missing"]).await.expect_nil();
+    call(&state, &[b"ZADD", b"z", b"1", b"only"]).await;
+    // Single known member → that member.
+    call(&state, &[b"ZRANDMEMBER", b"z"]).await.expect_bulk(b"only");
+}
+
+#[tokio::test]
+async fn zrandmember_positive_count_distinct() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"a", b"2", b"b", b"3", b"c"]).await;
+    let reply = call(&state, &[b"ZRANDMEMBER", b"z", b"2"]).await.into_bulk_array();
+    assert_eq!(reply.len(), 2);
+    let distinct: std::collections::HashSet<_> = reply.iter().collect();
+    assert_eq!(distinct.len(), 2, "positive count must be distinct");
+    // Requested count exceeds zset size → returns all members, capped.
+    let reply = call(&state, &[b"ZRANDMEMBER", b"z", b"10"]).await.into_bulk_array();
+    assert_eq!(reply.len(), 3);
+}
+
+#[tokio::test]
+async fn zrandmember_negative_count_allows_duplicates() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"only"]).await;
+    let reply = call(&state, &[b"ZRANDMEMBER", b"z", b"-5"]).await.into_bulk_array();
+    assert_eq!(reply.len(), 5);
+    for item in reply {
+        assert_eq!(&item[..], b"only");
+    }
+}
+
+#[tokio::test]
+async fn zrandmember_withscores_interleaves_pairs() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"1", b"a", b"2", b"b", b"3", b"c"]).await;
+    let reply = call(&state, &[b"ZRANDMEMBER", b"z", b"3", b"WITHSCORES"]).await.into_bulk_array();
+    assert_eq!(reply.len(), 6);
+    // Every other entry is a score for the prior member.
+    for chunk in reply.chunks(2) {
+        let member = std::str::from_utf8(&chunk[0]).expect("utf8");
+        let score = std::str::from_utf8(&chunk[1]).expect("utf8");
+        let expected = match member {
+            "a" => "1",
+            "b" => "2",
+            "c" => "3",
+            other => panic!("unexpected member {other}"),
+        };
+        assert_eq!(score, expected);
+    }
+}
+
+#[tokio::test]
+async fn zrandmember_missing_key_with_count_returns_empty_array() {
+    let state = test_state();
+    let reply = call(&state, &[b"ZRANDMEMBER", b"missing", b"3"]).await.into_bulk_array();
+    assert!(reply.is_empty());
+}
+
+#[tokio::test]
+async fn zrandmember_on_wrong_type_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"ZRANDMEMBER", b"k"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
 async fn zrank_returns_ascending_index() {
     let state = test_state();
     call(&state, &[b"ZADD", b"z", b"1", b"a", b"2", b"b", b"3", b"c"]).await;


### PR DESCRIPTION
## Summary

- Adds `ZRANDMEMBER key [count [WITHSCORES]]`
- No-count → bulk string member (nil on missing key)
- Positive count → up to N distinct members (capped at zset size)
- Negative count → exactly \|N\| members with duplicates allowed
- `WITHSCORES` interleaves `member, score` pairs using the same `format_score` formatter as `ZRANGE`
- New storage primitive `zrandmember` + internal sampler `pick_random_from_zset`

## Why

Parity with `SRANDMEMBER` (shipped) and `HRANDFIELD` (separate issue). Redis samples uniformly over members — scores are not weights.

Closes #58.

## Test plan

- [x] no-count missing / present
- [x] positive count distinct + caps at zset size
- [x] negative count allows duplicates
- [x] WITHSCORES interleaves correctly with right score per member
- [x] missing key with count returns empty array
- [x] wrong-type errors
- [x] lint / fmt clean