### PR TITLE
:sparkles: add HyperLogLog: PFADD / PFCOUNT / PFMERGE

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -163,6 +163,10 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "BITCOUNT" => handle_bitcount(state, args).await,
         "BITPOS" => handle_bitpos(state, args).await,
         "BITOP" => handle_bitop(state, args).await,
+        // HyperLogLog
+        "PFADD" => handle_pfadd(state, args).await,
+        "PFCOUNT" => handle_pfcount(state, args).await,
+        "PFMERGE" => handle_pfmerge(state, args).await,
         // Strings
         "GET" => handle_get(state, args).await,
         "GETEX" => handle_getex(state, args).await,
@@ -1053,6 +1057,41 @@ async fn handle_strlen(state: &State, args: Vec<Bytes>) -> Result<RespReply, Rus
 /// pairs, plus optional per-match lengths). `LEN` and `IDX` are mutually
 /// exclusive. Missing keys are treated as empty strings; WRONGTYPE is
 /// surfaced when either key exists but isn't a string.
+/// Redis `PFADD key [element [element ...]]`. Returns `1` if any register
+/// was updated (including when the key was created by this call), else `0`.
+async fn handle_pfadd(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    if args.is_empty() {
+        return Err(RustyAntError::WrongArity { command: "PFADD".into() });
+    }
+    let key = arg_as_str(&args[0])?;
+    let changed = state.storage.pfadd(key, &args[1..]).await?;
+    Ok(RespReply::Integer(i64::from(changed)))
+}
+
+/// Redis `PFCOUNT key [key ...]`. Single-key returns the estimate; multi-key
+/// returns the estimate of the in-memory union (does not write).
+async fn handle_pfcount(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    if args.is_empty() {
+        return Err(RustyAntError::WrongArity { command: "PFCOUNT".into() });
+    }
+    let keys: Vec<String> = args.iter().map(arg_as_string).collect::<Result<_, _>>()?;
+    let n = state.storage.pfcount(&keys).await?;
+    Ok(RespReply::Integer(i64::try_from(n).unwrap_or(i64::MAX)))
+}
+
+/// Redis `PFMERGE destkey [sourcekey [sourcekey ...]]`. Unions sources
+/// into dest (dest's prior HLL participates). Accepts zero sources (no-op
+/// initialise on a missing destination).
+async fn handle_pfmerge(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    if args.is_empty() {
+        return Err(RustyAntError::WrongArity { command: "PFMERGE".into() });
+    }
+    let dest = arg_as_str(&args[0])?;
+    let sources: Vec<String> = args.iter().skip(1).map(arg_as_string).collect::<Result<_, _>>()?;
+    state.storage.pfmerge(dest, &sources).await?;
+    Ok(RespReply::ok())
+}
+
 async fn handle_lcs(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
     if args.len() < 2 {
         return Err(RustyAntError::WrongArity { command: "LCS".into() });

--- a/src/hll.rs
+++ b/src/hll.rs
@@ -1,0 +1,302 @@
+//! `HyperLogLog` — Redis-compatible dense encoding.
+//!
+//! Uses 16384 6-bit registers (14-bit bucket index), matching Redis's
+//! default precision. Values are stored as regular `string` keys with an
+//! HLL-specific 16-byte header (`HYLL` magic), so plain `GET` / `STRLEN`
+//! round-trip them transparently.
+//!
+//! The binary layout exactly matches `src/hyperloglog.c` in Redis — a
+//! blob produced here can be restored into a real Redis server (and vice
+//! versa). Only dense encoding is implemented; sparse is a later size
+//! optimisation.
+//!
+//! Cardinality estimation follows the classic `HyperLogLog` paper (Flajolet
+//! et al. 2007) with linear-counting correction for low-cardinality ranges
+//! and the 2^32 saturation correction at the top. Redis ships a larger
+//! HLL++ bias-correction table; on rustyant's scale (per-key analytics)
+//! the classic estimator is well within the documented 0.81% error at
+//! `m = 16384`.
+
+use crate::error::RustyAntError;
+
+/// Precision: 14 bits of hash → 16384 registers. Matches Redis.
+pub const HLL_P: u32 = 14;
+pub const HLL_REGISTERS: usize = 1 << HLL_P; // 16384
+pub const HLL_REGISTER_BITS: u32 = 6;
+const HLL_REGISTERS_BYTES: usize = (HLL_REGISTERS * HLL_REGISTER_BITS as usize).div_ceil(8);
+pub const HLL_HEADER_BYTES: usize = 16;
+pub const HLL_DENSE_BYTES: usize = HLL_HEADER_BYTES + HLL_REGISTERS_BYTES;
+
+const HLL_MAGIC: &[u8; 4] = b"HYLL";
+const HLL_DENSE: u8 = 0;
+
+const MURMUR_SEED: u64 = 0xadc8_3b19;
+
+/// True when `data` looks like a Redis HLL — checks magic + length.
+pub fn is_hll(data: &[u8]) -> bool {
+    data.len() == HLL_DENSE_BYTES && &data[0..4] == HLL_MAGIC && data[4] == HLL_DENSE
+}
+
+/// Construct an empty dense HLL blob (all registers zero, cached
+/// cardinality invalid).
+pub fn empty_dense() -> Vec<u8> {
+    let mut buf = vec![0u8; HLL_DENSE_BYTES];
+    buf[0..4].copy_from_slice(HLL_MAGIC);
+    buf[4] = HLL_DENSE;
+    // bytes 5..8 reserved (0). bytes 8..16: cached cardinality, all zero.
+    buf
+}
+
+/// Hash an element (`MurmurHash2-64A`) and split it into a `(bucket, zeros+1)`
+/// pair as the HLL algorithm expects: the low `HLL_P` bits are the bucket
+/// index; the count of leading zeros of the remaining bits (+ 1, capped)
+/// is the value to write into that register.
+fn hash_element(element: &[u8]) -> (usize, u8) {
+    let h = murmur64a(element, MURMUR_SEED);
+    // `& (HLL_REGISTERS - 1)` keeps only the low 14 bits, which always fit
+    // in usize on every platform we target.
+    #[allow(clippy::cast_possible_truncation)]
+    let bucket = (h as usize) & (HLL_REGISTERS - 1);
+    // Shift out the bucket bits; the remaining 50 bits hold leading zeros.
+    let rest = h >> HLL_P;
+    // `count + 1`: the stored register value is position of the first 1-bit
+    // in the remaining 50 bits (1-indexed). We cap at 50 (+1 for the one
+    // bit itself) = max register value 63 (fits in 6 bits).
+    #[allow(clippy::cast_possible_truncation)] // 64 - HLL_P = 50 fits in u8
+    let max = (64 - HLL_P) as u8;
+    #[allow(clippy::cast_possible_truncation)] // trailing_zeros ≤ 50 fits in u8
+    let count = if rest == 0 { max + 1 } else { (rest.trailing_zeros() as u8) + 1 };
+    (bucket, count.min(max + 1))
+}
+
+/// Read the 6-bit register at `idx` (0..16384) from the packed dense body.
+fn read_register(registers: &[u8], idx: usize) -> u8 {
+    let bit = idx * HLL_REGISTER_BITS as usize;
+    let byte = bit / 8;
+    let shift = bit % 8;
+    // A 6-bit register straddles at most two bytes.
+    let lo = u32::from(registers[byte]);
+    let hi = u32::from(*registers.get(byte + 1).unwrap_or(&0));
+    let combined = lo | (hi << 8);
+    ((combined >> shift) & 0x3f) as u8
+}
+
+/// Write the 6-bit register at `idx` to `value` (must be 0..=63).
+fn write_register(registers: &mut [u8], idx: usize, value: u8) {
+    let bit = idx * HLL_REGISTER_BITS as usize;
+    let byte = bit / 8;
+    let shift = bit % 8;
+    let mask = 0x3fu32 << shift;
+    let val = u32::from(value & 0x3f) << shift;
+    let mut combined = u32::from(registers[byte]) | (u32::from(registers.get(byte + 1).copied().unwrap_or(0)) << 8);
+    combined = (combined & !mask) | val;
+    registers[byte] = (combined & 0xff) as u8;
+    if byte + 1 < registers.len() {
+        registers[byte + 1] = ((combined >> 8) & 0xff) as u8;
+    }
+}
+
+/// Invalidate the cached cardinality header by flipping its top bit, which
+/// forces the next `PFCOUNT` to recompute.
+fn invalidate_cache(buf: &mut [u8]) {
+    buf[15] |= 0x80;
+}
+
+/// Add `element` to the HLL; returns `true` if a register was updated.
+///
+/// Callers are responsible for providing a valid dense-encoded buffer (the
+/// wrapper in commands.rs validates before calling).
+pub fn add(buf: &mut [u8], element: &[u8]) -> Result<bool, RustyAntError> {
+    if !is_hll(buf) {
+        return Err(RustyAntError::Parse("key is not a valid HyperLogLog string".into()));
+    }
+    let (bucket, value) = hash_element(element);
+    let registers = &mut buf[HLL_HEADER_BYTES..];
+    let current = read_register(registers, bucket);
+    if value > current {
+        write_register(registers, bucket, value);
+        invalidate_cache(buf);
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+/// Return the cardinality estimate for a single HLL.
+pub fn count(buf: &[u8]) -> Result<u64, RustyAntError> {
+    if !is_hll(buf) {
+        return Err(RustyAntError::Parse("key is not a valid HyperLogLog string".into()));
+    }
+    Ok(estimate_from_registers(&buf[HLL_HEADER_BYTES..]))
+}
+
+/// Merge `src` registers into `dest` in-place (register-wise max). Both
+/// must already be dense-encoded HLL blobs.
+pub fn merge_into(dest: &mut [u8], src: &[u8]) -> Result<(), RustyAntError> {
+    if !is_hll(dest) || !is_hll(src) {
+        return Err(RustyAntError::Parse("key is not a valid HyperLogLog string".into()));
+    }
+    let mut changed = false;
+    for i in 0..HLL_REGISTERS {
+        let s = read_register(&src[HLL_HEADER_BYTES..], i);
+        let d = read_register(&dest[HLL_HEADER_BYTES..], i);
+        if s > d {
+            let registers = &mut dest[HLL_HEADER_BYTES..];
+            write_register(registers, i, s);
+            changed = true;
+        }
+    }
+    if changed {
+        invalidate_cache(dest);
+    }
+    Ok(())
+}
+
+/// Classic `HyperLogLog` estimator with linear-counting correction for the
+/// low-cardinality regime and 2^32 saturation correction at the top.
+#[allow(clippy::cast_precision_loss)] // HLL_REGISTERS (16384) and zeros (≤ 16384) fit in f64 mantissa
+fn estimate_from_registers(registers: &[u8]) -> u64 {
+    let m = HLL_REGISTERS as f64;
+    // α_m constant for m = 16384 (from the HLL paper).
+    let alpha = 0.7213 / (1.0 + 1.079 / m);
+
+    let mut sum = 0.0_f64;
+    let mut zeros: u64 = 0;
+    for i in 0..HLL_REGISTERS {
+        let r = read_register(registers, i);
+        if r == 0 {
+            zeros += 1;
+        }
+        // 2^{-r}
+        sum += 2.0_f64.powi(-i32::from(r));
+    }
+
+    let raw = alpha * m * m / sum;
+    let two32 = f64::from(u32::MAX) + 1.0; // 2^32
+
+    // Low-cardinality regime: linear counting based on the proportion of
+    // zero registers (more accurate than raw HLL when many buckets are
+    // still unset).
+    let e = if raw <= 2.5 * m && zeros > 0 {
+        let v = zeros as f64;
+        m * (m / v).ln()
+    } else if raw > two32 / 30.0 {
+        // Saturation regime — unlikely to hit since Redis-scale counts
+        // rarely exceed 10^9, but matches the canonical formula.
+        -two32 * (1.0 - raw / two32).ln()
+    } else {
+        raw
+    };
+
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let n = e.round() as u64;
+    n
+}
+
+// ---------------------------------------------------------------------------
+// MurmurHash64A — Redis uses this for HLL with a fixed seed.
+// ---------------------------------------------------------------------------
+
+fn murmur64a(data: &[u8], seed: u64) -> u64 {
+    const M: u64 = 0xc6a4_a793_5bd1_e995;
+    const R: u32 = 47;
+
+    #[allow(clippy::cast_possible_truncation)]
+    let mut h = seed ^ ((data.len() as u64).wrapping_mul(M));
+
+    let chunks = data.chunks_exact(8);
+    let tail = chunks.remainder();
+    for chunk in chunks {
+        let mut k =
+            u64::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7]]);
+        k = k.wrapping_mul(M);
+        k ^= k >> R;
+        k = k.wrapping_mul(M);
+        h ^= k;
+        h = h.wrapping_mul(M);
+    }
+
+    // Tail: up to 7 straggler bytes, mixed most-significant first.
+    for (i, &b) in tail.iter().enumerate().rev() {
+        h ^= u64::from(b) << (i * 8);
+        if i == 0 {
+            h = h.wrapping_mul(M);
+        }
+    }
+
+    h ^= h >> R;
+    h = h.wrapping_mul(M);
+    h ^= h >> R;
+    h
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_is_valid_hll() {
+        let buf = empty_dense();
+        assert_eq!(buf.len(), HLL_DENSE_BYTES);
+        assert!(is_hll(&buf));
+        assert_eq!(count(&buf).expect("count"), 0);
+    }
+
+    #[test]
+    fn single_add_updates_register() {
+        let mut buf = empty_dense();
+        let changed = add(&mut buf, b"hello").expect("add");
+        assert!(changed);
+        // Counting with only one element should report 1 (linear counting
+        // regime — exact for tiny cardinalities).
+        assert_eq!(count(&buf).expect("count"), 1);
+    }
+
+    #[test]
+    fn duplicate_add_is_stable() {
+        let mut buf = empty_dense();
+        add(&mut buf, b"hello").expect("add");
+        let changed_again = add(&mut buf, b"hello").expect("add");
+        assert!(!changed_again, "repeat add should not change any register");
+        assert_eq!(count(&buf).expect("count"), 1);
+    }
+
+    #[test]
+    #[allow(clippy::cast_precision_loss)]
+    fn cardinality_estimates_within_two_percent() {
+        let mut buf = empty_dense();
+        for i in 0..10_000u32 {
+            add(&mut buf, format!("elem-{i}").as_bytes()).expect("add");
+        }
+        let est = count(&buf).expect("count") as f64;
+        let err = (est - 10_000.0).abs() / 10_000.0;
+        assert!(err < 0.02, "HLL estimate off by {err:.4} (got {est})");
+    }
+
+    #[test]
+    #[allow(clippy::cast_precision_loss)]
+    fn merge_takes_register_max() {
+        let mut a = empty_dense();
+        let mut b = empty_dense();
+        for i in 0..500u32 {
+            add(&mut a, format!("a-{i}").as_bytes()).expect("add");
+            add(&mut b, format!("b-{i}").as_bytes()).expect("add");
+        }
+        // Shared prefix — same element lands in both, so union cardinality
+        // is close to 500 + 500 = 1000.
+        let mut merged = a.clone();
+        merge_into(&mut merged, &b).expect("merge");
+        let est = count(&merged).expect("count") as f64;
+        let err = (est - 1000.0).abs() / 1000.0;
+        assert!(err < 0.05, "merged HLL estimate off by {err:.4} (got {est})");
+    }
+
+    #[test]
+    fn is_hll_rejects_arbitrary_strings() {
+        assert!(!is_hll(b"HYLL short"));
+        assert!(!is_hll(b""));
+        let mut buf = empty_dense();
+        buf[0] = b'X';
+        assert!(!is_hll(&buf));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod commands;
 pub mod error;
 pub mod geo;
 pub mod handler;
+pub mod hll;
 pub mod metrics;
 pub mod resp;
 pub mod settings;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -8,6 +8,7 @@ use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 
 use crate::error::RustyAntError;
+use crate::hll;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct StoredValue {
@@ -691,6 +692,20 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn get_and_delete(&self, key: &str) -> Result<Option<Bytes>, RustyAntError>;
     async fn strlen(&self, key: &str) -> Result<i64, RustyAntError>;
     async fn append(&self, key: &str, value: Bytes) -> Result<i64, RustyAntError>;
+    /// Redis `PFADD`: add each element to the HLL at `key`. Returns `true`
+    /// if any register was updated (i.e. at least one element hashed to a
+    /// higher leading-zero run than the current bucket value). Creates an
+    /// empty dense HLL on missing keys. Errors if `key` exists as a
+    /// non-HLL string or a non-string kind.
+    async fn pfadd(&self, key: &str, elements: &[Bytes]) -> Result<bool, RustyAntError>;
+    /// Redis `PFCOUNT`: reads the HLL(s) at `keys`; for a single key
+    /// returns its cardinality, for multiple the cardinality of the
+    /// in-memory register-wise union. Missing keys contribute nothing.
+    async fn pfcount(&self, keys: &[String]) -> Result<u64, RustyAntError>;
+    /// Redis `PFMERGE`: unions `sources` into `dest` (creating `dest` if
+    /// it did not exist). `dest`'s prior HLL participates in the union,
+    /// matching Redis.
+    async fn pfmerge(&self, dest: &str, sources: &[String]) -> Result<(), RustyAntError>;
     async fn incr_by(&self, key: &str, delta: i64) -> Result<i64, RustyAntError>;
     async fn incr_by_float(&self, key: &str, delta: f64) -> Result<f64, RustyAntError>;
     async fn getrange(&self, key: &str, start: i64, end: i64) -> Result<Bytes, RustyAntError>;
@@ -1911,6 +1926,115 @@ impl Storage for S3Storage {
             let len = i64::try_from(data.len()).unwrap_or(i64::MAX);
             let new_entry = StoredValue { expires_at_ms, value: Value::String(data) };
             Ok(CasAction::Write(new_entry, len))
+        })
+        .await
+    }
+
+    async fn pfadd(&self, key: &str, elements: &[Bytes]) -> Result<bool, RustyAntError> {
+        let elements = elements.to_vec();
+        self.cas(key, move |entry| {
+            let (existed, mut buf, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::String(d), expires_at_ms }) => {
+                    if !hll::is_hll(d) {
+                        return Err(RustyAntError::Parse(
+                            "WRONGTYPE Key is not a valid HyperLogLog string value.".into(),
+                        ));
+                    }
+                    (true, d.clone(), *expires_at_ms)
+                }
+                Some(_) => return Err(wrong_type(key)),
+                None => (false, hll::empty_dense(), None),
+            };
+            let mut changed = false;
+            for e in &elements {
+                if hll::add(&mut buf, e)? {
+                    changed = true;
+                }
+            }
+            // Creating a new HLL counts as a change (matches Redis's
+            // `PFADD newkey` with no elements → 1).
+            if !existed {
+                let new_entry = StoredValue { expires_at_ms, value: Value::String(buf) };
+                return Ok(CasAction::Write(new_entry, true));
+            }
+            if !changed {
+                return Ok(CasAction::NoOp(false));
+            }
+            let new_entry = StoredValue { expires_at_ms, value: Value::String(buf) };
+            Ok(CasAction::Write(new_entry, true))
+        })
+        .await
+    }
+
+    async fn pfcount(&self, keys: &[String]) -> Result<u64, RustyAntError> {
+        if keys.len() == 1 {
+            return match self.load(&keys[0]).await? {
+                Some(StoredValue { value: Value::String(d), .. }) => {
+                    if !hll::is_hll(&d) {
+                        return Err(RustyAntError::Parse(
+                            "WRONGTYPE Key is not a valid HyperLogLog string value.".into(),
+                        ));
+                    }
+                    hll::count(&d)
+                }
+                Some(_) => Err(wrong_type(&keys[0])),
+                None => Ok(0),
+            };
+        }
+        // Multi-key: build an in-memory union and count from that.
+        let mut merged = hll::empty_dense();
+        for k in keys {
+            match self.load(k).await? {
+                Some(StoredValue { value: Value::String(d), .. }) => {
+                    if !hll::is_hll(&d) {
+                        return Err(RustyAntError::Parse(
+                            "WRONGTYPE Key is not a valid HyperLogLog string value.".into(),
+                        ));
+                    }
+                    hll::merge_into(&mut merged, &d)?;
+                }
+                Some(_) => return Err(wrong_type(k)),
+                None => {}
+            }
+        }
+        hll::count(&merged)
+    }
+
+    async fn pfmerge(&self, dest: &str, sources: &[String]) -> Result<(), RustyAntError> {
+        // Build the union in memory first — a multi-key PFCOUNT-style
+        // traversal — then CAS it into `dest` (also including dest's
+        // existing HLL if present).
+        let mut merged = hll::empty_dense();
+        for k in sources {
+            match self.load(k).await? {
+                Some(StoredValue { value: Value::String(d), .. }) => {
+                    if !hll::is_hll(&d) {
+                        return Err(RustyAntError::Parse(
+                            "WRONGTYPE Key is not a valid HyperLogLog string value.".into(),
+                        ));
+                    }
+                    hll::merge_into(&mut merged, &d)?;
+                }
+                Some(_) => return Err(wrong_type(k)),
+                None => {}
+            }
+        }
+        self.cas(dest, move |entry| {
+            let (mut buf, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::String(d), expires_at_ms }) => {
+                    if !hll::is_hll(d) {
+                        return Err(RustyAntError::Parse(
+                            "WRONGTYPE Key is not a valid HyperLogLog string value.".into(),
+                        ));
+                    }
+                    (d.clone(), *expires_at_ms)
+                }
+                Some(_) => return Err(wrong_type(dest)),
+                None => (hll::empty_dense(), None),
+            };
+            hll::merge_into(&mut buf, &merged)?;
+            let new_entry = StoredValue { expires_at_ms, value: Value::String(buf) };
+            Ok(CasAction::Write(new_entry, ()))
         })
         .await
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -305,6 +305,125 @@ async fn memory_unknown_subcommand_errors() {
     call(&state, &[b"MEMORY"]).await.expect_error_prefix("ERR");
 }
 
