### PR TITLE
:sparkles: add Streams base (XADD / XREAD / XRANGE / XTRIM / ...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Implemented:
 rustyant targets the **most commonly used** Redis features — what a typical application workload on Lambda/S3 actually reaches for. Edge features and deprecated surface are not goals:
 
 - **Explicitly out of scope** (will not be added): Lua scripting (`EVAL` / `EVALSHA` / `SCRIPT *` / `FUNCTION *`), and deprecated commands superseded by modern equivalents (e.g. `GEORADIUS` / `GEORADIUSBYMEMBER` — use `GEOSEARCH` instead).
-- **Not yet implemented, PRs welcome**: streams (`XADD` / `XREAD` / consumer groups) — commonly used enough to be in scope, just not done yet.
+- **Not yet implemented, PRs welcome**: streams consumer groups (`XGROUP` / `XREADGROUP` / `XACK` / `XCLAIM` / `XPENDING` / `XAUTOCLAIM`) — the base stream surface is in, groups are the next layer.
 
 Transactions (`MULTI` / `EXEC` / `DISCARD` / `WATCH`) and subscribe-side pub/sub (`SUBSCRIBE` / `PSUBSCRIBE` / `UNSUBSCRIBE` / `PUNSUBSCRIBE`) return explicit errors — rustyant processes one command per HTTP request with no connection-level state, so cross-request queueing, optimistic CAS, and server-pushed pub/sub messages cannot be honored honestly. `UNWATCH`, `PUBLISH`, and the `PUBSUB` introspection subcommands do reply successfully: clearing a never-populated watch set is a trivial no-op; `PUBLISH` returns `:0` because zero subscribers is the literal truth on a no-substrate server; `PUBSUB CHANNELS` / `NUMSUB` / `NUMPAT` return correspondingly empty / zero results.
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -9,6 +9,7 @@ use crate::metrics;
 use crate::resp::RespReply;
 use crate::state::State;
 use crate::storage::{GetExOp, LexBound, ScoreBound, TtlResult, ZAddFlags, bit_at, now_ms};
+use crate::stream::{AddIdSpec, RangeId, StreamEntry, StreamId, parse_trim};
 
 /// Coarse classification of a dispatch result, emitted as a structured log
 /// field so `CloudWatch` queries can count/alert by outcome without string
@@ -293,6 +294,15 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "ZMSCORE" => handle_zmscore(state, args).await,
         "ZRANDMEMBER" => handle_zrandmember(state, args).await,
         "ZSCAN" => handle_zscan(state, args).await,
+        // Streams
+        "XADD" => handle_xadd(state, args).await,
+        "XLEN" => handle_xlen(state, args).await,
+        "XRANGE" => handle_xrange(state, args, false).await,
+        "XREVRANGE" => handle_xrange(state, args, true).await,
+        "XDEL" => handle_xdel(state, args).await,
+        "XTRIM" => handle_xtrim(state, args).await,
+        "XREAD" => handle_xread(state, args).await,
+        "XINFO" => handle_xinfo(state, args).await,
         other => Err(RustyAntError::UnknownCommand(other.to_string())),
     }
 }
@@ -3952,4 +3962,270 @@ fn command_meta_reply(meta: &CommandMeta) -> RespReply {
         RespReply::Integer(last_key),
         RespReply::Integer(step),
     ])
