### PR TITLE
:sparkles: add HRANDFIELD (random field sampling)

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -218,6 +218,7 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "HMGET" => handle_hmget(state, args).await,
         "HINCRBY" => handle_hincrby(state, args).await,
         "HINCRBYFLOAT" => handle_hincrbyfloat(state, args).await,
+        "HRANDFIELD" => handle_hrandfield(state, args).await,
         "HSCAN" => handle_hscan(state, args).await,
         // Lists
         "LPUSH" => handle_push(state, args, true).await,
@@ -1799,6 +1800,50 @@ async fn handle_hincrbyfloat(state: &State, args: Vec<Bytes>) -> Result<RespRepl
     }
     let new_val = state.storage.hincr_by_float(key, field, delta).await?;
     Ok(RespReply::BulkString(Some(Bytes::from(format_score(new_val).into_bytes()))))
+}
+
+/// Redis `HRANDFIELD key [count [WITHVALUES]]`.
+///
+/// No-count form: one random field as bulk, or nil on missing key.
+/// Positive count: up to `count` distinct fields. Negative count:
+/// exactly `|count|` fields with duplicates allowed. `WITHVALUES`
+/// interleaves `field, value` pairs in reply.
+async fn handle_hrandfield(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("HRANDFIELD", matches!(args.len(), 1..=3))?;
+    let key = arg_as_str(&args[0])?;
+
+    if args.len() == 1 {
+        let mut picked = state.storage.hrandfield(key, 1, false).await?;
+        return Ok(picked
+            .pop()
+            .map_or(RespReply::Nil, |(f, _)| RespReply::BulkString(Some(Bytes::from(f.into_bytes())))));
+    }
+
+    let count = parse_i64(&args[1], "count")?;
+    let with_values = if args.len() == 3 {
+        if !arg_as_str(&args[2])?.eq_ignore_ascii_case("WITHVALUES") {
+            return Err(RustyAntError::Parse("syntax error".into()));
+        }
+        true
+    } else {
+        false
+    };
+
+    let allow_duplicates = count < 0;
+    let abs_count = count.checked_abs().ok_or_else(|| RustyAntError::Parse("count overflow".into()))?;
+    let picked = state.storage.hrandfield(key, abs_count, allow_duplicates).await?;
+    if with_values {
+        let mut out = Vec::with_capacity(picked.len() * 2);
+        for (field, value) in picked {
+            out.push(RespReply::BulkString(Some(Bytes::from(field.into_bytes()))));
+            out.push(RespReply::BulkString(Some(Bytes::from(value))));
+        }
+        Ok(RespReply::Array(out))
+    } else {
+        Ok(RespReply::Array(
+            picked.into_iter().map(|(f, _)| RespReply::BulkString(Some(Bytes::from(f.into_bytes())))).collect(),
+        ))
+    }
 }
 
 async fn handle_srem(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -547,6 +547,39 @@ fn pick_random(set: &BTreeSet<String>, count: i64, allow_duplicates: bool) -> Ve
         .collect()
 }
 
+/// `HRANDFIELD` sampler: uniform over fields. Returns `(field, value)` pairs
+/// so the handler can serialize with or without values. Shares the
+/// positive/negative count semantics of `pick_random`.
+fn pick_random_from_hash(
+    map: &BTreeMap<String, Vec<u8>>,
+    count: i64,
+    allow_duplicates: bool,
+) -> Vec<(String, Vec<u8>)> {
+    if map.is_empty() || count == 0 {
+        return Vec::new();
+    }
+    let ordered: Vec<(&String, &Vec<u8>)> = map.iter().collect();
+    let len = ordered.len();
+    if !allow_duplicates {
+        let take = usize::try_from(count).unwrap_or(0).min(len);
+        let start = usize::try_from(pseudo_rand_u64() % (len as u64)).unwrap_or(0);
+        return (0..take)
+            .map(|i| (ordered[(start + i) % len].0.clone(), ordered[(start + i) % len].1.clone()))
+            .collect();
+    }
+    let take = usize::try_from(count.unsigned_abs()).unwrap_or(0);
+    let mut rng = pseudo_rand_u64();
+    (0..take)
+        .map(|_| {
+            rng ^= rng << 13;
+            rng ^= rng >> 7;
+            rng ^= rng << 17;
+            let idx = usize::try_from(rng % (len as u64)).unwrap_or(0);
+            (ordered[idx].0.clone(), ordered[idx].1.clone())
+        })
+        .collect()
+}
+
 /// `ZRANDMEMBER` sampler: uniform over members (Redis ignores scores for
 /// weighting). Returns `(member, score)` pairs so the handler can format
 /// with or without scores. Mirrors `pick_random`'s positive/negative count
@@ -691,6 +724,16 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn hmget(&self, key: &str, fields: &[String]) -> Result<Vec<Option<Bytes>>, RustyAntError>;
     async fn hincr_by(&self, key: &str, field: &str, delta: i64) -> Result<i64, RustyAntError>;
     async fn hincr_by_float(&self, key: &str, field: &str, delta: f64) -> Result<f64, RustyAntError>;
