### PR TITLE
:sparkles: add ZSET lex range family

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -8,7 +8,7 @@ use crate::geo::{self, GeoUnit};
 use crate::metrics;
 use crate::resp::RespReply;
 use crate::state::State;
-use crate::storage::{GetExOp, ScoreBound, TtlResult, ZAddFlags, bit_at, now_ms};
+use crate::storage::{GetExOp, LexBound, ScoreBound, TtlResult, ZAddFlags, bit_at, now_ms};
 
 /// Coarse classification of a dispatch result, emitted as a structured log
 /// field so `CloudWatch` queries can count/alert by outcome without string
@@ -255,6 +255,10 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "ZREVRANGE" => handle_zrevrange(state, args).await,
         "ZRANGEBYSCORE" => handle_zrangebyscore(state, args).await,
         "ZREVRANGEBYSCORE" => handle_zrevrangebyscore(state, args).await,
+        "ZRANGEBYLEX" => handle_zrangebylex(state, args).await,
+        "ZREVRANGEBYLEX" => handle_zrevrangebylex(state, args).await,
+        "ZLEXCOUNT" => handle_zlexcount(state, args).await,
+        "ZREMRANGEBYLEX" => handle_zremrangebylex(state, args).await,
         "ZREMRANGEBYRANK" => handle_zremrangebyrank(state, args).await,
         "ZREMRANGEBYSCORE" => handle_zremrangebyscore(state, args).await,
         "ZPOPMIN" => handle_zpop(state, args, false).await,
@@ -1358,6 +1362,64 @@ async fn handle_zrangebyscore(state: &State, args: Vec<Bytes>) -> Result<RespRep
     Ok(RespReply::Array(
         members.into_iter().map(|m| RespReply::BulkString(Some(Bytes::from(m.into_bytes())))).collect(),
     ))
+}
+
+/// Parse a trailing `LIMIT offset count` tail at `args[start..]`. Returns
+/// `None` if absent; errors on any other trailing tokens. Validates the
+/// `LIMIT` literal is followed by exactly two integer args.
+fn parse_lex_limit(args: &[Bytes], start: usize) -> Result<Option<(i64, i64)>, RustyAntError> {
+    if args.len() == start {
+        return Ok(None);
+    }
+    if args.len() != start + 3 || !arg_as_str(&args[start])?.eq_ignore_ascii_case("LIMIT") {
+        return Err(RustyAntError::Parse("syntax error".into()));
+    }
+    let offset = parse_i64(&args[start + 1], "offset")?;
+    let count = parse_i64(&args[start + 2], "count")?;
+    Ok(Some((offset, count)))
+}
+
+async fn handle_zrangebylex(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("ZRANGEBYLEX", matches!(args.len(), 3 | 6))?;
+    let key = arg_as_str(&args[0])?;
+    let min = LexBound::parse(arg_as_str(&args[1])?)?;
+    let max = LexBound::parse(arg_as_str(&args[2])?)?;
+    let limit = parse_lex_limit(&args, 3)?;
+    let members = state.storage.zrangebylex(key, min, max, limit).await?;
+    Ok(RespReply::Array(
+        members.into_iter().map(|m| RespReply::BulkString(Some(Bytes::from(m.into_bytes())))).collect(),
+    ))
+}
+
+async fn handle_zrevrangebylex(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("ZREVRANGEBYLEX", matches!(args.len(), 3 | 6))?;
+    let key = arg_as_str(&args[0])?;
+    // Redis passes `(key, max, min)` to ZREVRANGEBYLEX.
+    let max = LexBound::parse(arg_as_str(&args[1])?)?;
+    let min = LexBound::parse(arg_as_str(&args[2])?)?;
+    let limit = parse_lex_limit(&args, 3)?;
+    let members = state.storage.zrevrangebylex(key, max, min, limit).await?;
+    Ok(RespReply::Array(
+        members.into_iter().map(|m| RespReply::BulkString(Some(Bytes::from(m.into_bytes())))).collect(),
+    ))
+}
+
+async fn handle_zlexcount(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("ZLEXCOUNT", args.len() == 3)?;
+    let key = arg_as_str(&args[0])?;
+    let min = LexBound::parse(arg_as_str(&args[1])?)?;
+    let max = LexBound::parse(arg_as_str(&args[2])?)?;
+    let n = state.storage.zlexcount(key, min, max).await?;
+    Ok(RespReply::Integer(n))
+}
+
+async fn handle_zremrangebylex(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("ZREMRANGEBYLEX", args.len() == 3)?;
+    let key = arg_as_str(&args[0])?;
+    let min = LexBound::parse(arg_as_str(&args[1])?)?;
+    let max = LexBound::parse(arg_as_str(&args[2])?)?;
+    let n = state.storage.zremrangebylex(key, min, max).await?;
+    Ok(RespReply::Integer(n))
 }
 
 async fn handle_setnx(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -126,6 +126,56 @@ impl ScoreBound {
     }
 }
 