+}
+
+// ---------------------------------------------------------------------------
+// Streams — XADD / XLEN / XRANGE / XREVRANGE / XDEL / XTRIM / XREAD / XINFO
+// ---------------------------------------------------------------------------
+
+fn stream_id_bulk(id: StreamId) -> RespReply {
+    RespReply::BulkString(Some(Bytes::from(id.to_string().into_bytes())))
+}
+
+fn entry_to_reply(entry: StreamEntry) -> RespReply {
+    // [id, [field1, value1, field2, value2, ...]]
+    let mut fields_arr = Vec::with_capacity(entry.fields.len() * 2);
+    for (f, v) in entry.fields {
+        fields_arr.push(RespReply::BulkString(Some(Bytes::from(f.into_bytes()))));
+        fields_arr.push(RespReply::BulkString(Some(Bytes::from(v))));
+    }
+    RespReply::Array(vec![stream_id_bulk(entry.id), RespReply::Array(fields_arr)])
+}
+
+/// Redis `XADD key [NOMKSTREAM] [MAXLEN|MINID [~|=] n [LIMIT n]] <id|*> field value [field value ...]`.
+async fn handle_xadd(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    if args.len() < 4 {
+        return Err(RustyAntError::WrongArity { command: "XADD".into() });
+    }
+    let key = arg_as_string(&args[0])?;
+    let mut i = 1;
+
+    // Optional NOMKSTREAM at the head of the option list.
+    let mut nomkstream = false;
+    if arg_as_str(&args[i])?.eq_ignore_ascii_case("NOMKSTREAM") {
+        nomkstream = true;
+        i += 1;
+    }
+
+    // Optional MAXLEN / MINID trim clause. `parse_trim` wants &str slices.
+    let mut trim: Option<(crate::stream::TrimBound, Option<usize>)> = None;
+    let head = arg_as_str(&args[i])?;
+    if head.eq_ignore_ascii_case("MAXLEN") || head.eq_ignore_ascii_case("MINID") {
+        // Convert the tail up to where the id arg will be into &str — the
+        // parser consumes as many tokens as it needs.
+        let remaining: Vec<&str> = (i..args.len()).map(|idx| arg_as_str(&args[idx])).collect::<Result<_, _>>()?;
+        let (bound, limit, consumed) = parse_trim(&remaining)?;
+        trim = Some((bound, limit));
+        i += consumed;
+    }
+
+    // Now args[i] is the id, and args[i+1..] are field/value pairs.
+    if i >= args.len() {
+        return Err(RustyAntError::WrongArity { command: "XADD".into() });
+    }
+    let id_spec = AddIdSpec::parse(arg_as_str(&args[i])?)?;
+    i += 1;
+    let pairs = &args[i..];
+    if pairs.is_empty() || pairs.len() % 2 != 0 {
+        return Err(RustyAntError::WrongArity { command: "XADD".into() });
+    }
+    let mut fields: Vec<(String, Vec<u8>)> = Vec::with_capacity(pairs.len() / 2);
+    let mut j = 0;
+    while j < pairs.len() {
+        fields.push((arg_as_string(&pairs[j])?, pairs[j + 1].to_vec()));
+        j += 2;
+    }
+
+    let result = state.storage.xadd(&key, id_spec, fields, nomkstream, trim).await?;
+    // `None` only occurs when NOMKSTREAM was set and the key did not exist.
+    Ok(result.map_or(RespReply::Nil, stream_id_bulk))
+}
+
+async fn handle_xlen(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    arity("XLEN", args.len() == 1)?;
+    let key = arg_as_str(&args[0])?;
+    Ok(RespReply::Integer(state.storage.xlen(key).await?))
+}
+
+/// Drives both XRANGE and XREVRANGE. For XREVRANGE, Redis takes
+/// `(key, end, start)` — we swap here so the storage signature stays
+/// `(start, end)`.
+async fn handle_xrange(state: &State, args: Vec<Bytes>, reverse: bool) -> Result<RespReply, RustyAntError> {
+    if !matches!(args.len(), 3 | 5) {
+        return Err(RustyAntError::WrongArity { command: if reverse { "XREVRANGE".into() } else { "XRANGE".into() } });
+    }
+    let key = arg_as_str(&args[0])?;
+    let (start, end) = if reverse {
+        (RangeId::parse(arg_as_str(&args[2])?)?, RangeId::parse(arg_as_str(&args[1])?)?)
+    } else {
+        (RangeId::parse(arg_as_str(&args[1])?)?, RangeId::parse(arg_as_str(&args[2])?)?)
+    };
+    let count = if args.len() == 5 {
+        if !arg_as_str(&args[3])?.eq_ignore_ascii_case("COUNT") {
+            return Err(RustyAntError::Parse("syntax error".into()));
+        }
+        let n = parse_i64(&args[4], "COUNT")?;
+        if n < 0 {
+            return Err(RustyAntError::Parse("COUNT must be non-negative".into()));
+        }
+        Some(usize::try_from(n).unwrap_or(0))
+    } else {
+        None
+    };
+    let entries = state.storage.xrange(key, start, end, count, reverse).await?;
+    Ok(RespReply::Array(entries.into_iter().map(entry_to_reply).collect()))
+}
+
+async fn handle_xdel(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    if args.len() < 2 {
+        return Err(RustyAntError::WrongArity { command: "XDEL".into() });
+    }
+    let key = arg_as_str(&args[0])?;
+    let ids: Vec<StreamId> = args.iter().skip(1).map(|a| StreamId::parse(arg_as_str(a)?)).collect::<Result<_, _>>()?;
+    Ok(RespReply::Integer(state.storage.xdel(key, &ids).await?))
+}
+
+async fn handle_xtrim(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    if args.len() < 3 {
+        return Err(RustyAntError::WrongArity { command: "XTRIM".into() });
+    }
+    let key = arg_as_str(&args[0])?;
+    let remaining: Vec<&str> = (1..args.len()).map(|idx| arg_as_str(&args[idx])).collect::<Result<_, _>>()?;
+    let (bound, limit, consumed) = parse_trim(&remaining)?;
+    // Any leftover tokens are a syntax error — XTRIM has no other args.
+    if consumed != remaining.len() {
+        return Err(RustyAntError::Parse("syntax error".into()));
+    }
+    Ok(RespReply::Integer(state.storage.xtrim(key, bound, limit).await?))
+}
+
+/// Redis `XREAD [COUNT n] [BLOCK ms] STREAMS key [key ...] id [id ...]`.
+/// BLOCK ms is accepted syntactically but returns immediately — a
+/// single-request server can't park the connection.
+async fn handle_xread(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    if args.len() < 3 {
+        return Err(RustyAntError::WrongArity { command: "XREAD".into() });
+    }
+    let mut count: Option<usize> = None;
+    let mut i = 0;
+    loop {
+        let tok = arg_as_str(&args[i])?.to_ascii_uppercase();
+        match tok.as_str() {
+            "COUNT" => {
+                if i + 1 >= args.len() {
+                    return Err(RustyAntError::Parse("syntax error".into()));
+                }
+                let n = parse_i64(&args[i + 1], "COUNT")?;
+                if n < 0 {
+                    return Err(RustyAntError::Parse("COUNT must be non-negative".into()));
+                }
+                count = Some(usize::try_from(n).unwrap_or(0));
+                i += 2;
+            }
+            "BLOCK" => {
+                // Parse for validation; ignore value — we don't block.
+                if i + 1 >= args.len() {
+                    return Err(RustyAntError::Parse("syntax error".into()));
+                }
+                let _ = parse_i64(&args[i + 1], "BLOCK")?;
+                i += 2;
+            }
+            "STREAMS" => {
+                i += 1;
+                break;
+            }
+            _ => return Err(RustyAntError::Parse("syntax error".into())),
+        }
+    }
+    let remaining = args.len() - i;
+    if remaining == 0 || remaining % 2 != 0 {
+        return Err(RustyAntError::Parse(
+            "Unbalanced XREAD list of streams: for each stream key an ID or '$' must be specified.".into(),
+        ));
+    }
+    let half = remaining / 2;
+    let keys: Vec<String> = (i..i + half).map(|idx| arg_as_string(&args[idx])).collect::<Result<_, _>>()?;
+    // `$` on a freshly-read stream means "only entries added after this call"
+    // which rustyant cannot deliver (non-blocking). Treat it as "max id" so
+    // that no historical entries slip through — matches Redis for the
+    // non-blocking case.
+    let mut after_ids: Vec<StreamId> = Vec::with_capacity(half);
+    for k in 0..half {
+        let id_str = arg_as_str(&args[i + half + k])?;
+        if id_str == "$" {
+            after_ids.push(StreamId::MAX);
+        } else {
+            after_ids.push(StreamId::parse(id_str)?);
+        }
+    }
+    let per_stream = state.storage.xread(&keys, &after_ids, count).await?;
+    if per_stream.is_empty() {
+        return Ok(RespReply::Nil);
+    }
+    // Reply shape: [[key, [entry, entry, ...]], ...]
+    Ok(RespReply::Array(
+        per_stream
+            .into_iter()
+            .map(|(key, entries)| {
+                RespReply::Array(vec![
+                    RespReply::BulkString(Some(Bytes::from(key.into_bytes()))),
+                    RespReply::Array(entries.into_iter().map(entry_to_reply).collect()),
+                ])
+            })
+            .collect(),
+    ))
+}
+
+/// Redis `XINFO STREAM key [FULL [COUNT n]]`.
+/// The FULL form is accepted syntactically but renders the same summary
+/// here — rustyant has no consumer-groups surface yet (#50), so there is
+/// nothing to emit under `groups`.
+async fn handle_xinfo(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    let sub = args.first().ok_or_else(|| RustyAntError::WrongArity { command: "XINFO".into() })?;
+    let sub = arg_as_str(sub)?.to_ascii_uppercase();
+    match sub.as_str() {
+        "STREAM" => {
+            if args.len() < 2 {
+                return Err(RustyAntError::WrongArity { command: "XINFO STREAM".into() });
+            }
+            let key = arg_as_str(&args[1])?;
+            // Optional FULL / COUNT tail — accepted but not used beyond
+            // syntactic validation.
+            if args.len() > 2 {
+                let tail_start = 2;
+                if !arg_as_str(&args[tail_start])?.eq_ignore_ascii_case("FULL") {
+                    return Err(RustyAntError::Parse("syntax error".into()));
+                }
+                if args.len() == 5 {
+                    if !arg_as_str(&args[3])?.eq_ignore_ascii_case("COUNT") {
+                        return Err(RustyAntError::Parse("syntax error".into()));
+                    }
+                    let _ = parse_i64(&args[4], "COUNT")?;
+                } else if args.len() != 3 {
+                    return Err(RustyAntError::Parse("syntax error".into()));
+                }
+            }
+            let Some(stream) = state.storage.xinfo_stream(key).await? else {
+                return Err(RustyAntError::Parse("no such key".into()));
+            };
+            let length = i64::try_from(stream.entries.len()).unwrap_or(i64::MAX);
+            let first_entry = stream.entries.first().cloned().map_or(RespReply::Nil, entry_to_reply);
+            let last_entry = stream.entries.last().cloned().map_or(RespReply::Nil, entry_to_reply);
+            Ok(RespReply::Array(vec![
+                RespReply::BulkString(Some(Bytes::from_static(b"length"))),
+                RespReply::Integer(length),
+                RespReply::BulkString(Some(Bytes::from_static(b"last-generated-id"))),
+                stream_id_bulk(stream.last_generated_id),
+                RespReply::BulkString(Some(Bytes::from_static(b"max-deleted-entry-id"))),
+                stream_id_bulk(stream.max_deleted_entry_id),
+                RespReply::BulkString(Some(Bytes::from_static(b"entries-added"))),
+                RespReply::Integer(i64::try_from(stream.entries_added).unwrap_or(i64::MAX)),
+                RespReply::BulkString(Some(Bytes::from_static(b"groups"))),
+                RespReply::Integer(0),
+                RespReply::BulkString(Some(Bytes::from_static(b"first-entry"))),
+                first_entry,
+                RespReply::BulkString(Some(Bytes::from_static(b"last-entry"))),
+                last_entry,
+            ]))
+        }
+        "GROUPS" | "CONSUMERS" => {
+            // Consumer-group surface — empty array is the honest answer
+            // until #50 ships. Real Redis returns the same shape here.
+            Ok(RespReply::Array(Vec::new()))
+        }
+        "HELP" => Ok(RespReply::Array(vec![RespReply::BulkString(Some(Bytes::from_static(
+            b"XINFO STREAM <key> [FULL [COUNT n]] -- summary for the stream at <key>.",
+        )))])),
+        other => Err(RustyAntError::Parse(format!("unsupported XINFO subcommand: {other}"))),
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod resp;
 pub mod settings;
 pub mod state;
 pub mod storage;
+pub mod stream;
 pub mod test_support;
 pub mod ws;
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::RustyAntError;
 use crate::hll;
+use crate::stream::{AddIdSpec, RangeId, StreamEntry, StreamId, StreamValue, TrimBound, resolve_add_id, trim_in_place};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct StoredValue {
@@ -26,6 +27,7 @@ pub enum Value {
     List(Vec<Vec<u8>>),
     Set(BTreeSet<String>),
     ZSet(BTreeMap<String, f64>),
+    Stream(crate::stream::StreamValue),
 }
 
 #[derive(Debug)]
@@ -227,6 +229,7 @@ const fn value_kind(value: &Value) -> &'static str {
         Value::List(_) => "list",
         Value::Set(_) => "set",
         Value::ZSet(_) => "zset",
+        Value::Stream(_) => "stream",
     }
 }
 
@@ -910,6 +913,61 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
         pattern: Option<&str>,
         count: usize,
     ) -> Result<(u64, Vec<(String, f64)>), RustyAntError>;
