### PR TITLE
:sparkles: add OBJECT ENCODING / IDLETIME / REFCOUNT / FREQ / HELP

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -105,6 +105,7 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "COMMAND" => handle_command(&args),
         "HELLO" => handle_hello(&args),
         "CLIENT" => handle_client(&args),
+        "OBJECT" => handle_object(state, args).await,
         "RESET" => Ok(RespReply::SimpleString("RESET".into())),
         "QUIT" => {
             arity("QUIT", args.is_empty())?;
@@ -2504,6 +2505,65 @@ fn hello_info_reply() -> RespReply {
 /// call on connect (SETINFO, SETNAME, ID, GETNAME) are accepted quietly;
 /// the rest return `+OK` too, with an explicit error only for genuinely
 /// unknown subcommand names.
+/// Redis `OBJECT` — introspection router that debuggers / GUI tools call.
+///
+/// `ENCODING` returns an honest fixed encoding per value-kind. rustyant has
+/// no listpack / quicklist / hashtable split internally, so the reported
+/// names are the "modern" Redis defaults. `IDLETIME` / `REFCOUNT` return
+/// `0` / `1` respectively — stable values since the backing concepts
+/// don't exist on S3. `FREQ` surfaces Redis's exact error when LFU is
+/// not configured. `HELP` returns canonical usage bullets.
+async fn handle_object(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    let sub = args.first().ok_or_else(|| RustyAntError::WrongArity { command: "OBJECT".into() })?;
+    let sub = arg_as_str(sub)?.to_ascii_uppercase();
+    if sub == "HELP" {
+        return Ok(RespReply::Array(
+            [
+                "OBJECT ENCODING <key> -- Return the kind of internal representation used in order to store the value.",
+                "OBJECT FREQ <key> -- Return the access frequency index of the key (LFU-only, not supported).",
+                "OBJECT IDLETIME <key> -- Return the idle time of the key (seconds).",
+                "OBJECT REFCOUNT <key> -- Return the number of references of the value.",
+                "OBJECT HELP -- Prints this help.",
+            ]
+            .into_iter()
+            .map(|s| RespReply::BulkString(Some(Bytes::from_static(s.as_bytes()))))
+            .collect(),
+        ));
+    }
+    // ENCODING / IDLETIME / REFCOUNT / FREQ all take exactly one key.
+    if args.len() != 2 {
+        return Err(RustyAntError::WrongArity { command: format!("OBJECT {sub}") });
+    }
+    let key = arg_as_str(&args[1])?;
+    match sub.as_str() {
+        "ENCODING" => match state.storage.kind(key).await? {
+            Some("string") => Ok(RespReply::BulkString(Some(Bytes::from_static(b"raw")))),
+            Some("hash" | "list" | "zset") => Ok(RespReply::BulkString(Some(Bytes::from_static(b"listpack")))),
+            Some("set") => Ok(RespReply::BulkString(Some(Bytes::from_static(b"hashtable")))),
+            Some(other) => Ok(RespReply::BulkString(Some(Bytes::from(other.as_bytes().to_vec())))),
+            None => Err(RustyAntError::Parse("no such key".into())),
+        },
+        "IDLETIME" => {
+            if state.storage.exists(key).await? {
+                Ok(RespReply::Integer(0))
+            } else {
+                Err(RustyAntError::Parse("no such key".into()))
+            }
+        }
+        "REFCOUNT" => {
+            if state.storage.exists(key).await? {
+                Ok(RespReply::Integer(1))
+            } else {
+                Err(RustyAntError::Parse("no such key".into()))
+            }
+        }
+        "FREQ" => Err(RustyAntError::Parse(
+            "An LFU maxmemory policy is not selected, access frequency not tracked. Please note that when switching between maxmemory policies at runtime LFU and LRU data will take some time to adjust.".into(),
+        )),
+        other => Err(RustyAntError::Parse(format!("unsupported OBJECT subcommand: {other}"))),
+    }
+}
+
 fn handle_client(args: &[Bytes]) -> Result<RespReply, RustyAntError> {
     let sub = args.first().ok_or_else(|| RustyAntError::WrongArity { command: "CLIENT".into() })?;
     let sub = arg_as_str(sub)?.to_ascii_uppercase();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -152,6 +152,66 @@ async fn select_non_numeric_errors() {
 }
 
 #[tokio::test]
+async fn object_encoding_per_kind() {
+    let state = test_state();
+    call(&state, &[b"SET", b"s", b"v"]).await;
+    call(&state, &[b"OBJECT", b"ENCODING", b"s"]).await.expect_bulk(b"raw");
+    call(&state, &[b"HSET", b"h", b"f", b"v"]).await;
+    call(&state, &[b"OBJECT", b"ENCODING", b"h"]).await.expect_bulk(b"listpack");
+    call(&state, &[b"SADD", b"set", b"x"]).await;
+    call(&state, &[b"OBJECT", b"ENCODING", b"set"]).await.expect_bulk(b"hashtable");
+    call(&state, &[b"ZADD", b"z", b"1", b"a"]).await;
+    call(&state, &[b"OBJECT", b"ENCODING", b"z"]).await.expect_bulk(b"listpack");
+    call(&state, &[b"LPUSH", b"l", b"x"]).await;
+    call(&state, &[b"OBJECT", b"ENCODING", b"l"]).await.expect_bulk(b"listpack");
+}
+
+#[tokio::test]
+async fn object_encoding_missing_key_errors() {
+    let state = test_state();
+    call(&state, &[b"OBJECT", b"ENCODING", b"ghost"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn object_idletime_and_refcount_on_existing_key() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"OBJECT", b"IDLETIME", b"k"]).await.expect_integer(0);
+    call(&state, &[b"OBJECT", b"REFCOUNT", b"k"]).await.expect_integer(1);
+}
+
+#[tokio::test]
+async fn object_idletime_missing_errors() {
+    let state = test_state();
+    call(&state, &[b"OBJECT", b"IDLETIME", b"ghost"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"OBJECT", b"REFCOUNT", b"ghost"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn object_freq_always_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    // Redis returns an LFU-not-selected error even for existing keys.
+    call(&state, &[b"OBJECT", b"FREQ", b"k"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn object_help_returns_bullets() {
+    let state = test_state();
+    let reply = call(&state, &[b"OBJECT", b"HELP"]).await.into_bulk_array();
+    assert!(!reply.is_empty());
+    let joined: Vec<String> = reply.iter().map(|b| String::from_utf8_lossy(b).to_string()).collect();
+    assert!(joined.iter().any(|s| s.contains("ENCODING")), "help should mention ENCODING: {joined:?}");
+}
+
+#[tokio::test]
+async fn object_unknown_subcommand_errors() {
+    let state = test_state();
+    call(&state, &[b"OBJECT", b"WEIRD", b"k"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"OBJECT"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
 async fn malformed_body_returns_parse_error() {
     let state = test_state();
     let resp = handle(


### PR DESCRIPTION
## Summary

- \`OBJECT ENCODING key\` → per-kind encoding (raw / listpack / hashtable)
- \`OBJECT IDLETIME key\` / \`OBJECT REFCOUNT key\` → 0 / 1 for existing keys; error for missing
- \`OBJECT FREQ key\` → Redis's exact LFU-not-selected error
- \`OBJECT HELP\` → canonical usage array
- Unknown subcommand errors explicitly

## Why

Debuggers and GUI tools (redis-cli, RDM, redisinsight) probe \`OBJECT ENCODING\` to decide how to render values. \`unknown command\` logs scare users and can break tool detection.

Closes #61.

## Test plan

- [x] ENCODING per kind (string/hash/list/set/zset)
- [x] ENCODING on missing key errors
- [x] IDLETIME / REFCOUNT on existing and missing
- [x] FREQ always errors (LFU not enabled)
- [x] HELP returns non-empty array mentioning ENCODING
- [x] Unknown subcommand + no-arg error
- [x] lint / fmt / typos clean