### PR TITLE
:sparkles: add CONFIG GET / SET / RESETSTAT / REWRITE

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -103,6 +103,7 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "TIME" => handle_time(&args),
         "INFO" => handle_info(state, args).await,
         "COMMAND" => handle_command(&args),
+        "CONFIG" => handle_config(&args),
         "HELLO" => handle_hello(&args),
         "CLIENT" => handle_client(&args),
         "OBJECT" => handle_object(state, args).await,
@@ -2875,6 +2876,60 @@ fn hello_info_reply() -> RespReply {
 /// call on connect (SETINFO, SETNAME, ID, GETNAME) are accepted quietly;
 /// the rest return `+OK` too, with an explicit error only for genuinely
 /// unknown subcommand names.
+/// Redis `CONFIG` — subcommand router.
+///
+/// `GET pattern [pattern ...]` returns a flat `[key, value, key, value]`
+/// reply matching Redis's wire format. Supported keys are stubbed with
+/// honest values: rustyant has no in-process config, so `maxmemory` is
+/// `"0"`, `save` is empty, `appendonly` is `"no"`, etc. Unknown keys
+/// simply don't appear in the reply (matching Redis when a pattern has
+/// no matches). `SET` / `RESETSTAT` / `REWRITE` accept-and-no-op.
+fn handle_config(args: &[Bytes]) -> Result<RespReply, RustyAntError> {
+    let sub = args.first().ok_or_else(|| RustyAntError::WrongArity { command: "CONFIG".into() })?;
+    let sub = arg_as_str(sub)?.to_ascii_uppercase();
+    match sub.as_str() {
+        "GET" => {
+            if args.len() < 2 {
+                return Err(RustyAntError::WrongArity { command: "CONFIG GET".into() });
+            }
+            let mut out: Vec<RespReply> = Vec::new();
+            // One pass per pattern, matching Redis's behavior when multiple
+            // patterns are given (Redis de-duplicates but order isn't
+            // specified; we accumulate in known-key order per pattern).
+            for arg in &args[1..] {
+                let pattern = arg_as_str(arg)?;
+                let wm = wildmatch::WildMatch::new(pattern);
+                for (key, value) in CONFIG_STUB {
+                    if wm.matches(key) {
+                        out.push(RespReply::BulkString(Some(Bytes::from_static(key.as_bytes()))));
+                        out.push(RespReply::BulkString(Some(Bytes::from_static(value.as_bytes()))));
+                    }
+                }
+            }
+            Ok(RespReply::Array(out))
+        }
+        "SET" | "RESETSTAT" | "REWRITE" => Ok(RespReply::ok()),
+        other => Err(RustyAntError::Parse(format!("unsupported CONFIG subcommand: {other}"))),
+    }
+}
+
+/// Minimum-viable `CONFIG GET` surface. Honest values for rustyant:
+/// no in-process memory cap, no persistence (S3 is authoritative), single
+/// namespace. Covers what redis-py / Laravel / most GUI tools probe on
+/// connection setup.
+const CONFIG_STUB: &[(&str, &str)] = &[
+    ("maxmemory", "0"),
+    ("maxmemory-policy", "noeviction"),
+    ("save", ""),
+    ("appendonly", "no"),
+    ("timeout", "0"),
+    ("tcp-keepalive", "0"),
+    ("databases", "1"),
+    ("hash-max-listpack-entries", "0"),
+    ("list-max-listpack-size", "0"),
+    ("zset-max-listpack-entries", "0"),
+];
+
 /// Redis `OBJECT` — introspection router that debuggers / GUI tools call.
 ///
 /// `ENCODING` returns an honest fixed encoding per value-kind. rustyant has

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -152,6 +152,52 @@ async fn select_non_numeric_errors() {
 }
 
 #[tokio::test]
+async fn config_get_exact_key_returns_pair() {
+    let state = test_state();
+    let reply = call(&state, &[b"CONFIG", b"GET", b"maxmemory"]).await.into_bulk_array();
+    assert_eq!(reply.iter().map(|b| b.to_vec()).collect::<Vec<_>>(), vec![b"maxmemory".to_vec(), b"0".to_vec()]);
+}
+
+#[tokio::test]
+async fn config_get_glob_matches_multiple() {
+    let state = test_state();
+    let reply = call(&state, &[b"CONFIG", b"GET", b"maxmemory*"]).await.into_bulk_array();
+    // Should match "maxmemory" and "maxmemory-policy" → 4 flat entries.
+    assert_eq!(reply.len(), 4);
+    let keys: Vec<Vec<u8>> = reply.iter().step_by(2).map(|b| b.to_vec()).collect();
+    assert!(keys.contains(&b"maxmemory".to_vec()));
+    assert!(keys.contains(&b"maxmemory-policy".to_vec()));
+}
+
+#[tokio::test]
+async fn config_get_unknown_key_returns_empty() {
+    let state = test_state();
+    let reply = call(&state, &[b"CONFIG", b"GET", b"nonexistent"]).await.into_bulk_array();
+    assert!(reply.is_empty());
+}
+
+#[tokio::test]
+async fn config_set_and_resetstat_accept_silently() {
+    let state = test_state();
+    call(&state, &[b"CONFIG", b"SET", b"maxmemory", b"0"]).await.expect_simple("OK");
+    call(&state, &[b"CONFIG", b"RESETSTAT"]).await.expect_simple("OK");
+    call(&state, &[b"CONFIG", b"REWRITE"]).await.expect_simple("OK");
+}
+
+#[tokio::test]
+async fn config_unknown_subcommand_errors() {
+    let state = test_state();
+    call(&state, &[b"CONFIG", b"FOO"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"CONFIG"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn config_get_empty_pattern_list_errors() {
+    let state = test_state();
+    call(&state, &[b"CONFIG", b"GET"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
 async fn object_encoding_per_kind() {
     let state = test_state();
     call(&state, &[b"SET", b"s", b"v"]).await;


### PR DESCRIPTION
## Summary

- \`CONFIG GET pattern [pattern ...]\` — flat \`[key, value, ...]\` reply, glob-matched against a fixed allowlist of honest values
- \`CONFIG SET\` / \`CONFIG RESETSTAT\` / \`CONFIG REWRITE\` — accept-and-no-op \`+OK\`
- Unknown subcommand errors explicitly
- 10 allowlisted keys covering what redis-py / Laravel / GUI tools probe

## Why

Many clients emit \`CONFIG GET maxmemory\` / similar on connection setup. Before this PR that returned \`unknown command\` — scary in logs, broke some GUI tool detection. Now returns honest values that match how rustyant actually behaves.

Closes #59.

## Test plan

- [x] exact key returns `[key, value]`
- [x] glob pattern (`maxmemory*`) matches multiple
- [x] unknown pattern returns empty array
- [x] SET / RESETSTAT / REWRITE return OK
- [x] Unknown subcommand errors
- [x] No arg to GET errors
- [x] lint / fmt / typos clean