+
+    // ---- Streams -------------------------------------------------------
+    /// Redis `XADD`. Resolves the caller's id spec against the stream's
+    /// `last_generated_id`, appends the entry, and optionally trims the
+    /// head to satisfy a `MAXLEN` / `MINID` bound. Returns the id that
+    /// was actually written.
+    ///
+    /// `nomkstream` set to true: behave like Redis's NOMKSTREAM — if the
+    /// key does not exist, return `None` without creating it.
+    async fn xadd(
+        &self,
+        key: &str,
+        id: AddIdSpec,
+        fields: Vec<(String, Vec<u8>)>,
+        nomkstream: bool,
+        trim: Option<(TrimBound, Option<usize>)>,
+    ) -> Result<Option<StreamId>, RustyAntError>;
+
+    /// Redis `XLEN`: number of entries in the stream. 0 for missing key;
+    /// WRONGTYPE if the key exists as a different kind.
+    async fn xlen(&self, key: &str) -> Result<i64, RustyAntError>;
+
+    /// Redis `XRANGE` / `XREVRANGE`: entries whose id falls within
+    /// `[start, end]`. `reverse=true` walks the matching slice from
+    /// newest to oldest. `count` caps the number of returned entries.
+    async fn xrange(
+        &self,
+        key: &str,
+        start: RangeId,
+        end: RangeId,
+        count: Option<usize>,
+        reverse: bool,
+    ) -> Result<Vec<StreamEntry>, RustyAntError>;
+
+    /// Redis `XDEL`: remove entries by id; returns the number deleted.
+    async fn xdel(&self, key: &str, ids: &[StreamId]) -> Result<i64, RustyAntError>;
+
+    /// Redis `XTRIM`: apply `bound` to the stream, returning the count
+    /// of entries removed. `limit` caps the work per call (Redis's
+    /// `LIMIT n` argument).
+    async fn xtrim(&self, key: &str, bound: TrimBound, limit: Option<usize>) -> Result<i64, RustyAntError>;
+
+    /// Redis `XREAD`: for each `(key, after_id)` pair, return entries
+    /// strictly after `after_id`. `count` caps per-stream. The caller is
+    /// responsible for shaping the `XREAD` reply — this just returns the
+    /// flat map from stream name to its matching entries.
+    async fn xread(
+        &self,
+        keys: &[String],
+        after_ids: &[StreamId],
+        count: Option<usize>,
+    ) -> Result<Vec<(String, Vec<StreamEntry>)>, RustyAntError>;
+
+    /// Redis `XINFO STREAM key`: headline summary of the stream.
+    async fn xinfo_stream(&self, key: &str) -> Result<Option<StreamValue>, RustyAntError>;
 
     /// Return every key matching `pattern` (Redis-style glob: `*`, `?`).
     /// On S3 this fans out to repeated `ListObjectsV2` calls until the