+/// Lex-bound for `ZRANGEBYLEX` / `ZLEXCOUNT`.
+///
+/// Matches Redis's syntax: `[member` is inclusive, `(member` is exclusive,
+/// `-` / `+` are the extremes. Comparison is byte-wise (Redis's `memcmp`),
+/// so it only makes sense when all members share the same score —
+/// documented at both ends.
+#[derive(Debug, Clone)]
+pub enum LexBound {
+    Inclusive(String),
+    Exclusive(String),
+    MinusInf,
+    PlusInf,
+}
+
+impl LexBound {
+    pub fn parse(s: &str) -> Result<Self, RustyAntError> {
+        match s {
+            "-" => Ok(Self::MinusInf),
+            "+" => Ok(Self::PlusInf),
+            other => other.strip_prefix('[').map(|rest| Self::Inclusive(rest.to_string())).map_or_else(
+                || {
+                    other.strip_prefix('(').map_or_else(
+                        || Err(RustyAntError::Parse("min or max not valid string range item".into())),
+                        |rest| Ok(Self::Exclusive(rest.to_string())),
+                    )
+                },
+                Ok,
+            ),
+        }
+    }
+
+    fn ge_min(&self, member: &str) -> bool {
+        match self {
+            Self::Inclusive(v) => member >= v.as_str(),
+            Self::Exclusive(v) => member > v.as_str(),
+            Self::MinusInf => true,
+            Self::PlusInf => false,
+        }
+    }
+
+    fn le_max(&self, member: &str) -> bool {
+        match self {
+            Self::Inclusive(v) => member <= v.as_str(),
+            Self::Exclusive(v) => member < v.as_str(),
+            Self::MinusInf => false,
+            Self::PlusInf => true,
+        }
+    }
+}
+
 pub fn now_ms() -> i64 {
     SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
 }
