### PR TITLE
:sparkles: add MEMORY subcommand family

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -131,6 +131,7 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
             Ok(RespReply::Integer(state.started_at_ms / 1000))
         }
         "LATENCY" => handle_latency(&args),
+        "MEMORY" => handle_memory(state, args).await,
         "DEBUG" => handle_debug(&args).await,
         "MULTI" => handle_multi(&args),
         "EXEC" => handle_exec(&args),
@@ -3065,6 +3066,41 @@ fn handle_bgsave(args: &[Bytes]) -> Result<RespReply, RustyAntError> {
 /// the `LATENCY` command family itself is stubbed. `HISTORY` / `LATEST` /
 /// `GRAPH` return empty results, `RESET` returns `0`, `DOCTOR` returns a
 /// bland all-clear string.
+/// Redis `MEMORY` — subcommand router.
+///
+/// `USAGE key [SAMPLES n]` is the one with real callers (bigkeys scripts,
+/// memory profilers); rustyant reports the serialized byte length of the
+/// value, which is the honest analog on an S3-backed store where there is
+/// no in-process allocator to query. `SAMPLES` is accepted and ignored.
+/// Remaining subcommands (`STATS`, `DOCTOR`, `PURGE`, `MALLOC-STATS`) are
+/// admin / profiler surface without a sensible answer here.
+async fn handle_memory(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    let sub = args.first().ok_or_else(|| RustyAntError::WrongArity { command: "MEMORY".into() })?;
+    let sub = arg_as_str(sub)?.to_ascii_uppercase();
+    match sub.as_str() {
+        "USAGE" => {
+            if !matches!(args.len(), 2 | 4) {
+                return Err(RustyAntError::WrongArity { command: "MEMORY USAGE".into() });
+            }
+            let key = arg_as_str(&args[1])?;
+            if args.len() == 4 {
+                if !arg_as_str(&args[2])?.eq_ignore_ascii_case("SAMPLES") {
+                    return Err(RustyAntError::Parse("syntax error".into()));
+                }
+                // Parse for validation; value is ignored on this backend.
+                let _ = parse_i64(&args[3], "SAMPLES")?;
+            }
+            Ok(state.storage.mem_usage(key).await?.map_or(RespReply::Nil, RespReply::Integer))
+        }
+        "DOCTOR" => Ok(RespReply::BulkString(Some(Bytes::from_static(
+            b"Sam, I detected a few issues in this Redis instance memory implants:\n\n * rustyant runs on S3, so no in-process heap signals are collected.\n",
+        )))),
+        "PURGE" => Ok(RespReply::ok()),
+        "STATS" | "MALLOC-STATS" => Ok(RespReply::Array(Vec::new())),
+        other => Err(RustyAntError::Parse(format!("unsupported MEMORY subcommand: {other}"))),
+    }
+}
+
 fn handle_latency(args: &[Bytes]) -> Result<RespReply, RustyAntError> {
     let sub = args.first().ok_or_else(|| RustyAntError::WrongArity { command: "LATENCY".into() })?;
     let sub = arg_as_str(sub)?.to_ascii_uppercase();

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -674,6 +674,12 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     /// `"list"`, `"set"`, `"zset"`) or `None` when the key is missing/expired.
     async fn kind(&self, key: &str) -> Result<Option<&'static str>, RustyAntError>;
 
+    /// Approximate byte size of the value for `MEMORY USAGE`. `None` for
+    /// missing / expired keys. Returns the serialized-JSON byte length on
+    /// the S3 backend (what the object actually occupies), which is the
+    /// closest honest signal we have without an in-process allocator.
+    async fn mem_usage(&self, key: &str) -> Result<Option<i64>, RustyAntError>;
+
     async fn get_string(&self, key: &str) -> Result<Option<Bytes>, RustyAntError>;
     /// `GETEX`: return the string value (`None` when missing / wrong type is an
     /// error) and atomically adjust its TTL per `op` in the same read-modify-
@@ -1264,6 +1270,16 @@ impl Storage for S3Storage {
 
     async fn kind(&self, key: &str) -> Result<Option<&'static str>, RustyAntError> {
         Ok(self.load(key).await?.map(|v| value_kind(&v.value)))
+    }
+
+    async fn mem_usage(&self, key: &str) -> Result<Option<i64>, RustyAntError> {
+        let Some(entry) = self.load(key).await? else { return Ok(None) };
+        // Serialize the value to JSON — the same shape written to S3 — and
+        // report its byte length. Not a perfect analog of Redis's
+        // `MEMORY USAGE` (which tallies in-process allocations) but an
+        // honest "bytes this key occupies on the backend".
+        let serialized = serde_json::to_vec(&entry.value)?;
+        Ok(Some(i64::try_from(serialized.len()).unwrap_or(i64::MAX)))
     }
 
     async fn expire_at(&self, key: &str, expires_at_ms: i64) -> Result<bool, RustyAntError> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -258,6 +258,54 @@ async fn object_unknown_subcommand_errors() {
 }
 
 #[tokio::test]
+async fn memory_usage_missing_key_returns_nil() {
+    let state = test_state();
+    call(&state, &[b"MEMORY", b"USAGE", b"ghost"]).await.expect_nil();
+}
+
+#[tokio::test]
+async fn memory_usage_returns_positive_for_existing_key() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"hello"]).await;
+    let reply = call(&state, &[b"MEMORY", b"USAGE", b"k"]).await;
+    let body = String::from_utf8_lossy(&reply.raw).to_string();
+    assert!(body.starts_with(':'), "expected integer reply, got {body}");
+    // Serialized JSON for the string value includes the bytes; just assert > 0.
+    let n: i64 = body.trim_start_matches(':').trim_end().parse().expect("integer");
+    assert!(n > 0, "expected positive byte count, got {n}");
+}
+
+#[tokio::test]
+async fn memory_usage_samples_is_accepted_and_ignored() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"hello"]).await;
+    // Any non-negative SAMPLES value is fine.
+    let a = call(&state, &[b"MEMORY", b"USAGE", b"k"]).await;
+    let b = call(&state, &[b"MEMORY", b"USAGE", b"k", b"SAMPLES", b"5"]).await;
+    assert_eq!(a.raw, b.raw, "SAMPLES should not change the computed size");
+}
+
+#[tokio::test]
+async fn memory_usage_non_samples_option_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"MEMORY", b"USAGE", b"k", b"BOGUS", b"1"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn memory_purge_returns_ok() {
+    let state = test_state();
+    call(&state, &[b"MEMORY", b"PURGE"]).await.expect_simple("OK");
+}
+
+#[tokio::test]
+async fn memory_unknown_subcommand_errors() {
+    let state = test_state();
+    call(&state, &[b"MEMORY", b"ELSE"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"MEMORY"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
 async fn malformed_body_returns_parse_error() {
     let state = test_state();
     let resp = handle(


### PR DESCRIPTION
## Summary

- \`MEMORY USAGE key [SAMPLES n]\` — returns the key's serialized byte length
- \`MEMORY PURGE\` → \`+OK\` no-op
- \`MEMORY DOCTOR\` → bulk string
- \`MEMORY STATS\` / \`MALLOC-STATS\` → empty array
- Unknown subcommands error explicitly
- New storage trait method \`mem_usage(key) -> Option<i64>\`

## Why

\`MEMORY USAGE\` is what \`redis-cli --bigkeys\` / memory-profiler tools call. Without it, rustyant users have to pull values and measure client-side. Serialized-JSON length is the honest byte count on the S3 backend (there is no in-process heap).

Closes #66.

## Test plan

- [x] USAGE on missing key → nil
- [x] USAGE on existing string → positive integer
- [x] USAGE ... SAMPLES n accepts n, ignores value (same answer)
- [x] USAGE with unknown option errors
- [x] PURGE → OK
- [x] Unknown subcommand errors
- [x] lint / fmt / typos clean