@@ -1879,6 +1937,153 @@ impl Storage for S3Storage {
             }
             Some(_) => Err(wrong_type(key)),
             None => Ok((0, Vec::new())),
+        }
+    }
+
+    // ---- Streams -------------------------------------------------------
+
+    async fn xadd(
+        &self,
+        key: &str,
+        id_spec: AddIdSpec,
+        fields: Vec<(String, Vec<u8>)>,
+        nomkstream: bool,
+        trim: Option<(TrimBound, Option<usize>)>,
+    ) -> Result<Option<StreamId>, RustyAntError> {
+        let now = u64::try_from(now_ms().max(0)).unwrap_or(0);
+        self.cas(key, move |entry| {
+            let (mut stream, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::Stream(s), expires_at_ms }) => (s.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => {
+                    if nomkstream {
+                        return Ok(CasAction::NoOp(None));
+                    }
+                    (StreamValue::default(), None)
+                }
+            };
+            let id = resolve_add_id(id_spec, stream.last_generated_id, now)?;
+            stream.entries.push(StreamEntry { id, fields: fields.clone() });
+            stream.last_generated_id = id;
+            stream.entries_added = stream.entries_added.saturating_add(1);
+            if let Some((bound, limit)) = trim {
+                trim_in_place(&mut stream, bound, limit);
+            }
+            let new_entry = StoredValue { expires_at_ms, value: Value::Stream(stream) };
+            Ok(CasAction::Write(new_entry, Some(id)))
+        })
+        .await
+    }
+
+    async fn xlen(&self, key: &str) -> Result<i64, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::Stream(s), .. }) => Ok(i64::try_from(s.entries.len()).unwrap_or(i64::MAX)),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(0),
+        }
+    }
+
+    async fn xrange(
+        &self,
+        key: &str,
+        start: RangeId,
+        end: RangeId,
+        count: Option<usize>,
+        reverse: bool,
+    ) -> Result<Vec<StreamEntry>, RustyAntError> {
+        let stream = match self.load(key).await? {
+            Some(StoredValue { value: Value::Stream(s), .. }) => s,
+            Some(_) => return Err(wrong_type(key)),
+            None => return Ok(Vec::new()),
+        };
+        let mut filtered: Vec<StreamEntry> =
+            stream.entries.into_iter().filter(|e| start.ge_min(e.id) && end.le_max(e.id)).collect();
+        if reverse {
+            filtered.reverse();
+        }
+        if let Some(cap) = count {
+            filtered.truncate(cap);
+        }
+        Ok(filtered)
+    }
+
+    async fn xdel(&self, key: &str, ids: &[StreamId]) -> Result<i64, RustyAntError> {
+        let ids = ids.to_vec();
+        self.cas(key, move |entry| {
+            let (mut stream, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::Stream(s), expires_at_ms }) => (s.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => return Ok(CasAction::NoOp(0)),
+            };
+            let before = stream.entries.len();
+            stream.entries.retain(|e| {
+                if ids.contains(&e.id) {
+                    if e.id > stream.max_deleted_entry_id {
+                        stream.max_deleted_entry_id = e.id;
+                    }
+                    false
+                } else {
+                    true
+                }
+            });
+            let removed = i64::try_from(before - stream.entries.len()).unwrap_or(i64::MAX);
+            if removed == 0 {
+                return Ok(CasAction::NoOp(0));
+            }
+            let new_entry = StoredValue { expires_at_ms, value: Value::Stream(stream) };
+            Ok(CasAction::Write(new_entry, removed))
+        })
+        .await
+    }
+
+    async fn xtrim(&self, key: &str, bound: TrimBound, limit: Option<usize>) -> Result<i64, RustyAntError> {
+        self.cas(key, move |entry| {
+            let (mut stream, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::Stream(s), expires_at_ms }) => (s.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => return Ok(CasAction::NoOp(0)),
+            };
+            let removed = trim_in_place(&mut stream, bound, limit);
+            if removed == 0 {
+                return Ok(CasAction::NoOp(0));
+            }
+            let new_entry = StoredValue { expires_at_ms, value: Value::Stream(stream) };
+            Ok(CasAction::Write(new_entry, i64::try_from(removed).unwrap_or(i64::MAX)))
+        })
+        .await
+    }
+
+    async fn xread(
+        &self,
+        keys: &[String],
+        after_ids: &[StreamId],
+        count: Option<usize>,
+    ) -> Result<Vec<(String, Vec<StreamEntry>)>, RustyAntError> {
+        let mut out: Vec<(String, Vec<StreamEntry>)> = Vec::new();
+        for (key, after) in keys.iter().zip(after_ids.iter()) {
+            let entries = match self.load(key).await? {
+                Some(StoredValue { value: Value::Stream(s), .. }) => {
+                    let mut matched: Vec<StreamEntry> = s.entries.into_iter().filter(|e| e.id > *after).collect();
+                    if let Some(cap) = count {
+                        matched.truncate(cap);
+                    }
+                    matched
+                }
+                Some(_) => return Err(wrong_type(key)),
+                None => Vec::new(),
+            };
+            if !entries.is_empty() {
+                out.push((key.clone(), entries));
+            }
+        }
+        Ok(out)
+    }
+
+    async fn xinfo_stream(&self, key: &str) -> Result<Option<StreamValue>, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::Stream(s), .. }) => Ok(Some(s)),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(None),
         }
     }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,0 +1,400 @@