+    /// Redis `HRANDFIELD` sampler: uniform over fields. Positive `count` ⇒
+    /// distinct fields (capped at hash size); negative ⇒ exactly `|count|`
+    /// with duplicates. Returns `(field, value)` pairs; the handler decides
+    /// whether to serialize values.
+    async fn hrandfield(
+        &self,
+        key: &str,
+        count: i64,
+        allow_duplicates: bool,
+    ) -> Result<Vec<(String, Vec<u8>)>, RustyAntError>;
     /// Incremental iteration over a hash's `(field, value)` pairs. `cursor=0`
     /// starts a fresh scan; a non-zero return cursor means more pages remain,
     /// `0` means the scan is exhausted. `count` bounds the batch size; `MATCH`
@@ -2253,6 +2296,19 @@ impl Storage for S3Storage {
             Ok(CasAction::Write(new_entry, new_val))
         })
         .await
+    }
+
+    async fn hrandfield(
+        &self,
+        key: &str,
+        count: i64,
+        allow_duplicates: bool,
+    ) -> Result<Vec<(String, Vec<u8>)>, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::Hash(m), .. }) => Ok(pick_random_from_hash(&m, count, allow_duplicates)),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(Vec::new()),
+        }
     }
 
     async fn srem(&self, key: &str, members: &[String]) -> Result<i64, RustyAntError> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1245,6 +1245,71 @@ async fn hincrbyfloat_on_wrong_type_errors() {
 }
 
 #[tokio::test]
+async fn hrandfield_no_count_returns_bulk_or_nil() {
+    let state = test_state();
+    call(&state, &[b"HRANDFIELD", b"missing"]).await.expect_nil();
+    call(&state, &[b"HSET", b"h", b"only", b"1"]).await;
+    call(&state, &[b"HRANDFIELD", b"h"]).await.expect_bulk(b"only");
+}
+
+#[tokio::test]
+async fn hrandfield_positive_count_distinct() {
+    let state = test_state();
+    call(&state, &[b"HSET", b"h", b"a", b"1", b"b", b"2", b"c", b"3"]).await;
+    let reply = call(&state, &[b"HRANDFIELD", b"h", b"2"]).await.into_bulk_array();
+    assert_eq!(reply.len(), 2);
+    let distinct: std::collections::HashSet<_> = reply.iter().collect();
+    assert_eq!(distinct.len(), 2, "positive count must be distinct");
+    // Excess count caps at hash size.
+    let reply = call(&state, &[b"HRANDFIELD", b"h", b"10"]).await.into_bulk_array();
+    assert_eq!(reply.len(), 3);
+}
+
+#[tokio::test]
+async fn hrandfield_negative_count_allows_duplicates() {
+    let state = test_state();
+    call(&state, &[b"HSET", b"h", b"only", b"1"]).await;
+    let reply = call(&state, &[b"HRANDFIELD", b"h", b"-5"]).await.into_bulk_array();
+    assert_eq!(reply.len(), 5);
+    for item in reply {
+        assert_eq!(&item[..], b"only");
+    }
+}
+
+#[tokio::test]
+async fn hrandfield_withvalues_interleaves_pairs() {
+    let state = test_state();
+    call(&state, &[b"HSET", b"h", b"a", b"1", b"b", b"2", b"c", b"3"]).await;
+    let reply = call(&state, &[b"HRANDFIELD", b"h", b"3", b"WITHVALUES"]).await.into_bulk_array();
+    assert_eq!(reply.len(), 6);
+    for chunk in reply.chunks(2) {
+        let field = std::str::from_utf8(&chunk[0]).expect("utf8");
+        let value = std::str::from_utf8(&chunk[1]).expect("utf8");
+        let expected = match field {
+            "a" => "1",
+            "b" => "2",
+            "c" => "3",
+            other => panic!("unexpected field {other}"),
+        };
+        assert_eq!(value, expected);
+    }
+}
+
+#[tokio::test]
+async fn hrandfield_missing_key_with_count_returns_empty() {
+    let state = test_state();
+    let reply = call(&state, &[b"HRANDFIELD", b"missing", b"3"]).await.into_bulk_array();
+    assert!(reply.is_empty());
+}
+
+#[tokio::test]
+async fn hrandfield_on_wrong_type_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"HRANDFIELD", b"k"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
 async fn srem_returns_count_removed() {
     let state = test_state();
     call(&state, &[b"SADD", b"s", b"a", b"b", b"c"]).await;


### PR DESCRIPTION
## Summary

- `HRANDFIELD key [count [WITHVALUES]]`
- No count → bulk string (or nil on missing key)
- Positive count → distinct fields, capped at hash size
- Negative count → exactly \|count\| with duplicates allowed
- `WITHVALUES` interleaves `field, value` pairs

## Why

Parity with `SRANDMEMBER` and the recently-landed `ZRANDMEMBER`. Used for random sampling / A-B decisioning without round-tripping the whole hash client-side.

Closes #57.

## Test plan

- [x] no-count missing / present
- [x] positive count distinct + caps at hash size
- [x] negative count allows duplicates
- [x] WITHVALUES interleaves correctly with right value per field
- [x] missing key with count returns empty array
- [x] wrong-type errors
- [x] lint / fmt / typos clean