@@ -272,6 +322,31 @@ fn apply_setrange(data: &mut Vec<u8>, offset: usize, value: &[u8]) {
 /// bounds.
 fn filter_zset_by_score(map: BTreeMap<String, f64>, min: ScoreBound, max: ScoreBound) -> Vec<String> {
     sorted_zset(map).into_iter().filter(|(_, s)| min.ge_min(*s) && max.le_max(*s)).map(|(m, _)| m).collect()
+}
+
+/// Walk the `ZSet` in ascending member lex order and collect members whose
+/// byte-wise key falls within the lex window. Callers apply any `LIMIT` on
+/// the returned slice. Redis's lex-range commands only make sense when all
+/// scores are equal; this does not validate that — same stance as Redis.
+fn filter_zset_by_lex(map: &BTreeMap<String, f64>, min: &LexBound, max: &LexBound) -> Vec<String> {
+    map.keys().filter(|m| min.ge_min(m.as_str()) && max.le_max(m.as_str())).cloned().collect()
+}
+
+/// Apply a `(offset, count)` limit to an already-ordered member list. `count`
+/// <= 0 or `None` returns everything from `offset` onward. Offsets past the
+/// end collapse to empty, matching Redis.
+fn apply_lex_limit(mut members: Vec<String>, limit: Option<(i64, i64)>) -> Vec<String> {
+    let Some((offset, count)) = limit else { return members };
+    let offset_usize = usize::try_from(offset.max(0)).unwrap_or(0);
+    if offset_usize >= members.len() {
+        return Vec::new();
+    }
+    members.drain(..offset_usize);
+    if count >= 0 {
+        let cap = usize::try_from(count).unwrap_or(0);
+        members.truncate(cap);
+    }
+    members
 }
 
 /// Number of members whose score falls within `[min, max]` (inclusive/
@@ -687,6 +762,26 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     -> Result<Vec<String>, RustyAntError>;
     async fn zremrangebyrank(&self, key: &str, start: i64, stop: i64) -> Result<i64, RustyAntError>;
     async fn zremrangebyscore(&self, key: &str, min: ScoreBound, max: ScoreBound) -> Result<i64, RustyAntError>;
+    /// Lex-ordered range read. `limit` is `(offset, count)`; `count` <= 0 or
+    /// `None` means no cap. Results are in ascending member order.
+    async fn zrangebylex(
+        &self,
+        key: &str,
+        min: LexBound,
+        max: LexBound,
+        limit: Option<(i64, i64)>,
+    ) -> Result<Vec<String>, RustyAntError>;
+    /// `ZREVRANGEBYLEX` — Redis takes `(key, max, min)` order to signal the
+    /// reverse direction; the storage layer mirrors that.
+    async fn zrevrangebylex(
+        &self,
+        key: &str,
+        max: LexBound,
+        min: LexBound,
+        limit: Option<(i64, i64)>,
+    ) -> Result<Vec<String>, RustyAntError>;
+    async fn zlexcount(&self, key: &str, min: LexBound, max: LexBound) -> Result<i64, RustyAntError>;
+    async fn zremrangebylex(&self, key: &str, min: LexBound, max: LexBound) -> Result<i64, RustyAntError>;
     async fn zpopmin(&self, key: &str, count: usize) -> Result<Vec<(String, f64)>, RustyAntError>;
     async fn zpopmax(&self, key: &str, count: usize) -> Result<Vec<(String, f64)>, RustyAntError>;
     async fn zscore(&self, key: &str, member: &str) -> Result<Option<f64>, RustyAntError>;
@@ -2263,6 +2358,78 @@ impl Storage for S3Storage {
             } else {
                 let new_entry = StoredValue { expires_at_ms, value: Value::ZSet(kept) };
                 Ok(CasAction::Write(new_entry, removed_i))
+            }
+        })
+        .await
+    }
+
+    async fn zrangebylex(
+        &self,
+        key: &str,
+        min: LexBound,
+        max: LexBound,
+        limit: Option<(i64, i64)>,
+    ) -> Result<Vec<String>, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::ZSet(m), .. }) => {
+                let filtered = filter_zset_by_lex(&m, &min, &max);
+                Ok(apply_lex_limit(filtered, limit))
+            }
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(Vec::new()),
+        }
+    }
+
+    async fn zrevrangebylex(
+        &self,
+        key: &str,
+        max: LexBound,
+        min: LexBound,
+        limit: Option<(i64, i64)>,
+    ) -> Result<Vec<String>, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::ZSet(m), .. }) => {
+                let mut filtered = filter_zset_by_lex(&m, &min, &max);
+                filtered.reverse();
+                Ok(apply_lex_limit(filtered, limit))
+            }
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(Vec::new()),
+        }
+    }
+
+    async fn zlexcount(&self, key: &str, min: LexBound, max: LexBound) -> Result<i64, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::ZSet(m), .. }) => {
+                let n = m.keys().filter(|k| min.ge_min(k.as_str()) && max.le_max(k.as_str())).count();
+                Ok(i64::try_from(n).unwrap_or(i64::MAX))
+            }
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(0),
+        }
+    }
+
+    async fn zremrangebylex(&self, key: &str, min: LexBound, max: LexBound) -> Result<i64, RustyAntError> {
+        self.cas(key, move |entry| {
+            let (map, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::ZSet(m), expires_at_ms }) => (m.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => return Ok(CasAction::NoOp(0)),
+            };
+            let mut kept = BTreeMap::new();
+            let mut removed: i64 = 0;
+            for (member, score) in map {
+                if min.ge_min(member.as_str()) && max.le_max(member.as_str()) {
+                    removed += 1;
+                } else {
+                    kept.insert(member, score);
+                }
+            }
+            if kept.is_empty() {
+                Ok(CasAction::Delete(removed))
+            } else {
+                let new_entry = StoredValue { expires_at_ms, value: Value::ZSet(kept) };
+                Ok(CasAction::Write(new_entry, removed))
             }
         })
         .await

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1235,6 +1235,97 @@ async fn zrangebyscore_infinity_bounds() {
 }
 
 // ---------------------------------------------------------------------------