+//! Redis Streams — base primitives and shared parsing.
+//!
+//! Streams are an append-only log of `(id, field-value-map)` entries. The
+//! id is `<ms>-<seq>`, monotonic within the key. Entries are kept sorted
+//! ascending by id.
+//!
+//! This module owns the data types and the parsing helpers used by the
+//! command handlers in `commands.rs`. Storage operations (append, range
+//! scan, trim, delete) live on the `Storage` trait and are driven by the
+//! CAS loop in `S3Storage`.
+
+use std::cmp::Ordering;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::RustyAntError;
+
+/// Monotonic stream id. Redis formats ids as `"<ms>-<seq>"` on the wire;
+/// we keep them as a pair for ordering and emit the formatted form when
+/// serialising replies.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StreamId {
+    pub ms: u64,
+    pub seq: u64,
+}
+
+impl StreamId {
+    pub const MIN: Self = Self { ms: 0, seq: 0 };
+    pub const MAX: Self = Self { ms: u64::MAX, seq: u64::MAX };
+
+    /// Parse a concrete id from the Redis wire form (`<ms>-<seq>` or just
+    /// `<ms>`). Does NOT accept `*` / `-` / `+` — those only make sense in
+    /// specific command contexts and are resolved by the caller.
+    pub fn parse(s: &str) -> Result<Self, RustyAntError> {
+        let (ms_part, seq_part) = s.split_once('-').map_or((s, None), |(a, b)| (a, Some(b)));
+        let ms: u64 = ms_part
+            .parse()
+            .map_err(|_| RustyAntError::Parse("Invalid stream ID specified as stream command argument".into()))?;
+        let seq: u64 = match seq_part {
+            Some(b) => b
+                .parse()
+                .map_err(|_| RustyAntError::Parse("Invalid stream ID specified as stream command argument".into()))?,
+            None => 0,
+        };
+        Ok(Self { ms, seq })
+    }
+
+    /// Increment by one seq (wrapping into the next ms on overflow). Used
+    /// when a caller needs the "next" id after a known one — e.g. XREAD's
+    /// exclusive "strictly after `id`" walk.
+    #[must_use]
+    pub const fn next(self) -> Self {
+        if self.seq == u64::MAX {
+            Self { ms: self.ms.wrapping_add(1), seq: 0 }
+        } else {
+            Self { ms: self.ms, seq: self.seq + 1 }
+        }
+    }
+}
+
+impl fmt::Display for StreamId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}-{}", self.ms, self.seq)
+    }
+}
+
+impl PartialOrd for StreamId {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for StreamId {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.ms.cmp(&other.ms).then_with(|| self.seq.cmp(&other.seq))
+    }
+}
+
+/// An appended entry. Field ordering is preserved from the caller's
+/// argument list, matching Redis's return order for `XRANGE` et al.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StreamEntry {
+    pub id: StreamId,
+    pub fields: Vec<(String, Vec<u8>)>,
+}
+
+/// The stream value-kind.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StreamValue {
+    /// Entries in ascending id order.
+    pub entries: Vec<StreamEntry>,
+    /// Highest id ever generated for this stream — used to enforce
+    /// monotonicity against auto-id (`*`) as well as explicit ids.
+    #[serde(default)]
+    pub last_generated_id: StreamId,
+    /// Number of entries that have ever been deleted via `XDEL` or
+    /// trimmed via `XADD MAXLEN` / `XTRIM`. Reported by `XINFO STREAM`
+    /// and, in real Redis, used to compute consumer-group lag.
+    #[serde(default)]
+    pub max_deleted_entry_id: StreamId,
+    /// Total entries ever added (including those since trimmed / deleted).
+    #[serde(default)]
+    pub entries_added: u64,
+}
+
+/// Parsed id argument for `XADD` — either auto (`*`), an auto-seq within
+/// a specific ms (`<ms>-*`), or a concrete `<ms>-<seq>`.
+#[derive(Debug, Clone, Copy)]
+pub enum AddIdSpec {
+    Auto,
+    PartialMs(u64),
+    Concrete(StreamId),
+}
+
+impl AddIdSpec {
+    pub fn parse(s: &str) -> Result<Self, RustyAntError> {
+        if s == "*" {
+            return Ok(Self::Auto);
+        }
+        if let Some((ms_part, seq_part)) = s.split_once('-') {
+            let ms: u64 = ms_part
+                .parse()
+                .map_err(|_| RustyAntError::Parse("Invalid stream ID specified as stream command argument".into()))?;
+            if seq_part == "*" {
+                return Ok(Self::PartialMs(ms));
+            }
+            let seq: u64 = seq_part
+                .parse()
+                .map_err(|_| RustyAntError::Parse("Invalid stream ID specified as stream command argument".into()))?;
+            return Ok(Self::Concrete(StreamId { ms, seq }));
+        }
+        // Bare number — same as <ms>-0.
+        let ms: u64 = s
+            .parse()
+            .map_err(|_| RustyAntError::Parse("Invalid stream ID specified as stream command argument".into()))?;
+        Ok(Self::Concrete(StreamId { ms, seq: 0 }))
+    }
+}
+
+/// Parsed start/end id for range queries.
+///
+/// `-` / `+` are the stream-wide extremes; an explicit id parses the
+/// standard form. Redis also accepts a `(` prefix for exclusivity
+/// (Redis 6.2+); this module supports both.
+#[derive(Debug, Clone, Copy)]
+pub enum RangeId {
+    MinInf,
+    MaxInf,
+    Inclusive(StreamId),
+    /// `(<ms>-<seq>` — exclusive, typically used for pagination.
+    Exclusive(StreamId),
+}
+
+impl RangeId {
+    pub fn parse(s: &str) -> Result<Self, RustyAntError> {
+        match s {
+            "-" => Ok(Self::MinInf),
+            "+" => Ok(Self::MaxInf),
+            other => {
+                if let Some(rest) = other.strip_prefix('(') {
+                    Ok(Self::Exclusive(StreamId::parse(rest)?))
+                } else {
+                    Ok(Self::Inclusive(StreamId::parse(other)?))
+                }
+            }
+        }
+    }
+
+    /// Determine whether `id` is above the minimum bound this range
+    /// represents.
+    pub fn ge_min(self, id: StreamId) -> bool {
+        match self {
+            Self::MinInf => true,
+            Self::MaxInf => false,
+            Self::Inclusive(bound) => id >= bound,
+            Self::Exclusive(bound) => id > bound,
+        }
+    }
+
+    /// Determine whether `id` is below the maximum bound this range
+    /// represents.
+    pub fn le_max(self, id: StreamId) -> bool {
+        match self {
+            Self::MinInf => false,
+            Self::MaxInf => true,
+            Self::Inclusive(bound) => id <= bound,
+            Self::Exclusive(bound) => id < bound,
+        }
+    }
+}
+
+/// Resolve an `AddIdSpec` against `last_generated_id` and the current
+/// wall-clock `now_ms`. Returns the concrete id to store, or an error if
+/// the caller-supplied id would go backwards.
+pub fn resolve_add_id(spec: AddIdSpec, last: StreamId, now_ms: u64) -> Result<StreamId, RustyAntError> {
+    let candidate = match spec {
+        AddIdSpec::Auto => {
+            if now_ms > last.ms {
+                StreamId { ms: now_ms, seq: 0 }
+            } else {
+                // Same ms (or clock went backwards) — bump seq from last.
+                last.next()
+            }
+        }
+        AddIdSpec::PartialMs(ms) => {
+            if ms < last.ms {
+                return Err(RustyAntError::Parse(
+                    "The ID specified in XADD is equal or smaller than the target stream top item".into(),
+                ));
+            }
+            if ms == last.ms { last.next() } else { StreamId { ms, seq: 0 } }
+        }
+        AddIdSpec::Concrete(id) => {
+            if id <= last {
+                return Err(RustyAntError::Parse(
+                    "The ID specified in XADD is equal or smaller than the target stream top item".into(),
+                ));
+            }
+            id
+        }
+    };
+    Ok(candidate)
+}
+
+/// `XTRIM` mode — MAXLEN bounds by entry count, MINID bounds by id.
+#[derive(Debug, Clone, Copy)]
+pub enum TrimBound {
+    MaxLen(usize),
+    MinId(StreamId),
+}
+
+/// Parse a `MAXLEN [~|=] n` / `MINID [~|=] id` pair plus optional
+/// `LIMIT n` at the start of `tokens`. Returns the bound, optional
+/// LIMIT, and the number of tokens consumed.
+///
+/// The `~` / `=` modifier is accepted and otherwise ignored: on S3 we
+/// always apply exactly, and `~` is a Redis-internal optimisation hint.
+/// LIMIT caps the number of entries trimmed per call; we honor it.
+pub fn parse_trim(tokens: &[&str]) -> Result<(TrimBound, Option<usize>, usize), RustyAntError> {
+    if tokens.is_empty() {
+        return Err(RustyAntError::Parse("syntax error".into()));
+    }
+    let keyword = tokens[0].to_ascii_uppercase();
+    let (bound_kind, mut consumed) = match keyword.as_str() {
+        "MAXLEN" | "MINID" => (keyword, 1usize),
+        _ => return Err(RustyAntError::Parse("syntax error".into())),
+    };
+    // Optional ~ / =.
+    if tokens.get(consumed).is_some_and(|t| *t == "~" || *t == "=") {
+        consumed += 1;
+    }
+    let threshold_tok = tokens.get(consumed).ok_or_else(|| RustyAntError::Parse("syntax error".into()))?;
+    consumed += 1;
+    let bound = match bound_kind.as_str() {
+        "MAXLEN" => {
+            let n: i64 = threshold_tok
+                .parse()
+                .map_err(|_| RustyAntError::Parse("value is not an integer or out of range".into()))?;
+            if n < 0 {
+                return Err(RustyAntError::Parse("MAXLEN must be non-negative".into()));
+            }
+            TrimBound::MaxLen(usize::try_from(n).unwrap_or(0))
+        }
+        _ => TrimBound::MinId(StreamId::parse(threshold_tok)?),
+    };
+
+    // Optional LIMIT n.
+    let limit: Option<usize> = if tokens.get(consumed).is_some_and(|t| t.eq_ignore_ascii_case("LIMIT")) {
+        consumed += 1;
+        let n_tok = tokens.get(consumed).ok_or_else(|| RustyAntError::Parse("syntax error".into()))?;
+        consumed += 1;
+        let n: i64 =
+            n_tok.parse().map_err(|_| RustyAntError::Parse("value is not an integer or out of range".into()))?;
+        if n < 0 {
+            return Err(RustyAntError::Parse("LIMIT must be non-negative".into()));
+        }
+        Some(usize::try_from(n).unwrap_or(0))
+    } else {
+        None
+    };
+
+    Ok((bound, limit, consumed))
+}
+
+/// Apply a `TrimBound` to the stream's entries in-place. Returns the
+/// number of entries removed. `limit` caps the work per call (Redis
+/// semantics — useful on very long streams; 0-cap removes nothing).
+pub fn trim_in_place(stream: &mut StreamValue, bound: TrimBound, limit: Option<usize>) -> usize {
+    let target_start_idx = match bound {
+        TrimBound::MaxLen(max) => stream.entries.len().saturating_sub(max),
+        TrimBound::MinId(min) => stream.entries.partition_point(|e| e.id < min),
+    };
+    let mut to_remove = target_start_idx;
+    if let Some(cap) = limit {
+        to_remove = to_remove.min(cap);
+    }
+    if to_remove == 0 {
+        return 0;
+    }
+    let removed: Vec<StreamEntry> = stream.entries.drain(..to_remove).collect();
+    if let Some(last) = removed.last() {
+        if last.id > stream.max_deleted_entry_id {
+            stream.max_deleted_entry_id = last.id;
+        }
+    }
+    removed.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stream_id_roundtrip() {
+        let id = StreamId::parse("1726934567890-5").expect("parse");
+        assert_eq!(id.to_string(), "1726934567890-5");
+        assert_eq!(StreamId::parse("42").expect("parse"), StreamId { ms: 42, seq: 0 });
+    }
+
+    #[test]
+    fn stream_id_ordering_within_and_across_ms() {
+        assert!(StreamId { ms: 1, seq: 2 } < StreamId { ms: 1, seq: 3 });
+        assert!(StreamId { ms: 1, seq: 99 } < StreamId { ms: 2, seq: 0 });
+    }
+
+    #[test]
+    fn auto_id_uses_now_when_ahead() {
+        let last = StreamId { ms: 10, seq: 5 };
+        let id = resolve_add_id(AddIdSpec::Auto, last, 50).expect("resolve");
+        assert_eq!(id, StreamId { ms: 50, seq: 0 });
+    }
+
+    #[test]
+    fn auto_id_bumps_seq_when_clock_not_advanced() {
+        let last = StreamId { ms: 10, seq: 5 };
+        let id = resolve_add_id(AddIdSpec::Auto, last, 10).expect("resolve");
+        assert_eq!(id, StreamId { ms: 10, seq: 6 });
+    }
+
+    #[test]
+    fn partial_ms_fills_seq() {
+        let last = StreamId { ms: 5, seq: 9 };
+        // ms ahead of last → seq starts at 0
+        let id = resolve_add_id(AddIdSpec::PartialMs(6), last, 100).expect("resolve");
+        assert_eq!(id, StreamId { ms: 6, seq: 0 });
+        // same ms → seq bumps
+        let id2 = resolve_add_id(AddIdSpec::PartialMs(5), last, 100).expect("resolve");
+        assert_eq!(id2, StreamId { ms: 5, seq: 10 });
+    }
+
+    #[test]
+    fn explicit_id_rejected_when_not_monotonic() {
+        let last = StreamId { ms: 5, seq: 0 };
+        assert!(resolve_add_id(AddIdSpec::Concrete(StreamId { ms: 5, seq: 0 }), last, 100).is_err());
+        assert!(resolve_add_id(AddIdSpec::Concrete(StreamId { ms: 4, seq: 99 }), last, 100).is_err());
+        assert!(resolve_add_id(AddIdSpec::Concrete(StreamId { ms: 5, seq: 1 }), last, 100).is_ok());
+    }
+
+    #[test]
+    fn trim_maxlen_removes_head() {
+        let mut s = StreamValue::default();
+        for ms in 1..=5u64 {
+            s.entries.push(StreamEntry { id: StreamId { ms, seq: 0 }, fields: vec![] });
+        }
+        assert_eq!(trim_in_place(&mut s, TrimBound::MaxLen(2), None), 3);
+        assert_eq!(s.entries.len(), 2);
+        assert_eq!(s.entries[0].id.ms, 4);
+    }
+
+    #[test]
+    fn trim_minid_removes_below_threshold() {
+        let mut s = StreamValue::default();
+        for ms in 1..=5u64 {
+            s.entries.push(StreamEntry { id: StreamId { ms, seq: 0 }, fields: vec![] });
+        }
+        assert_eq!(trim_in_place(&mut s, TrimBound::MinId(StreamId { ms: 3, seq: 0 }), None), 2);
+        assert_eq!(s.entries[0].id.ms, 3);
+    }
+
+    #[test]
+    fn trim_honors_limit() {
+        let mut s = StreamValue::default();
+        for ms in 1..=5u64 {
+            s.entries.push(StreamEntry { id: StreamId { ms, seq: 0 }, fields: vec![] });
+        }
+        // Want to remove 3 (to keep 2), but LIMIT 1 caps at 1 removal.
+        assert_eq!(trim_in_place(&mut s, TrimBound::MaxLen(2), Some(1)), 1);
+        assert_eq!(s.entries.len(), 4);
+    }
+
+    #[test]
+    fn range_id_bounds() {
+        let r = RangeId::parse("-").expect("parse");
+        assert!(r.ge_min(StreamId { ms: 0, seq: 0 }));
+        let r = RangeId::parse("(5-0").expect("parse");
+        assert!(!r.ge_min(StreamId { ms: 5, seq: 0 }));
+        assert!(r.ge_min(StreamId { ms: 5, seq: 1 }));
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -424,6 +424,197 @@ async fn pf_stored_as_string_roundtrips_via_get() {
     assert!(raw[body_start..].starts_with(b"HYLL"), "GET on HLL key did not return an HYLL-prefixed blob");
 }
 
+// ---------------------------------------------------------------------------
+// Streams — XADD / XLEN / XRANGE / XREVRANGE / XDEL / XTRIM / XREAD / XINFO
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn xadd_appends_and_xlen_counts() {
+    let state = test_state();
+    // Auto-id with a single field.
+    let reply = call(&state, &[b"XADD", b"s", b"*", b"f1", b"v1"]).await;
+    // Reply is a bulk string "<ms>-0" or similar; just check it parses.
+    let body = String::from_utf8_lossy(&reply.raw).to_string();
+    assert!(body.contains('-'), "expected ms-seq id: {body}");
+    call(&state, &[b"XLEN", b"s"]).await.expect_integer(1);
+    call(&state, &[b"XADD", b"s", b"*", b"f1", b"v2", b"f2", b"v3"]).await;
+    call(&state, &[b"XLEN", b"s"]).await.expect_integer(2);
+}
+
+#[tokio::test]
+async fn xadd_explicit_id_round_trips() {
+    let state = test_state();
+    call(&state, &[b"XADD", b"s", b"1-1", b"f", b"v"]).await.expect_bulk(b"1-1");
+    // Backwards id → error.
+    call(&state, &[b"XADD", b"s", b"1-0", b"f", b"v"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"XADD", b"s", b"2-0", b"f", b"v"]).await.expect_bulk(b"2-0");
+}
+
+#[tokio::test]
+async fn xadd_nomkstream_on_missing_returns_nil() {
+    let state = test_state();
+    call(&state, &[b"XADD", b"ghost", b"NOMKSTREAM", b"*", b"f", b"v"]).await.expect_nil();
+    call(&state, &[b"EXISTS", b"ghost"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn xlen_missing_key_returns_zero() {
+    let state = test_state();
+    call(&state, &[b"XLEN", b"missing"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn xrange_returns_matching_entries() {
+    let state = test_state();
+    call(&state, &[b"XADD", b"s", b"1-0", b"k", b"a"]).await;
+    call(&state, &[b"XADD", b"s", b"2-0", b"k", b"b"]).await;
+    call(&state, &[b"XADD", b"s", b"3-0", b"k", b"c"]).await;
+    let reply = call(&state, &[b"XRANGE", b"s", b"-", b"+"]).await;
+    let raw = String::from_utf8_lossy(&reply.raw).to_string();
+    assert!(raw.starts_with("*3\r\n"), "expected 3 entries, got: {raw}");
+    // Ids appear in the reply.
+    assert!(raw.contains("1-0") && raw.contains("2-0") && raw.contains("3-0"));
+}
+
+#[tokio::test]
+async fn xrange_count_caps_results() {
+    let state = test_state();
+    for ms in 1..=5u64 {
+        call(&state, &[b"XADD", b"s", format!("{ms}-0").as_bytes(), b"k", b"v"]).await;
+    }
+    let reply = call(&state, &[b"XRANGE", b"s", b"-", b"+", b"COUNT", b"2"]).await;
+    let raw = String::from_utf8_lossy(&reply.raw).to_string();
+    assert!(raw.starts_with("*2\r\n"), "expected 2 entries, got: {raw}");
+}
+
+#[tokio::test]
+async fn xrevrange_walks_backwards() {
+    let state = test_state();
+    for ms in 1..=3u64 {
+        call(&state, &[b"XADD", b"s", format!("{ms}-0").as_bytes(), b"k", b"v"]).await;
+    }
+    let reply = call(&state, &[b"XREVRANGE", b"s", b"+", b"-"]).await;
+    let raw = String::from_utf8_lossy(&reply.raw).to_string();
+    // First id in the reply should be the highest (3-0).
+    let pos_3 = raw.find("3-0").expect("3-0 present");
+    let pos_1 = raw.find("1-0").expect("1-0 present");
+    assert!(pos_3 < pos_1, "XREVRANGE should emit newest first");
+}
+
+#[tokio::test]
+async fn xdel_removes_by_id() {
+    let state = test_state();
+    call(&state, &[b"XADD", b"s", b"1-0", b"f", b"a"]).await;
+    call(&state, &[b"XADD", b"s", b"2-0", b"f", b"b"]).await;
+    call(&state, &[b"XADD", b"s", b"3-0", b"f", b"c"]).await;
+    call(&state, &[b"XDEL", b"s", b"2-0", b"99-0"]).await.expect_integer(1);
+    call(&state, &[b"XLEN", b"s"]).await.expect_integer(2);
+}
+
+#[tokio::test]
+async fn xtrim_maxlen_trims_head() {
+    let state = test_state();
+    for ms in 1..=5u64 {
+        call(&state, &[b"XADD", b"s", format!("{ms}-0").as_bytes(), b"k", b"v"]).await;
+    }
+    call(&state, &[b"XTRIM", b"s", b"MAXLEN", b"2"]).await.expect_integer(3);
+    call(&state, &[b"XLEN", b"s"]).await.expect_integer(2);
+}
+
+#[tokio::test]
+async fn xtrim_minid_drops_below_threshold() {
+    let state = test_state();
+    for ms in 1..=5u64 {
+        call(&state, &[b"XADD", b"s", format!("{ms}-0").as_bytes(), b"k", b"v"]).await;
+    }
+    // Drop everything strictly below 3-0.
+    call(&state, &[b"XTRIM", b"s", b"MINID", b"3-0"]).await.expect_integer(2);
+    call(&state, &[b"XLEN", b"s"]).await.expect_integer(3);
+}
+
+#[tokio::test]
+async fn xadd_trim_clause_applies_on_append() {
+    let state = test_state();
+    for ms in 1..=3u64 {
+        call(&state, &[b"XADD", b"s", format!("{ms}-0").as_bytes(), b"k", b"v"]).await;
+    }
+    // Append with MAXLEN 2 → pre-existing head is trimmed, final length 2.
+    call(&state, &[b"XADD", b"s", b"MAXLEN", b"2", b"4-0", b"k", b"v"]).await.expect_bulk(b"4-0");
+    call(&state, &[b"XLEN", b"s"]).await.expect_integer(2);
+}
+
+#[tokio::test]
+async fn xread_returns_entries_after_id() {
+    let state = test_state();
+    call(&state, &[b"XADD", b"s", b"1-0", b"f", b"a"]).await;
+    call(&state, &[b"XADD", b"s", b"2-0", b"f", b"b"]).await;
+    let reply = call(&state, &[b"XREAD", b"STREAMS", b"s", b"1-0"]).await;
+    let raw = String::from_utf8_lossy(&reply.raw).to_string();
+    // Only 2-0 is strictly after 1-0.
+    assert!(raw.contains("2-0"), "reply should contain 2-0: {raw}");
+    assert!(!raw.contains("1-0"), "reply should not contain 1-0: {raw}");
+}
+
+#[tokio::test]
+async fn xread_count_caps_per_stream() {
+    let state = test_state();
+    for ms in 1..=5u64 {
+        call(&state, &[b"XADD", b"s", format!("{ms}-0").as_bytes(), b"k", b"v"]).await;
+    }
+    let reply = call(&state, &[b"XREAD", b"COUNT", b"2", b"STREAMS", b"s", b"0"]).await;
+    let raw = String::from_utf8_lossy(&reply.raw).to_string();
+    // Two entries.
+    assert!(raw.contains("1-0") && raw.contains("2-0"));
+    assert!(!raw.contains("3-0"), "COUNT 2 should cap results: {raw}");
+}
+
+#[tokio::test]
+async fn xread_with_dollar_returns_nil_for_nonblocking() {
+    let state = test_state();
+    call(&state, &[b"XADD", b"s", b"1-0", b"f", b"v"]).await;
+    // `$` means "only new entries" — rustyant is non-blocking, so nil.
+    call(&state, &[b"XREAD", b"STREAMS", b"s", b"$"]).await.expect_nil();
+}
+
+#[tokio::test]
+async fn xread_all_empty_returns_nil() {
+    let state = test_state();
+    call(&state, &[b"XREAD", b"STREAMS", b"missing", b"0"]).await.expect_nil();
+}
+
+#[tokio::test]
+async fn xinfo_stream_summary() {
+    let state = test_state();
+    call(&state, &[b"XADD", b"s", b"1-0", b"k", b"a"]).await;
+    call(&state, &[b"XADD", b"s", b"2-0", b"k", b"b"]).await;
+    let reply = call(&state, &[b"XINFO", b"STREAM", b"s"]).await;
+    let raw = String::from_utf8_lossy(&reply.raw).to_string();
+    assert!(raw.contains("length"));
+    assert!(raw.contains("last-generated-id"));
+    assert!(raw.contains("2-0"), "should carry the latest id");
+}
+
+#[tokio::test]
+async fn xinfo_stream_missing_key_errors() {
+    let state = test_state();
+    call(&state, &[b"XINFO", b"STREAM", b"ghost"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn xadd_on_wrong_type_errors() {
+    let state = test_state();
+    call(&state, &[b"SET", b"k", b"v"]).await;
+    call(&state, &[b"XADD", b"k", b"*", b"f", b"v"]).await.expect_error_prefix("ERR");
+    call(&state, &[b"XLEN", b"k"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn type_of_stream_reports_stream() {
+    let state = test_state();
+    call(&state, &[b"XADD", b"s", b"*", b"f", b"v"]).await;
+    call(&state, &[b"TYPE", b"s"]).await.expect_simple("stream");
+}
+
 #[tokio::test]
 async fn malformed_body_returns_parse_error() {
     let state = test_state();


### PR DESCRIPTION
## Summary

New \`stream\` value-kind plus 8 commands: \`XADD\`, \`XLEN\`, \`XRANGE\`, \`XREVRANGE\`, \`XDEL\`, \`XTRIM\`, \`XREAD\`, \`XINFO\`. Backed by a new \`src/stream.rs\` module that owns ids, parsing, and trimming primitives; storage gets 7 trait methods plumbed through the existing CAS machinery.

Closes #49.

## Scope

- **In:** base stream commands, NOMKSTREAM / MAXLEN / MINID on XADD, COUNT on XRANGE / XREVRANGE / XREAD, \`-\` / \`+\` / \`(exclusive\` range bounds, monotonic auto-ids, XINFO STREAM summary.
- **Deferred to #50:** XGROUP / XREADGROUP / XACK / XCLAIM / XPENDING / XAUTOCLAIM.
- **BLOCK on XREAD:** parsed for syntactic correctness but returns immediately — single-request-per-HTTP server can't park the connection. \`\$\` marker returns nil on the non-blocking path.
- **~ / = modifier on trim:** accepted and ignored. On S3 we always trim exactly; ~ is a Redis-internal memory-layout hint.

## Test plan

- [x] 10 unit tests in src/stream.rs (id parse / ordering / resolve_add_id / trim variants / range bounds)
- [x] 20 integration tests in tests/integration.rs (XADD append / explicit-id / NOMKSTREAM / WRONGTYPE; XLEN; XRANGE / XREVRANGE / COUNT; XDEL; XTRIM MAXLEN / MINID; XADD trim clause; XREAD after-id / COUNT / \`\$\` / all-empty; XINFO summary / missing-key; TYPE returns \"stream\")
- [x] lint / fmt / typos clean
- [x] README scope line updated