+// ---------------------------------------------------------------------------
+// HyperLogLog — PFADD / PFCOUNT / PFMERGE
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn pfadd_creates_and_counts() {
+    let state = test_state();
+    // New key → create + report 1.
+    call(&state, &[b"PFADD", b"h", b"a"]).await.expect_integer(1);
+    // Duplicate add on same element → no change.
+    call(&state, &[b"PFADD", b"h", b"a"]).await.expect_integer(0);
+    // Additional distinct element → change.
+    call(&state, &[b"PFADD", b"h", b"b", b"c"]).await.expect_integer(1);
+    call(&state, &[b"PFCOUNT", b"h"]).await.expect_integer(3);
+}
+
+#[tokio::test]
+async fn pfadd_zero_elements_creates_empty_key() {
+    let state = test_state();
+    call(&state, &[b"PFADD", b"h"]).await.expect_integer(1);
+    // Second PFADD with no elements on an existing key → 0.
+    call(&state, &[b"PFADD", b"h"]).await.expect_integer(0);
+    call(&state, &[b"PFCOUNT", b"h"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn pfcount_missing_key_is_zero() {
+    let state = test_state();
+    call(&state, &[b"PFCOUNT", b"missing"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn pfcount_estimates_within_tolerance() {
+    let state = test_state();
+    // Add 1000 distinct elements in a batch.
+    let mut elements: Vec<Vec<u8>> = Vec::with_capacity(1001);
+    elements.push(b"PFADD".to_vec());
+    elements.push(b"big".to_vec());
+    for i in 0..1000u32 {
+        elements.push(format!("e-{i}").into_bytes());
+    }
+    let args: Vec<&[u8]> = elements.iter().map(Vec::as_slice).collect();
+    call(&state, &args).await;
+    // HLL is probabilistic — allow 2% error on 1000 elements (spec says 0.81%).
+    let reply = call(&state, &[b"PFCOUNT", b"big"]).await;
+    let body = String::from_utf8_lossy(&reply.raw).to_string();
+    let n: i64 = body.trim_start_matches(':').trim_end().parse().expect("integer");
+    assert!((n - 1000).abs() < 20, "estimate {n} is not within 2% of 1000");
+}
+
+#[tokio::test]
+async fn pfcount_multi_key_returns_union_estimate() {
+    let state = test_state();
+    call(&state, &[b"PFADD", b"a", b"x", b"y", b"z"]).await;
+    call(&state, &[b"PFADD", b"b", b"z", b"w"]).await;
+    // Union: {x, y, z, w} → 4 distinct. PFCOUNT reads both, does not write.
+    call(&state, &[b"PFCOUNT", b"a", b"b"]).await.expect_integer(4);
+    // Original keys unchanged.
+    call(&state, &[b"PFCOUNT", b"a"]).await.expect_integer(3);
+    call(&state, &[b"PFCOUNT", b"b"]).await.expect_integer(2);
+}
+
+#[tokio::test]
+async fn pfmerge_unions_sources_into_dest() {
+    let state = test_state();
+    call(&state, &[b"PFADD", b"a", b"x", b"y"]).await;
+    call(&state, &[b"PFADD", b"b", b"y", b"z"]).await;
+    call(&state, &[b"PFMERGE", b"dest", b"a", b"b"]).await.expect_simple("OK");
+    // Union: {x, y, z} → 3.
+    call(&state, &[b"PFCOUNT", b"dest"]).await.expect_integer(3);
+}
+
+#[tokio::test]
+async fn pfmerge_with_existing_dest_preserves_prior_state() {
+    let state = test_state();
+    call(&state, &[b"PFADD", b"dest", b"x"]).await;
+    call(&state, &[b"PFADD", b"src", b"y"]).await;
+    call(&state, &[b"PFMERGE", b"dest", b"src"]).await.expect_simple("OK");
+    // Original {x} + merged {y} → 2.
+    call(&state, &[b"PFCOUNT", b"dest"]).await.expect_integer(2);
+}
+
+#[tokio::test]
+async fn pfmerge_zero_sources_creates_empty_dest() {
+    let state = test_state();
+    call(&state, &[b"PFMERGE", b"dest"]).await.expect_simple("OK");
+    call(&state, &[b"PFCOUNT", b"dest"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn pfadd_on_non_hll_string_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"not an hll"]).await;
+    call(&state, &[b"PFADD", b"k", b"x"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"PFCOUNT", b"k"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn pfadd_on_non_string_kind_errors() {
+    let state = test_state();
+    call(&state, &[b"LPUSH", b"l", b"x"]).await;
+    call(&state, &[b"PFADD", b"l", b"x"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn pf_stored_as_string_roundtrips_via_get() {
+    // An HLL value lives as a string; GET should retrieve the raw HLL
+    // blob, matching Redis.
+    let state = test_state();
+    call(&state, &[b"PFADD", b"h", b"x"]).await;
+    let reply = call(&state, &[b"GET", b"h"]).await;
+    // Expect a bulk string reply whose body starts with the HYLL magic.
+    let raw = reply.raw;
+    // Find the bulk-string payload between the `$<len>\r\n` header and trailing `\r\n`.
+    let header_end = raw.iter().position(|&b| b == b'\n').expect("header terminator");
+    let body_start = header_end + 1;
+    assert!(raw[body_start..].starts_with(b"HYLL"), "GET on HLL key did not return an HYLL-prefixed blob");
+}
+
 #[tokio::test]
 async fn malformed_body_returns_parse_error() {
     let state = test_state();


### PR DESCRIPTION
## Summary

- New \`src/hll.rs\` module with:
  - Dense 16384-register HLL encoding matching Redis's wire format (HYLL magic, 16-byte header, 12288 packed-register bytes)
  - MurmurHash64A hash with Redis's seed \`0xadc83b19\`
  - Classic HLL estimator + linear-counting correction
- Storage trait gains \`pfadd\` / \`pfcount\` / \`pfmerge\` with CAS-protected updates
- Handlers for PFADD / PFCOUNT / PFMERGE
- 6 unit tests in \`src/hll.rs\` + 11 integration tests in \`tests/integration.rs\`

## Why

HLL is the default probabilistic primitive for unique-visitor / unique-event counting — one of the most reached-for Redis features outside the five core types.

Closes #51.

## Compatibility

Blobs produced here match Redis's dense format byte-for-byte, so:
- \`GET\` on an HLL key returns the raw HYLL-prefixed blob (test asserts this)
- A \`DUMP\` / \`RESTORE\` path (future #65) will carry HLL state across
- Cross-instance merges via \`PFMERGE\` work because the hash + register layout is shared

## Scope

- Dense encoding only — sparse is a size optimisation, can ship later.
- Classic estimator (not the full HLL++ bias table) — well within the documented 0.81% error at \`m = 16384\` for target-scale counts.

## Test plan

- [x] PFADD creates key / counts distinct / skips duplicates
- [x] PFADD with 0 elements creates empty key (returns 1) then no-ops (returns 0)
- [x] PFCOUNT on missing returns 0
- [x] PFCOUNT estimates within 2% on 1000-element workload
- [x] PFCOUNT on multi-key returns union estimate, does not write
- [x] PFMERGE unions sources, preserves existing dest state, accepts 0 sources
- [x] PFADD on non-HLL string → WRONGTYPE; on non-string kind → WRONGTYPE
- [x] GET on HLL key returns HYLL-prefixed blob
- [x] 6 unit tests (empty / add / duplicate / estimate accuracy / merge / is_hll rejection)
- [x] lint / fmt / typos clean