+// ZRANGEBYLEX / ZREVRANGEBYLEX / ZLEXCOUNT / ZREMRANGEBYLEX
+// Lex bounds assume equal scores across members (the canonical Redis use case).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn zrangebylex_inclusive_and_exclusive() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"0", b"a", b"0", b"b", b"0", b"c", b"0", b"d"]).await;
+    // [b ... [c → inclusive both ends → b, c
+    let m = call(&state, &[b"ZRANGEBYLEX", b"z", b"[b", b"[c"]).await.into_bulk_array();
+    assert_eq!(m.iter().map(|b| b.to_vec()).collect::<Vec<_>>(), vec![b"b".to_vec(), b"c".to_vec()]);
+    // (a ... (d → exclusive → b, c
+    let m = call(&state, &[b"ZRANGEBYLEX", b"z", b"(a", b"(d"]).await.into_bulk_array();
+    assert_eq!(m.iter().map(|b| b.to_vec()).collect::<Vec<_>>(), vec![b"b".to_vec(), b"c".to_vec()]);
+}
+
+#[tokio::test]
+async fn zrangebylex_unbounded() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"0", b"a", b"0", b"b", b"0", b"c"]).await;
+    // - ... + → all members in lex order
+    let m = call(&state, &[b"ZRANGEBYLEX", b"z", b"-", b"+"]).await.into_bulk_array();
+    assert_eq!(m.iter().map(|b| b.to_vec()).collect::<Vec<_>>(), vec![b"a".to_vec(), b"b".to_vec(), b"c".to_vec()]);
+}
+
+#[tokio::test]
+async fn zrangebylex_limit() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"0", b"a", b"0", b"b", b"0", b"c", b"0", b"d", b"0", b"e"]).await;
+    // offset 1, count 2 → b, c
+    let m = call(&state, &[b"ZRANGEBYLEX", b"z", b"-", b"+", b"LIMIT", b"1", b"2"]).await.into_bulk_array();
+    assert_eq!(m.iter().map(|b| b.to_vec()).collect::<Vec<_>>(), vec![b"b".to_vec(), b"c".to_vec()]);
+    // Negative count → no cap (returns rest after offset).
+    let m = call(&state, &[b"ZRANGEBYLEX", b"z", b"-", b"+", b"LIMIT", b"2", b"-1"]).await.into_bulk_array();
+    assert_eq!(m.iter().map(|b| b.to_vec()).collect::<Vec<_>>(), vec![b"c".to_vec(), b"d".to_vec(), b"e".to_vec()]);
+}
+
+#[tokio::test]
+async fn zrevrangebylex_reverse_order() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"0", b"a", b"0", b"b", b"0", b"c", b"0", b"d"]).await;
+    // Reverse: note Redis takes (max, min) in that order.
+    let m = call(&state, &[b"ZREVRANGEBYLEX", b"z", b"[c", b"[a"]).await.into_bulk_array();
+    assert_eq!(m.iter().map(|b| b.to_vec()).collect::<Vec<_>>(), vec![b"c".to_vec(), b"b".to_vec(), b"a".to_vec()]);
+    // Unbounded reverse.
+    let m = call(&state, &[b"ZREVRANGEBYLEX", b"z", b"+", b"-"]).await.into_bulk_array();
+    assert_eq!(m.len(), 4);
+    assert_eq!(m[0].as_ref(), b"d");
+}
+
+#[tokio::test]
+async fn zlexcount_counts_window() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"0", b"a", b"0", b"b", b"0", b"c"]).await;
+    call(&state, &[b"ZLEXCOUNT", b"z", b"-", b"+"]).await.expect_integer(3);
+    call(&state, &[b"ZLEXCOUNT", b"z", b"[a", b"[b"]).await.expect_integer(2);
+    call(&state, &[b"ZLEXCOUNT", b"z", b"(a", b"(c"]).await.expect_integer(1);
+    call(&state, &[b"ZLEXCOUNT", b"missing", b"-", b"+"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn zremrangebylex_removes_and_empties() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"0", b"a", b"0", b"b", b"0", b"c"]).await;
+    // Remove `b` only.
+    call(&state, &[b"ZREMRANGEBYLEX", b"z", b"[b", b"[b"]).await.expect_integer(1);
+    call(&state, &[b"ZCARD", b"z"]).await.expect_integer(2);
+    // Remove the rest — key should disappear.
+    call(&state, &[b"ZREMRANGEBYLEX", b"z", b"-", b"+"]).await.expect_integer(2);
+    call(&state, &[b"EXISTS", b"z"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn zlex_missing_prefix_errors() {
+    let state = test_state();
+    call(&state, &[b"ZADD", b"z", b"0", b"a"]).await;
+    // Without a [ ( - + prefix, it's a syntax error.
+    call(&state, &[b"ZRANGEBYLEX", b"z", b"a", b"b"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"ZLEXCOUNT", b"z", b"a", b"b"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn zlex_wrong_type_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"ZRANGEBYLEX", b"k", b"-", b"+"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"ZLEXCOUNT", b"k", b"-", b"+"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"ZREMRANGEBYLEX", b"k", b"-", b"+"]).await.expect_error_prefix("ERR");
+}
+
+// ---------------------------------------------------------------------------
 // KEYS and SCAN
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `ZRANGEBYLEX` / `ZREVRANGEBYLEX` with optional `LIMIT offset count`
- `ZLEXCOUNT` / `ZREMRANGEBYLEX`
- New `LexBound` enum (`[` inclusive / `(` exclusive / `-` / `+`) parallel to `ScoreBound`
- New storage primitives and shared helpers (`filter_zset_by_lex`, `apply_lex_limit`)

## Why

Lex-ordered zsets (all scores equal) are the canonical pattern for sorted text indexes / autocomplete. Without these, lex access from rustyant required pulling the full zset and sorting client-side.

Closes #53.

## Test plan

- [x] inclusive / exclusive bounds
- [x] unbounded `-` / `+`
- [x] `LIMIT offset count` including negative count (no cap)
- [x] reverse form with `(max, min)` argument order
- [x] ZLEXCOUNT including missing key
- [x] ZREMRANGEBYLEX deletes key when empty
- [x] invalid bound prefix errors
- [x] wrong-type key errors
- [x] lint / fmt clean