### PR TITLE
:sparkles: add Streams consumer groups (XGROUP / XREADGROUP / XACK / XCLAIM / XPENDING / XAUTOCLAIM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ Implemented:
 rustyant targets the **most commonly used** Redis features — what a typical application workload on Lambda/S3 actually reaches for. Edge features and deprecated surface are not goals:
 
 - **Explicitly out of scope** (will not be added): Lua scripting (`EVAL` / `EVALSHA` / `SCRIPT *` / `FUNCTION *`), and deprecated commands superseded by modern equivalents (e.g. `GEORADIUS` / `GEORADIUSBYMEMBER` — use `GEOSEARCH` instead).
-- **Not yet implemented, PRs welcome**: streams consumer groups (`XGROUP` / `XREADGROUP` / `XACK` / `XCLAIM` / `XPENDING` / `XAUTOCLAIM`) — the base stream surface is in, groups are the next layer.
 
 Transactions (`MULTI` / `EXEC` / `DISCARD` / `WATCH`) and subscribe-side pub/sub (`SUBSCRIBE` / `PSUBSCRIBE` / `UNSUBSCRIBE` / `PUNSUBSCRIBE`) return explicit errors — rustyant processes one command per HTTP request with no connection-level state, so cross-request queueing, optimistic CAS, and server-pushed pub/sub messages cannot be honored honestly. `UNWATCH`, `PUBLISH`, and the `PUBSUB` introspection subcommands do reply successfully: clearing a never-populated watch set is a trivial no-op; `PUBLISH` returns `:0` because zero subscribers is the literal truth on a no-substrate server; `PUBSUB CHANNELS` / `NUMSUB` / `NUMPAT` return correspondingly empty / zero results.
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -9,7 +9,10 @@ use crate::metrics;
 use crate::resp::RespReply;
 use crate::state::State;
 use crate::storage::{GetExOp, LexBound, ScoreBound, TtlResult, ZAddFlags, bit_at, now_ms};
-use crate::stream::{AddIdSpec, RangeId, StreamEntry, StreamId, parse_trim};
+use crate::stream::{
+    AddIdSpec, GroupStartId, RangeId, StreamEntry, StreamId, XClaimOpts, XClaimResult, XGroupOp, XReadGroupId,
+    parse_trim,
+};
 
 /// Coarse classification of a dispatch result, emitted as a structured log
 /// field so `CloudWatch` queries can count/alert by outcome without string
@@ -303,6 +306,13 @@ async fn run(state: &State, tokens: Vec<Bytes>) -> Result<RespReply, RustyAntErr
         "XTRIM" => handle_xtrim(state, args).await,
         "XREAD" => handle_xread(state, args).await,
         "XINFO" => handle_xinfo(state, args).await,
+        // Streams consumer groups
+        "XGROUP" => handle_xgroup(state, args).await,
+        "XREADGROUP" => handle_xreadgroup(state, args).await,
+        "XACK" => handle_xack(state, args).await,
+        "XCLAIM" => handle_xclaim(state, args).await,
+        "XPENDING" => handle_xpending(state, args).await,
+        "XAUTOCLAIM" => handle_xautoclaim(state, args).await,
         other => Err(RustyAntError::UnknownCommand(other.to_string())),
     }
 }
@@ -4168,8 +4178,9 @@ async fn handle_xread(state: &State, args: Vec<Bytes>) -> Result<RespReply, Rust
 
 /// Redis `XINFO STREAM key [FULL [COUNT n]]`.
 /// The FULL form is accepted syntactically but renders the same summary
-/// here — rustyant has no consumer-groups surface yet (#50), so there is
-/// nothing to emit under `groups`.
+/// here — STREAM, GROUPS, and CONSUMERS each have their own assembly
+/// path, all routed from this single entry point.
+#[allow(clippy::too_many_lines)] // four subcommands in one router
 async fn handle_xinfo(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
     let sub = args.first().ok_or_else(|| RustyAntError::WrongArity { command: "XINFO".into() })?;
     let sub = arg_as_str(sub)?.to_ascii_uppercase();
@@ -4201,6 +4212,7 @@ async fn handle_xinfo(state: &State, args: Vec<Bytes>) -> Result<RespReply, Rust
             let length = i64::try_from(stream.entries.len()).unwrap_or(i64::MAX);
             let first_entry = stream.entries.first().cloned().map_or(RespReply::Nil, entry_to_reply);
             let last_entry = stream.entries.last().cloned().map_or(RespReply::Nil, entry_to_reply);
+            let groups_count = i64::try_from(stream.groups.len()).unwrap_or(i64::MAX);
             Ok(RespReply::Array(vec![
                 RespReply::BulkString(Some(Bytes::from_static(b"length"))),
                 RespReply::Integer(length),
@@ -4211,21 +4223,426 @@ async fn handle_xinfo(state: &State, args: Vec<Bytes>) -> Result<RespReply, Rust
                 RespReply::BulkString(Some(Bytes::from_static(b"entries-added"))),
                 RespReply::Integer(i64::try_from(stream.entries_added).unwrap_or(i64::MAX)),
                 RespReply::BulkString(Some(Bytes::from_static(b"groups"))),
-                RespReply::Integer(0),
+                RespReply::Integer(groups_count),
                 RespReply::BulkString(Some(Bytes::from_static(b"first-entry"))),
                 first_entry,
                 RespReply::BulkString(Some(Bytes::from_static(b"last-entry"))),
                 last_entry,
             ]))
         }
-        "GROUPS" | "CONSUMERS" => {
-            // Consumer-group surface — empty array is the honest answer
-            // until #50 ships. Real Redis returns the same shape here.
-            Ok(RespReply::Array(Vec::new()))
+        "GROUPS" => {
+            if args.len() != 2 {
+                return Err(RustyAntError::WrongArity { command: "XINFO GROUPS".into() });
+            }
+            let key = arg_as_str(&args[1])?;
+            let groups = state.storage.xinfo_groups(key).await?;
+            Ok(RespReply::Array(
+                groups
+                    .into_iter()
+                    .map(|g| {
+                        RespReply::Array(vec![
+                            RespReply::BulkString(Some(Bytes::from_static(b"name"))),
+                            RespReply::BulkString(Some(Bytes::from(g.name.into_bytes()))),
+                            RespReply::BulkString(Some(Bytes::from_static(b"consumers"))),
+                            RespReply::Integer(i64::try_from(g.consumers).unwrap_or(i64::MAX)),
+                            RespReply::BulkString(Some(Bytes::from_static(b"pending"))),
+                            RespReply::Integer(i64::try_from(g.pending).unwrap_or(i64::MAX)),
+                            RespReply::BulkString(Some(Bytes::from_static(b"last-delivered-id"))),
+                            stream_id_bulk(g.last_delivered_id),
+                        ])
+                    })
+                    .collect(),
+            ))
         }
-        "HELP" => Ok(RespReply::Array(vec![RespReply::BulkString(Some(Bytes::from_static(
-            b"XINFO STREAM <key> [FULL [COUNT n]] -- summary for the stream at <key>.",
-        )))])),
+        "CONSUMERS" => {
+            if args.len() != 3 {
+                return Err(RustyAntError::WrongArity { command: "XINFO CONSUMERS".into() });
+            }
+            let key = arg_as_str(&args[1])?;
+            let group = arg_as_str(&args[2])?;
+            let consumers = state.storage.xinfo_consumers(key, group).await?;
+            Ok(RespReply::Array(
+                consumers
+                    .into_iter()
+                    .map(|c| {
+                        RespReply::Array(vec![
+                            RespReply::BulkString(Some(Bytes::from_static(b"name"))),
+                            RespReply::BulkString(Some(Bytes::from(c.name.into_bytes()))),
+                            RespReply::BulkString(Some(Bytes::from_static(b"pending"))),
+                            RespReply::Integer(i64::try_from(c.pending).unwrap_or(i64::MAX)),
+                            RespReply::BulkString(Some(Bytes::from_static(b"idle"))),
+                            RespReply::Integer(c.idle_ms),
+                        ])
+                    })
+                    .collect(),
+            ))
+        }
+        "HELP" => Ok(RespReply::Array(vec![
+            RespReply::BulkString(Some(Bytes::from_static(
+                b"XINFO STREAM <key> [FULL [COUNT n]] -- summary for the stream at <key>.",
+            ))),
+            RespReply::BulkString(Some(Bytes::from_static(b"XINFO GROUPS <key> -- groups defined on <key>."))),
+            RespReply::BulkString(Some(Bytes::from_static(
+                b"XINFO CONSUMERS <key> <group> -- consumers in <group> on <key>.",
+            ))),
+        ])),
         other => Err(RustyAntError::Parse(format!("unsupported XINFO subcommand: {other}"))),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Streams consumer groups — XGROUP / XREADGROUP / XACK / XCLAIM / XPENDING / XAUTOCLAIM
+// ---------------------------------------------------------------------------
+
+/// Redis `XGROUP <subcmd> <key> <group> ...`.
+async fn handle_xgroup(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    if args.len() < 2 {
+        return Err(RustyAntError::WrongArity { command: "XGROUP".into() });
+    }
+    let sub = arg_as_str(&args[0])?.to_ascii_uppercase();
+    let key = arg_as_str(&args[1])?;
+    let op = match sub.as_str() {
+        "CREATE" => {
+            if args.len() < 4 {
+                return Err(RustyAntError::WrongArity { command: "XGROUP CREATE".into() });
+            }
+            let group = arg_as_string(&args[2])?;
+            let start_id = GroupStartId::parse(arg_as_str(&args[3])?)?;
+            let mut mkstream = false;
+            // Optional MKSTREAM and ENTRIESREAD trailing tokens.
+            let mut i = 4;
+            while i < args.len() {
+                let tok = arg_as_str(&args[i])?.to_ascii_uppercase();
+                match tok.as_str() {
+                    "MKSTREAM" => {
+                        mkstream = true;
+                        i += 1;
+                    }
+                    "ENTRIESREAD" => {
+                        // Accept and ignore — Redis 7 optimisation hint.
+                        if i + 1 >= args.len() {
+                            return Err(RustyAntError::Parse("syntax error".into()));
+                        }
+                        let _ = parse_i64(&args[i + 1], "ENTRIESREAD")?;
+                        i += 2;
+                    }
+                    _ => return Err(RustyAntError::Parse("syntax error".into())),
+                }
+            }
+            XGroupOp::Create { group, start_id, mkstream }
+        }
+        "SETID" => {
+            if args.len() < 4 {
+                return Err(RustyAntError::WrongArity { command: "XGROUP SETID".into() });
+            }
+            XGroupOp::SetId { group: arg_as_string(&args[2])?, start_id: GroupStartId::parse(arg_as_str(&args[3])?)? }
+        }
+        "DESTROY" => {
+            if args.len() != 3 {
+                return Err(RustyAntError::WrongArity { command: "XGROUP DESTROY".into() });
+            }
+            XGroupOp::Destroy { group: arg_as_string(&args[2])? }
+        }
+        "CREATECONSUMER" => {
+            if args.len() != 4 {
+                return Err(RustyAntError::WrongArity { command: "XGROUP CREATECONSUMER".into() });
+            }
+            XGroupOp::CreateConsumer { group: arg_as_string(&args[2])?, consumer: arg_as_string(&args[3])? }
+        }
+        "DELCONSUMER" => {
+            if args.len() != 4 {
+                return Err(RustyAntError::WrongArity { command: "XGROUP DELCONSUMER".into() });
+            }
+            XGroupOp::DelConsumer { group: arg_as_string(&args[2])?, consumer: arg_as_string(&args[3])? }
+        }
+        "HELP" => {
+            return Ok(RespReply::Array(vec![RespReply::BulkString(Some(Bytes::from_static(
+                b"XGROUP CREATE | SETID | DESTROY | CREATECONSUMER | DELCONSUMER",
+            )))]));
+        }
+        other => return Err(RustyAntError::Parse(format!("unsupported XGROUP subcommand: {other}"))),
+    };
+    let n = state.storage.xgroup(key, op).await?;
+    // CREATE / SETID return +OK; DELCONSUMER returns the pending count;
+    // others return :0 / :1.
+    match sub.as_str() {
+        "CREATE" | "SETID" => Ok(RespReply::ok()),
+        _ => Ok(RespReply::Integer(n)),
+    }
+}
+
+/// Redis `XREADGROUP GROUP <group> <consumer> [COUNT n] [BLOCK ms] [NOACK] STREAMS keys ids`.
+async fn handle_xreadgroup(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    if args.len() < 6 {
+        return Err(RustyAntError::WrongArity { command: "XREADGROUP".into() });
+    }
+    if !arg_as_str(&args[0])?.eq_ignore_ascii_case("GROUP") {
+        return Err(RustyAntError::Parse("syntax error".into()));
+    }
+    let group = arg_as_string(&args[1])?;
+    let consumer = arg_as_string(&args[2])?;
+    let mut i = 3;
+    let mut count: Option<usize> = None;
+    let mut noack = false;
+    loop {
+        let tok = arg_as_str(&args[i])?.to_ascii_uppercase();
+        match tok.as_str() {
+            "COUNT" => {
+                if i + 1 >= args.len() {
+                    return Err(RustyAntError::Parse("syntax error".into()));
+                }
+                let n = parse_i64(&args[i + 1], "COUNT")?;
+                if n < 0 {
+                    return Err(RustyAntError::Parse("COUNT must be non-negative".into()));
+                }
+                count = Some(usize::try_from(n).unwrap_or(0));
+                i += 2;
+            }
+            "BLOCK" => {
+                if i + 1 >= args.len() {
+                    return Err(RustyAntError::Parse("syntax error".into()));
+                }
+                let _ = parse_i64(&args[i + 1], "BLOCK")?;
+                i += 2;
+            }
+            "NOACK" => {
+                noack = true;
+                i += 1;
+            }
+            "STREAMS" => {
+                i += 1;
+                break;
+            }
+            _ => return Err(RustyAntError::Parse("syntax error".into())),
+        }
+    }
+    let remaining = args.len() - i;
+    if remaining == 0 || remaining % 2 != 0 {
+        return Err(RustyAntError::Parse(
+            "Unbalanced XREADGROUP list of streams: for each stream key an ID or '>' must be specified.".into(),
+        ));
+    }
+    let half = remaining / 2;
+    let keys: Vec<String> = (i..i + half).map(|idx| arg_as_string(&args[idx])).collect::<Result<_, _>>()?;
+    let ids: Vec<XReadGroupId> =
+        (i + half..i + remaining).map(|idx| XReadGroupId::parse(arg_as_str(&args[idx])?)).collect::<Result<_, _>>()?;
+    let now = now_ms();
+    let per_stream = state.storage.xreadgroup(&group, &consumer, &keys, &ids, count, noack, now).await?;
+    if per_stream.is_empty() {
+        return Ok(RespReply::Nil);
+    }
+    Ok(RespReply::Array(
+        per_stream
+            .into_iter()
+            .map(|(key, entries)| {
+                RespReply::Array(vec![
+                    RespReply::BulkString(Some(Bytes::from(key.into_bytes()))),
+                    RespReply::Array(entries.into_iter().map(entry_to_reply).collect()),
+                ])
+            })
+            .collect(),
+    ))
+}
+
+/// Redis `XACK key group id [id ...]`.
+async fn handle_xack(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    if args.len() < 3 {
+        return Err(RustyAntError::WrongArity { command: "XACK".into() });
+    }
+    let key = arg_as_str(&args[0])?;
+    let group = arg_as_str(&args[1])?;
+    let ids: Vec<StreamId> = args.iter().skip(2).map(|a| StreamId::parse(arg_as_str(a)?)).collect::<Result<_, _>>()?;
+    Ok(RespReply::Integer(state.storage.xack(key, group, &ids).await?))
+}
+
+/// Redis `XCLAIM key group consumer min-idle-time id [id ...] [IDLE ms] [TIME ms] [RETRYCOUNT n] [FORCE] [JUSTID]`.
+async fn handle_xclaim(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    if args.len() < 5 {
+        return Err(RustyAntError::WrongArity { command: "XCLAIM".into() });
+    }
+    let key = arg_as_str(&args[0])?;
+    let group = arg_as_str(&args[1])?;
+    let consumer = arg_as_str(&args[2])?;
+    let min_idle = parse_i64(&args[3], "min-idle-time")?;
+
+    // Walk ids until we hit an option keyword.
+    let mut ids: Vec<StreamId> = Vec::new();
+    let mut i = 4;
+    while i < args.len() {
+        let tok = arg_as_str(&args[i])?;
+        let upper = tok.to_ascii_uppercase();
+        if matches!(upper.as_str(), "IDLE" | "TIME" | "RETRYCOUNT" | "FORCE" | "JUSTID") {
+            break;
+        }
+        ids.push(StreamId::parse(tok)?);
+        i += 1;
+    }
+    let mut opts = XClaimOpts { now_ms: now_ms(), ..XClaimOpts::default() };
+    while i < args.len() {
+        let tok = arg_as_str(&args[i])?.to_ascii_uppercase();
+        match tok.as_str() {
+            "IDLE" => {
+                if i + 1 >= args.len() {
+                    return Err(RustyAntError::Parse("syntax error".into()));
+                }
+                opts.idle_ms = Some(parse_i64(&args[i + 1], "IDLE")?);
+                i += 2;
+            }
+            "TIME" => {
+                if i + 1 >= args.len() {
+                    return Err(RustyAntError::Parse("syntax error".into()));
+                }
+                opts.time_ms = Some(parse_i64(&args[i + 1], "TIME")?);
+                i += 2;
+            }
+            "RETRYCOUNT" => {
+                if i + 1 >= args.len() {
+                    return Err(RustyAntError::Parse("syntax error".into()));
+                }
+                let n = parse_i64(&args[i + 1], "RETRYCOUNT")?;
+                if n < 0 {
+                    return Err(RustyAntError::Parse("RETRYCOUNT must be non-negative".into()));
+                }
+                opts.retry_count = Some(u64::try_from(n).unwrap_or(0));
+                i += 2;
+            }
+            "FORCE" => {
+                opts.force = true;
+                i += 1;
+            }
+            "JUSTID" => {
+                opts.just_id = true;
+                i += 1;
+            }
+            _ => return Err(RustyAntError::Parse("syntax error".into())),
+        }
+    }
+
+    let claimed = state.storage.xclaim(key, group, consumer, min_idle, &ids, opts).await?;
+    Ok(RespReply::Array(claimed.into_iter().map(claim_result_to_reply).collect()))
+}
+
+fn claim_result_to_reply(result: XClaimResult) -> RespReply {
+    match result.fields {
+        Some(fields) => {
+            let mut fields_arr = Vec::with_capacity(fields.len() * 2);
+            for (f, v) in fields {
+                fields_arr.push(RespReply::BulkString(Some(Bytes::from(f.into_bytes()))));
+                fields_arr.push(RespReply::BulkString(Some(Bytes::from(v))));
+            }
+            RespReply::Array(vec![stream_id_bulk(result.id), RespReply::Array(fields_arr)])
+        }
+        None => stream_id_bulk(result.id),
+    }
+}
+
+/// Redis `XPENDING key group [[IDLE ms] start end count [consumer]]`.
+async fn handle_xpending(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    if args.len() < 2 {
+        return Err(RustyAntError::WrongArity { command: "XPENDING".into() });
+    }
+    let key = arg_as_str(&args[0])?;
+    let group = arg_as_str(&args[1])?;
+    if args.len() == 2 {
+        // Summary form.
+        let summary = state.storage.xpending_summary(key, group).await?;
+        let Some(s) = summary else {
+            return Ok(RespReply::Array(vec![RespReply::Integer(0), RespReply::Nil, RespReply::Nil, RespReply::Nil]));
+        };
+        let consumers_arr: Vec<RespReply> = s
+            .per_consumer
+            .into_iter()
+            .map(|(c, n)| {
+                RespReply::Array(vec![
+                    RespReply::BulkString(Some(Bytes::from(c.into_bytes()))),
+                    RespReply::BulkString(Some(Bytes::from(n.to_string().into_bytes()))),
+                ])
+            })
+            .collect();
+        return Ok(RespReply::Array(vec![
+            RespReply::Integer(i64::try_from(s.count).unwrap_or(i64::MAX)),
+            stream_id_bulk(s.min),
+            stream_id_bulk(s.max),
+            RespReply::Array(consumers_arr),
+        ]));
+    }
+    // Detail form: [IDLE ms] start end count [consumer]
+    let mut i = 2;
+    let mut idle_ms: Option<i64> = None;
+    if arg_as_str(&args[i])?.eq_ignore_ascii_case("IDLE") {
+        if i + 1 >= args.len() {
+            return Err(RustyAntError::Parse("syntax error".into()));
+        }
+        idle_ms = Some(parse_i64(&args[i + 1], "IDLE")?);
+        i += 2;
+    }
+    if i + 3 > args.len() {
+        return Err(RustyAntError::Parse("syntax error".into()));
+    }
+    let start = RangeId::parse(arg_as_str(&args[i])?)?;
+    let end = RangeId::parse(arg_as_str(&args[i + 1])?)?;
+    let count_n = parse_i64(&args[i + 2], "count")?;
+    if count_n < 0 {
+        return Err(RustyAntError::Parse("count must be non-negative".into()));
+    }
+    let count = usize::try_from(count_n).unwrap_or(0);
+    i += 3;
+    let consumer = if i < args.len() { Some(arg_as_str(&args[i])?) } else { None };
+    let now = now_ms();
+    let rows = state.storage.xpending_detail(key, group, start, end, count, consumer, idle_ms, now).await?;
+    Ok(RespReply::Array(
+        rows.into_iter()
+            .map(|r| {
+                RespReply::Array(vec![
+                    stream_id_bulk(r.id),
+                    RespReply::BulkString(Some(Bytes::from(r.consumer.into_bytes()))),
+                    RespReply::Integer(r.idle_ms),
+                    RespReply::Integer(i64::try_from(r.delivery_count).unwrap_or(i64::MAX)),
+                ])
+            })
+            .collect(),
+    ))
+}
+
+/// Redis `XAUTOCLAIM key group consumer min-idle-time start [COUNT n] [JUSTID]`.
+async fn handle_xautoclaim(state: &State, args: Vec<Bytes>) -> Result<RespReply, RustyAntError> {
+    if args.len() < 5 {
+        return Err(RustyAntError::WrongArity { command: "XAUTOCLAIM".into() });
+    }
+    let key = arg_as_str(&args[0])?;
+    let group = arg_as_str(&args[1])?;
+    let consumer = arg_as_str(&args[2])?;
+    let min_idle = parse_i64(&args[3], "min-idle-time")?;
+    let start = StreamId::parse(arg_as_str(&args[4])?)?;
+    let mut count: usize = 100;
+    let mut just_id = false;
+    let mut i = 5;
+    while i < args.len() {
+        let tok = arg_as_str(&args[i])?.to_ascii_uppercase();
+        match tok.as_str() {
+            "COUNT" => {
+                if i + 1 >= args.len() {
+                    return Err(RustyAntError::Parse("syntax error".into()));
+                }
+                let n = parse_i64(&args[i + 1], "COUNT")?;
+                if n < 0 {
+                    return Err(RustyAntError::Parse("COUNT must be non-negative".into()));
+                }
+                count = usize::try_from(n).unwrap_or(0);
+                i += 2;
+            }
+            "JUSTID" => {
+                just_id = true;
+                i += 1;
+            }
+            _ => return Err(RustyAntError::Parse("syntax error".into())),
+        }
+    }
+    let now = now_ms();
+    let result = state.storage.xautoclaim(key, group, consumer, min_idle, start, count, just_id, now).await?;
+    Ok(RespReply::Array(vec![
+        stream_id_bulk(result.next_cursor),
+        RespReply::Array(result.claimed.into_iter().map(claim_result_to_reply).collect()),
+        RespReply::Array(result.deleted_ids.into_iter().map(stream_id_bulk).collect()),
+    ]))
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -9,7 +9,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::RustyAntError;
 use crate::hll;
-use crate::stream::{AddIdSpec, RangeId, StreamEntry, StreamId, StreamValue, TrimBound, resolve_add_id, trim_in_place};
+use crate::stream::{
+    AddIdSpec, ConsumerGroup, GroupStartId, PendingEntry, RangeId, StreamEntry, StreamId, StreamValue, TrimBound,
+    XAutoClaimResult, XClaimOpts, XClaimResult, XGroupOp, XInfoConsumer, XInfoGroup, XPendingDetailRow,
+    XPendingSummary, XReadGroupId, resolve_add_id, trim_in_place,
+};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct StoredValue {
@@ -219,6 +223,67 @@ fn asc_rank_of(map: &BTreeMap<String, f64>, member: &str) -> Option<i64> {
 
 fn wrong_type(key: &str) -> RustyAntError {
     RustyAntError::WrongType { key: key.to_string() }
+}
+
+/// Variant of `wrong_type` for use inside CAS closures where the `key`
+/// borrow doesn't reach. Reports as a generic WRONGTYPE error.
+const fn wrong_type_error() -> RustyAntError {
+    RustyAntError::WrongType { key: String::new() }
+}
+
+/// Group does not exist on this stream — Redis's exact wording.
+fn no_group_error(group: &str) -> RustyAntError {
+    RustyAntError::Parse(format!("NOGROUP No such consumer group '{group}' for key name. The group does not exist."))
+}
+
+/// Apply an `XGroupOp` to the stream value in-place. Returns the integer
+/// reply value the caller should propagate (Redis: `:1` / `:0` for most
+/// subcommands; the count of pending entries owned by a deleted consumer
+/// for `DELCONSUMER`).
+fn apply_xgroup_op(stream: &mut StreamValue, op: &XGroupOp, existed: bool) -> Result<i64, RustyAntError> {
+    match op {
+        XGroupOp::Create { group, start_id, mkstream } => {
+            if !existed && !*mkstream {
+                return Err(RustyAntError::Parse(
+                    "ERR The XGROUP subcommand requires the key to exist. Note that for CREATE you may want to use the MKSTREAM option to create an empty stream automatically.".into(),
+                ));
+            }
+            if stream.groups.contains_key(group) {
+                return Err(RustyAntError::Parse("BUSYGROUP Consumer Group name already exists".into()));
+            }
+            let last_delivered_id = match start_id {
+                GroupStartId::Concrete(id) => *id,
+                GroupStartId::Latest => stream.last_generated_id,
+            };
+            stream.groups.insert(group.clone(), ConsumerGroup { last_delivered_id, ..ConsumerGroup::default() });
+            Ok(1)
+        }
+        XGroupOp::SetId { group, start_id } => {
+            let g = stream.groups.get_mut(group).ok_or_else(|| no_group_error(group))?;
+            g.last_delivered_id = match start_id {
+                GroupStartId::Concrete(id) => *id,
+                GroupStartId::Latest => stream.last_generated_id,
+            };
+            Ok(1)
+        }
+        XGroupOp::Destroy { group } => Ok(i64::from(stream.groups.remove(group).is_some())),
+        XGroupOp::CreateConsumer { group, consumer } => {
+            let g = stream.groups.get_mut(group).ok_or_else(|| no_group_error(group))?;
+            if g.consumers.contains_key(consumer) {
+                return Ok(0);
+            }
+            g.consumers.insert(consumer.clone(), crate::stream::Consumer::default());
+            Ok(1)
+        }
+        XGroupOp::DelConsumer { group, consumer } => {
+            let g = stream.groups.get_mut(group).ok_or_else(|| no_group_error(group))?;
+            g.consumers.remove(consumer);
+            let pending_owned =
+                i64::try_from(g.pel.values().filter(|p| p.consumer == *consumer).count()).unwrap_or(i64::MAX);
+            g.pel.retain(|_, p| p.consumer != *consumer);
+            Ok(pending_owned)
+        }
+    }
 }
 
 /// Redis `TYPE` reply tag for a stored value.
@@ -666,6 +731,7 @@ async fn cas_backoff(attempt: u32) {
 // ---------------------------------------------------------------------------
 
 #[async_trait]
+#[allow(clippy::too_many_arguments)] // xclaim / xreadgroup / xautoclaim mirror Redis's option surface
 pub trait Storage: Send + Sync + std::fmt::Debug {
     async fn delete(&self, key: &str) -> Result<bool, RustyAntError>;
     async fn exists(&self, key: &str) -> Result<bool, RustyAntError>;
@@ -968,6 +1034,89 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
 
     /// Redis `XINFO STREAM key`: headline summary of the stream.
     async fn xinfo_stream(&self, key: &str) -> Result<Option<StreamValue>, RustyAntError>;
+
+    /// Redis `XGROUP CREATE / SETID / DESTROY / CREATECONSUMER / DELCONSUMER`.
+    /// `op` chooses which subcommand to apply; `mkstream` is honored only
+    /// for `Create`. Returns a generic int payload (created? / destroyed?
+    /// / consumer-deleted-pending-count / etc.) — the handler interprets it.
+    async fn xgroup(&self, key: &str, op: XGroupOp) -> Result<i64, RustyAntError>;
+
+    /// Redis `XREADGROUP GROUP <group> <consumer> [COUNT n] [NOACK] STREAMS keys ids`.
+    /// `>` ids fetch new entries (advance the group's `last_delivered_id`
+    /// and add to the PEL unless `noack`); explicit ids re-read from the
+    /// PEL filtering by `consumer`.
+    async fn xreadgroup(
+        &self,
+        group: &str,
+        consumer: &str,
+        keys: &[String],
+        ids: &[XReadGroupId],
+        count: Option<usize>,
+        noack: bool,
+        now_ms_override: i64,
+    ) -> Result<Vec<(String, Vec<StreamEntry>)>, RustyAntError>;
+
+    /// Redis `XACK key group id [id ...]`. Removes acknowledged entries
+    /// from the group's PEL; returns the count actually removed.
+    async fn xack(&self, key: &str, group: &str, ids: &[StreamId]) -> Result<i64, RustyAntError>;
+
+    /// Redis `XCLAIM`. Reassigns ownership of pending entries to
+    /// `consumer` if they have been idle for at least `min_idle_ms`.
+    /// `force` adds entries to the PEL even when not previously pending.
+    /// Returns the entries that were claimed (or just their ids when
+    /// `just_id` is set).
+    #[allow(clippy::too_many_arguments)]
+    async fn xclaim(
+        &self,
+        key: &str,
+        group: &str,
+        consumer: &str,
+        min_idle_ms: i64,
+        ids: &[StreamId],
+        opts: XClaimOpts,
+    ) -> Result<Vec<XClaimResult>, RustyAntError>;
+
+    /// Redis `XPENDING key group` — summary form. Returns `(count, min_id,
+    /// max_id, per_consumer_counts)` for the group's PEL.
+    async fn xpending_summary(&self, key: &str, group: &str) -> Result<Option<XPendingSummary>, RustyAntError>;
+
+    /// Redis `XPENDING key group [IDLE ms] start end count [consumer]`.
+    /// Detail form — returns matching PEL rows.
+    async fn xpending_detail(
+        &self,
+        key: &str,
+        group: &str,
+        start: RangeId,
+        end: RangeId,
+        count: usize,
+        consumer: Option<&str>,
+        idle_ms: Option<i64>,
+        now_ms_override: i64,
+    ) -> Result<Vec<XPendingDetailRow>, RustyAntError>;
+
+    /// Redis `XAUTOCLAIM`. Sweeps PEL entries idle ≥ `min_idle_ms` and
+    /// reassigns up to `count` of them to `consumer`. Returns the cursor
+    /// (id to resume from on the next call), the entries claimed (or
+    /// just their ids if `just_id`), and any ids that were dropped
+    /// because they no longer exist in the stream.
+    #[allow(clippy::too_many_arguments)]
+    async fn xautoclaim(
+        &self,
+        key: &str,
+        group: &str,
+        consumer: &str,
+        min_idle_ms: i64,
+        start: StreamId,
+        count: usize,
+        just_id: bool,
+        now_ms_override: i64,
+    ) -> Result<XAutoClaimResult, RustyAntError>;
+
+    /// Redis `XINFO GROUPS key`: per-group summary.
+    async fn xinfo_groups(&self, key: &str) -> Result<Vec<XInfoGroup>, RustyAntError>;
+
+    /// Redis `XINFO CONSUMERS key group`: per-consumer summary.
+    async fn xinfo_consumers(&self, key: &str, group: &str) -> Result<Vec<XInfoConsumer>, RustyAntError>;
 
     /// Return every key matching `pattern` (Redis-style glob: `*`, `?`).
     /// On S3 this fans out to repeated `ListObjectsV2` calls until the
@@ -2085,6 +2234,354 @@ impl Storage for S3Storage {
             Some(_) => Err(wrong_type(key)),
             None => Ok(None),
         }
+    }
+
+    async fn xgroup(&self, key: &str, op: XGroupOp) -> Result<i64, RustyAntError> {
+        self.cas(key, move |entry| {
+            let (mut stream, expires_at_ms, existed) = match entry {
+                Some(StoredValue { value: Value::Stream(s), expires_at_ms }) => (s.clone(), *expires_at_ms, true),
+                Some(_) => return Err(wrong_type(key)),
+                None => (StreamValue::default(), None, false),
+            };
+            let result = apply_xgroup_op(&mut stream, &op, existed)?;
+            // CREATE / SETID / DESTROY / etc. all imply a write. CREATE
+            // without MKSTREAM on a missing key is the one path that
+            // bails out early via the helper.
+            let new_entry = StoredValue { expires_at_ms, value: Value::Stream(stream) };
+            Ok(CasAction::Write(new_entry, result))
+        })
+        .await
+    }
+
+    async fn xreadgroup(
+        &self,
+        group: &str,
+        consumer: &str,
+        keys: &[String],
+        ids: &[XReadGroupId],
+        count: Option<usize>,
+        noack: bool,
+        now_ms_override: i64,
+    ) -> Result<Vec<(String, Vec<StreamEntry>)>, RustyAntError> {
+        let mut out: Vec<(String, Vec<StreamEntry>)> = Vec::new();
+        for (key, id_spec) in keys.iter().zip(ids.iter()) {
+            let group = group.to_string();
+            let consumer = consumer.to_string();
+            let id_spec = *id_spec;
+            let entries: Vec<StreamEntry> = self
+                .cas(key, move |entry| {
+                    let (mut stream, expires_at_ms) = match entry {
+                        Some(StoredValue { value: Value::Stream(s), expires_at_ms }) => (s.clone(), *expires_at_ms),
+                        Some(_) => return Err(wrong_type_error()),
+                        None => return Err(no_group_error(&group)),
+                    };
+                    let g = stream.groups.get_mut(&group).ok_or_else(|| no_group_error(&group))?;
+                    let mut delivered: Vec<StreamEntry> = match id_spec {
+                        XReadGroupId::NewEntries => {
+                            let last = g.last_delivered_id;
+                            let mut newish: Vec<StreamEntry> =
+                                stream.entries.iter().filter(|e| e.id > last).cloned().collect();
+                            if let Some(cap) = count {
+                                newish.truncate(cap);
+                            }
+                            // Replay through the PEL bookkeeping.
+                            for entry in &newish {
+                                if !noack {
+                                    g.pel.insert(
+                                        entry.id,
+                                        PendingEntry {
+                                            consumer: consumer.clone(),
+                                            delivery_time_ms: now_ms_override,
+                                            delivery_count: 1,
+                                        },
+                                    );
+                                }
+                                if entry.id > g.last_delivered_id {
+                                    g.last_delivered_id = entry.id;
+                                }
+                            }
+                            g.consumers.entry(consumer.clone()).or_default().seen_ms = now_ms_override;
+                            newish
+                        }
+                        XReadGroupId::Pending(after) => {
+                            // Re-read PEL rows owned by this consumer that are > after.
+                            let mut rows: Vec<StreamId> = g
+                                .pel
+                                .iter()
+                                .filter(|(id, p)| **id > after && p.consumer == consumer)
+                                .map(|(id, _)| *id)
+                                .collect();
+                            if let Some(cap) = count {
+                                rows.truncate(cap);
+                            }
+                            // Bump delivery_count for each re-delivery.
+                            for id in &rows {
+                                if let Some(p) = g.pel.get_mut(id) {
+                                    p.delivery_count = p.delivery_count.saturating_add(1);
+                                    p.delivery_time_ms = now_ms_override;
+                                }
+                            }
+                            // Materialize the entries; drop ones that have
+                            // since been XDELed from the stream.
+                            rows.iter()
+                                .filter_map(|id| stream.entries.iter().find(|e| e.id == *id).cloned())
+                                .collect::<Vec<_>>()
+                        }
+                    };
+                    delivered.sort_by_key(|e| e.id);
+                    let new_entry = StoredValue { expires_at_ms, value: Value::Stream(stream) };
+                    Ok(CasAction::Write(new_entry, delivered))
+                })
+                .await?;
+            if !entries.is_empty() {
+                out.push((key.clone(), entries));
+            }
+        }
+        Ok(out)
+    }
+
+    async fn xack(&self, key: &str, group: &str, ids: &[StreamId]) -> Result<i64, RustyAntError> {
+        let group = group.to_string();
+        let ids = ids.to_vec();
+        self.cas(key, move |entry| {
+            let (mut stream, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::Stream(s), expires_at_ms }) => (s.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => return Ok(CasAction::NoOp(0)),
+            };
+            let Some(g) = stream.groups.get_mut(&group) else {
+                return Ok(CasAction::NoOp(0));
+            };
+            let mut acked: i64 = 0;
+            for id in &ids {
+                if g.pel.remove(id).is_some() {
+                    acked += 1;
+                }
+            }
+            if acked == 0 {
+                return Ok(CasAction::NoOp(0));
+            }
+            let new_entry = StoredValue { expires_at_ms, value: Value::Stream(stream) };
+            Ok(CasAction::Write(new_entry, acked))
+        })
+        .await
+    }
+
+    async fn xclaim(
+        &self,
+        key: &str,
+        group: &str,
+        consumer: &str,
+        min_idle_ms: i64,
+        ids: &[StreamId],
+        opts: XClaimOpts,
+    ) -> Result<Vec<XClaimResult>, RustyAntError> {
+        let group = group.to_string();
+        let consumer = consumer.to_string();
+        let ids = ids.to_vec();
+        self.cas(key, move |entry| {
+            let (mut stream, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::Stream(s), expires_at_ms }) => (s.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => return Err(no_group_error(&group)),
+            };
+            let g = stream.groups.get_mut(&group).ok_or_else(|| no_group_error(&group))?;
+            let new_delivery_time = opts.time_ms.unwrap_or_else(|| opts.now_ms - opts.idle_ms.unwrap_or(0));
+            let mut claimed: Vec<XClaimResult> = Vec::with_capacity(ids.len());
+            for id in &ids {
+                let existed_in_pel = g.pel.contains_key(id);
+                if !existed_in_pel && !opts.force {
+                    continue;
+                }
+                let entry_idle_ok =
+                    g.pel.get(id).is_none_or(|p| (opts.now_ms - p.delivery_time_ms).max(0) >= min_idle_ms);
+                if !entry_idle_ok {
+                    continue;
+                }
+                let new_count = match (g.pel.get(id), opts.retry_count) {
+                    (_, Some(rc)) => rc,
+                    (Some(p), None) => p.delivery_count.saturating_add(1),
+                    (None, None) => 1,
+                };
+                g.pel.insert(
+                    *id,
+                    PendingEntry {
+                        consumer: consumer.clone(),
+                        delivery_time_ms: new_delivery_time,
+                        delivery_count: new_count,
+                    },
+                );
+                g.consumers.entry(consumer.clone()).or_default().seen_ms = opts.now_ms;
+                let body = if opts.just_id {
+                    None
+                } else {
+                    stream.entries.iter().find(|e| e.id == *id).map(|e| e.fields.clone())
+                };
+                claimed.push(XClaimResult { id: *id, fields: body });
+            }
+            let new_entry = StoredValue { expires_at_ms, value: Value::Stream(stream) };
+            Ok(CasAction::Write(new_entry, claimed))
+        })
+        .await
+    }
+
+    async fn xpending_summary(&self, key: &str, group: &str) -> Result<Option<XPendingSummary>, RustyAntError> {
+        let stream = match self.load(key).await? {
+            Some(StoredValue { value: Value::Stream(s), .. }) => s,
+            Some(_) => return Err(wrong_type(key)),
+            None => return Err(no_group_error(group)),
+        };
+        let g = stream.groups.get(group).ok_or_else(|| no_group_error(group))?;
+        if g.pel.is_empty() {
+            return Ok(None);
+        }
+        let mut per_consumer: BTreeMap<String, u64> = BTreeMap::new();
+        for p in g.pel.values() {
+            *per_consumer.entry(p.consumer.clone()).or_insert(0) += 1;
+        }
+        let min = *g.pel.keys().next().expect("non-empty");
+        let max = *g.pel.keys().next_back().expect("non-empty");
+        Ok(Some(XPendingSummary {
+            count: g.pel.len() as u64,
+            min,
+            max,
+            per_consumer: per_consumer.into_iter().collect(),
+        }))
+    }
+
+    async fn xpending_detail(
+        &self,
+        key: &str,
+        group: &str,
+        start: RangeId,
+        end: RangeId,
+        count: usize,
+        consumer: Option<&str>,
+        idle_ms: Option<i64>,
+        now_ms_override: i64,
+    ) -> Result<Vec<XPendingDetailRow>, RustyAntError> {
+        let stream = match self.load(key).await? {
+            Some(StoredValue { value: Value::Stream(s), .. }) => s,
+            Some(_) => return Err(wrong_type(key)),
+            None => return Err(no_group_error(group)),
+        };
+        let g = stream.groups.get(group).ok_or_else(|| no_group_error(group))?;
+        let mut rows: Vec<XPendingDetailRow> = Vec::new();
+        for (id, p) in &g.pel {
+            if !start.ge_min(*id) || !end.le_max(*id) {
+                continue;
+            }
+            if let Some(c) = consumer {
+                if p.consumer != c {
+                    continue;
+                }
+            }
+            let idle = (now_ms_override - p.delivery_time_ms).max(0);
+            if let Some(min_idle) = idle_ms {
+                if idle < min_idle {
+                    continue;
+                }
+            }
+            rows.push(XPendingDetailRow {
+                id: *id,
+                consumer: p.consumer.clone(),
+                idle_ms: idle,
+                delivery_count: p.delivery_count,
+            });
+            if rows.len() >= count {
+                break;
+            }
+        }
+        Ok(rows)
+    }
+
+    async fn xautoclaim(
+        &self,
+        key: &str,
+        group: &str,
+        consumer: &str,
+        min_idle_ms: i64,
+        start: StreamId,
+        count: usize,
+        just_id: bool,
+        now_ms_override: i64,
+    ) -> Result<XAutoClaimResult, RustyAntError> {
+        let group = group.to_string();
+        let consumer = consumer.to_string();
+        self.cas(key, move |entry| {
+            let (mut stream, expires_at_ms) = match entry {
+                Some(StoredValue { value: Value::Stream(s), expires_at_ms }) => (s.clone(), *expires_at_ms),
+                Some(_) => return Err(wrong_type(key)),
+                None => return Err(no_group_error(&group)),
+            };
+            let g = stream.groups.get_mut(&group).ok_or_else(|| no_group_error(&group))?;
+            let mut claimed: Vec<XClaimResult> = Vec::new();
+            let mut deleted: Vec<StreamId> = Vec::new();
+            let mut next_cursor = StreamId::MIN;
+            let candidates: Vec<StreamId> = g
+                .pel
+                .range(start..)
+                .filter(|(_, p)| (now_ms_override - p.delivery_time_ms).max(0) >= min_idle_ms)
+                .map(|(id, _)| *id)
+                .collect();
+            for id in candidates {
+                if claimed.len() >= count {
+                    next_cursor = id;
+                    break;
+                }
+                if !stream.entries.iter().any(|e| e.id == id) {
+                    g.pel.remove(&id);
+                    deleted.push(id);
+                    continue;
+                }
+                if let Some(p) = g.pel.get_mut(&id) {
+                    p.consumer.clone_from(&consumer);
+                    p.delivery_time_ms = now_ms_override;
+                    p.delivery_count = p.delivery_count.saturating_add(1);
+                }
+                let body =
+                    if just_id { None } else { stream.entries.iter().find(|e| e.id == id).map(|e| e.fields.clone()) };
+                claimed.push(XClaimResult { id, fields: body });
+            }
+            g.consumers.entry(consumer.clone()).or_default().seen_ms = now_ms_override;
+            let new_entry = StoredValue { expires_at_ms, value: Value::Stream(stream) };
+            Ok(CasAction::Write(new_entry, XAutoClaimResult { next_cursor, claimed, deleted_ids: deleted }))
+        })
+        .await
+    }
+
+    async fn xinfo_groups(&self, key: &str) -> Result<Vec<XInfoGroup>, RustyAntError> {
+        match self.load(key).await? {
+            Some(StoredValue { value: Value::Stream(s), .. }) => Ok(s
+                .groups
+                .into_iter()
+                .map(|(name, g)| XInfoGroup {
+                    name,
+                    consumers: g.consumers.len() as u64,
+                    pending: g.pel.len() as u64,
+                    last_delivered_id: g.last_delivered_id,
+                })
+                .collect()),
+            Some(_) => Err(wrong_type(key)),
+            None => Ok(Vec::new()),
+        }
+    }
+
+    async fn xinfo_consumers(&self, key: &str, group: &str) -> Result<Vec<XInfoConsumer>, RustyAntError> {
+        let stream = match self.load(key).await? {
+            Some(StoredValue { value: Value::Stream(s), .. }) => s,
+            Some(_) => return Err(wrong_type(key)),
+            None => return Err(no_group_error(group)),
+        };
+        let g = stream.groups.get(group).ok_or_else(|| no_group_error(group))?;
+        let now = now_ms();
+        Ok(g.consumers
+            .iter()
+            .map(|(name, c)| {
+                let pending = g.pel.values().filter(|p| p.consumer == *name).count() as u64;
+                XInfoConsumer { name: name.clone(), pending, idle_ms: (now - c.seen_ms).max(0) }
+            })
+            .collect())
     }
 
     async fn getset(&self, key: &str, value: Bytes) -> Result<Option<Bytes>, RustyAntError> {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -10,6 +10,7 @@
 //! CAS loop in `S3Storage`.
 
 use std::cmp::Ordering;
+use std::collections::BTreeMap;
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
@@ -102,6 +103,186 @@ pub struct StreamValue {
     /// Total entries ever added (including those since trimmed / deleted).
     #[serde(default)]
     pub entries_added: u64,
+    /// Per-group state (consumers + pending entries list). Empty for
+    /// streams with no groups.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub groups: BTreeMap<String, ConsumerGroup>,
+}
+
+/// Per-group state.
+///
+/// `last_delivered_id` advances on every `XREADGROUP > ...` call. The
+/// `pel` (pending entries list) tracks entries that have been delivered
+/// but not yet `XACK`ed; each consumer additionally records when it
+/// last claimed an entry, used by `XCLAIM` / `XAUTOCLAIM` to find
+/// stalled work.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConsumerGroup {
+    pub last_delivered_id: StreamId,
+    /// Consumers known to this group, by name.
+    #[serde(default)]
+    pub consumers: BTreeMap<String, Consumer>,
+    /// Pending entries: id → (consumer, `delivery_time_ms`, `delivery_count`).
+    /// Serializes as a flat list of `[id, entry]` pairs so JSON can carry
+    /// it (object keys must be strings, but `StreamId` is a struct).
+    #[serde(default, with = "pel_serde")]
+    pub pel: BTreeMap<StreamId, PendingEntry>,
+}
+
+mod pel_serde {
+    use std::collections::BTreeMap;
+
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    use super::{PendingEntry, StreamId};
+
+    pub fn serialize<S: Serializer>(map: &BTreeMap<StreamId, PendingEntry>, s: S) -> Result<S::Ok, S::Error> {
+        let pairs: Vec<(StreamId, PendingEntry)> = map.iter().map(|(k, v)| (*k, v.clone())).collect();
+        pairs.serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<BTreeMap<StreamId, PendingEntry>, D::Error> {
+        let pairs: Vec<(StreamId, PendingEntry)> = Vec::deserialize(d)?;
+        Ok(pairs.into_iter().collect())
+    }
+}
+
+/// A single consumer within a group.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Consumer {
+    /// Wall-clock ms of the most recent delivery attributed to this consumer.
+    pub seen_ms: i64,
+}
+
+/// One row of the pending-entries list.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingEntry {
+    pub consumer: String,
+    pub delivery_time_ms: i64,
+    pub delivery_count: u64,
+}
+
+// ---------------------------------------------------------------------------
+// XGROUP — subcommand router payload, plus per-op metadata.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub enum XGroupOp {
+    /// Create a new group at `start_id` (Redis: `<id> | $`). `mkstream`
+    /// auto-creates the key as an empty stream when missing. `entries_read`
+    /// is a Redis 7+ optimization hint; rustyant accepts it but ignores.
+    Create { group: String, start_id: GroupStartId, mkstream: bool },
+    /// Reset the group's `last_delivered_id`.
+    SetId { group: String, start_id: GroupStartId },
+    /// Drop the group. Returns 1 if removed, 0 otherwise.
+    Destroy { group: String },
+    /// Force-add a consumer (returns 1 if created, 0 if it already existed).
+    CreateConsumer { group: String, consumer: String },
+    /// Remove a consumer; returns the number of pending entries that were
+    /// owned by it (matching Redis's reply).
+    DelConsumer { group: String, consumer: String },
+}
+
+/// `XGROUP CREATE` / `XGROUP SETID` accept either a concrete id or `$`,
+/// which means "the current `last_generated_id` of the stream".
+#[derive(Debug, Clone, Copy)]
+pub enum GroupStartId {
+    Concrete(StreamId),
+    Latest,
+}
+
+impl GroupStartId {
+    pub fn parse(s: &str) -> Result<Self, RustyAntError> {
+        if s == "$" { Ok(Self::Latest) } else { Ok(Self::Concrete(StreamId::parse(s)?)) }
+    }
+}
+
+/// Each `id` arg to `XREADGROUP` — `>` means "new entries", anything
+/// else is a concrete id from the PEL.
+#[derive(Debug, Clone, Copy)]
+pub enum XReadGroupId {
+    NewEntries,
+    Pending(StreamId),
+}
+
+impl XReadGroupId {
+    pub fn parse(s: &str) -> Result<Self, RustyAntError> {
+        if s == ">" { Ok(Self::NewEntries) } else { Ok(Self::Pending(StreamId::parse(s)?)) }
+    }
+}
+
+/// Options for `XCLAIM`.
+///
+/// `idle_ms` / `time_ms` override the default "set to current time"
+/// behavior; `retry_count` overrides the default "increment by 1".
+/// `force` adds the entry to the PEL even when not already pending.
+/// `just_id` returns just the ids, not full entries.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct XClaimOpts {
+    pub idle_ms: Option<i64>,
+    pub time_ms: Option<i64>,
+    pub retry_count: Option<u64>,
+    pub force: bool,
+    pub just_id: bool,
+    /// Wall-clock used when `idle_ms` and `time_ms` are unset — caller
+    /// supplies this so the storage layer doesn't need to read a clock.
+    pub now_ms: i64,
+}
+
+/// One entry returned by `XCLAIM`. Holds the full entry body unless
+/// `just_id` was requested in the call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct XClaimResult {
+    pub id: StreamId,
+    pub fields: Option<Vec<(String, Vec<u8>)>>,
+}
+
+/// `XPENDING <key> <group>` summary form.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct XPendingSummary {
+    pub count: u64,
+    pub min: StreamId,
+    pub max: StreamId,
+    /// (consumer, count) pairs for every consumer with at least one
+    /// pending entry.
+    pub per_consumer: Vec<(String, u64)>,
+}
+
+/// One row of the `XPENDING <key> <group> [...] start end count` form.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct XPendingDetailRow {
+    pub id: StreamId,
+    pub consumer: String,
+    pub idle_ms: i64,
+    pub delivery_count: u64,
+}
+
+/// Result tuple for `XAUTOCLAIM`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct XAutoClaimResult {
+    /// Next id to resume from (`0-0` when the sweep finished).
+    pub next_cursor: StreamId,
+    pub claimed: Vec<XClaimResult>,
+    /// Ids that were in the PEL but no longer in the stream (Redis 7
+    /// added this — XAUTOCLAIM "delete" ids).
+    pub deleted_ids: Vec<StreamId>,
+}
+
+/// `XINFO GROUPS` row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct XInfoGroup {
+    pub name: String,
+    pub consumers: u64,
+    pub pending: u64,
+    pub last_delivered_id: StreamId,
+}
+
+/// `XINFO CONSUMERS` row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct XInfoConsumer {
+    pub name: String,
+    pub pending: u64,
+    pub idle_ms: i64,
 }
 
 /// Parsed id argument for `XADD` — either auto (`*`), an auto-seq within

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -615,6 +615,200 @@ async fn type_of_stream_reports_stream() {
     call(&state, &[b"TYPE", b"s"]).await.expect_simple("stream");
 }
 
+// ---------------------------------------------------------------------------
+// Streams consumer groups — XGROUP / XREADGROUP / XACK / XCLAIM / XPENDING / XAUTOCLAIM
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn xgroup_create_requires_existing_stream_or_mkstream() {
+    let state = test_state();
+    // No stream + no MKSTREAM → error.
+    call(&state, &[b"XGROUP", b"CREATE", b"ghost", b"g", b"$"]).await.expect_error_prefix("ERR");
+    // Same with MKSTREAM → ok.
+    call(&state, &[b"XGROUP", b"CREATE", b"newstream", b"g", b"$", b"MKSTREAM"]).await.expect_simple("OK");
+    call(&state, &[b"TYPE", b"newstream"]).await.expect_simple("stream");
+    call(&state, &[b"XLEN", b"newstream"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn xgroup_create_dollar_starts_at_last_generated_id() {
+    let state = test_state();
+    call(&state, &[b"XADD", b"s", b"1-0", b"f", b"v"]).await;
+    call(&state, &[b"XADD", b"s", b"2-0", b"f", b"v"]).await;
+    call(&state, &[b"XGROUP", b"CREATE", b"s", b"g", b"$"]).await.expect_simple("OK");
+    // > delivery should yield 0 entries (group caught up to 2-0).
+    call(&state, &[b"XREADGROUP", b"GROUP", b"g", b"c1", b"STREAMS", b"s", b">"]).await.expect_nil();
+    // After XADD, > should deliver the new entry.
+    call(&state, &[b"XADD", b"s", b"3-0", b"f", b"v"]).await;
+    let reply = call(&state, &[b"XREADGROUP", b"GROUP", b"g", b"c1", b"STREAMS", b"s", b">"]).await;
+    let raw = String::from_utf8_lossy(&reply.raw).to_string();
+    assert!(raw.contains("3-0"), "expected new entry 3-0 in reply: {raw}");
+}
+
+#[tokio::test]
+async fn xgroup_create_busygroup_on_duplicate() {
+    let state = test_state();
+    call(&state, &[b"XADD", b"s", b"*", b"f", b"v"]).await;
+    call(&state, &[b"XGROUP", b"CREATE", b"s", b"g", b"$"]).await.expect_simple("OK");
+    call(&state, &[b"XGROUP", b"CREATE", b"s", b"g", b"$"]).await.expect_error_prefix("ERR");
+}
+
+#[tokio::test]
+async fn xgroup_destroy_removes_group() {
+    let state = test_state();
+    call(&state, &[b"XADD", b"s", b"*", b"f", b"v"]).await;
+    call(&state, &[b"XGROUP", b"CREATE", b"s", b"g", b"$"]).await.expect_simple("OK");
+    call(&state, &[b"XGROUP", b"DESTROY", b"s", b"g"]).await.expect_integer(1);
+    call(&state, &[b"XGROUP", b"DESTROY", b"s", b"g"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn xreadgroup_advances_last_delivered_id_and_creates_pel() {
+    let state = test_state();
+    call(&state, &[b"XADD", b"s", b"1-0", b"f", b"a"]).await;
+    call(&state, &[b"XADD", b"s", b"2-0", b"f", b"b"]).await;
+    call(&state, &[b"XGROUP", b"CREATE", b"s", b"g", b"0"]).await;
+    let reply = call(&state, &[b"XREADGROUP", b"GROUP", b"g", b"c1", b"COUNT", b"1", b"STREAMS", b"s", b">"]).await;
+    let raw = String::from_utf8_lossy(&reply.raw).to_string();
+    assert!(raw.contains("1-0"), "first delivery should be 1-0: {raw}");
+    // PEL should now have 1 entry.
+    call(&state, &[b"XPENDING", b"s", b"g"]).await; // for visibility
+}
+
+#[tokio::test]
+async fn xpending_summary_counts_pel() {
+    let state = test_state();
+    call(&state, &[b"XADD", b"s", b"1-0", b"f", b"a"]).await;
+    call(&state, &[b"XADD", b"s", b"2-0", b"f", b"b"]).await;
+    call(&state, &[b"XGROUP", b"CREATE", b"s", b"g", b"0"]).await;
+    call(&state, &[b"XREADGROUP", b"GROUP", b"g", b"c1", b"STREAMS", b"s", b">"]).await;
+    let reply = call(&state, &[b"XPENDING", b"s", b"g"]).await;
+    let raw = String::from_utf8_lossy(&reply.raw).to_string();
+    // Summary: [count, min_id, max_id, [[consumer, count]]]
+    assert!(raw.starts_with("*4\r\n:2\r\n"), "expected count 2: {raw}");
+    assert!(raw.contains("1-0"));
+    assert!(raw.contains("2-0"));
+    assert!(raw.contains("c1"));
+}
+
+#[tokio::test]
+async fn xack_removes_from_pel() {
+    let state = test_state();
+    call(&state, &[b"XADD", b"s", b"1-0", b"f", b"a"]).await;
+    call(&state, &[b"XGROUP", b"CREATE", b"s", b"g", b"0"]).await;
+    call(&state, &[b"XREADGROUP", b"GROUP", b"g", b"c1", b"STREAMS", b"s", b">"]).await;
+    call(&state, &[b"XACK", b"s", b"g", b"1-0"]).await.expect_integer(1);
+    call(&state, &[b"XACK", b"s", b"g", b"1-0"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn xreadgroup_noack_skips_pel() {
+    let state = test_state();
+    call(&state, &[b"XADD", b"s", b"1-0", b"f", b"a"]).await;
+    call(&state, &[b"XGROUP", b"CREATE", b"s", b"g", b"0"]).await;
+    call(&state, &[b"XREADGROUP", b"GROUP", b"g", b"c1", b"NOACK", b"STREAMS", b"s", b">"]).await;
+    // Nothing in PEL.
+    call(&state, &[b"XACK", b"s", b"g", b"1-0"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn xclaim_transfers_ownership() {
+    let state = test_state();
+    call(&state, &[b"XADD", b"s", b"1-0", b"f", b"a"]).await;
+    call(&state, &[b"XGROUP", b"CREATE", b"s", b"g", b"0"]).await;
+    call(&state, &[b"XREADGROUP", b"GROUP", b"g", b"c1", b"STREAMS", b"s", b">"]).await;
+    // c2 claims with min-idle 0 (immediately ok).
+    let reply = call(&state, &[b"XCLAIM", b"s", b"g", b"c2", b"0", b"1-0"]).await;
+    let raw = String::from_utf8_lossy(&reply.raw).to_string();
+    assert!(raw.contains("1-0"), "claim should return entry: {raw}");
+    // PEL summary now reports c2 instead of c1.
+    let summary = call(&state, &[b"XPENDING", b"s", b"g"]).await;
+    let raw = String::from_utf8_lossy(&summary.raw).to_string();
+    assert!(raw.contains("c2"));
+    assert!(!raw.contains("c1") || raw.split("c2").count() > 1);
+}
+
+#[tokio::test]
+async fn xclaim_justid_returns_only_ids() {
+    let state = test_state();
+    call(&state, &[b"XADD", b"s", b"1-0", b"f", b"a"]).await;
+    call(&state, &[b"XGROUP", b"CREATE", b"s", b"g", b"0"]).await;
+    call(&state, &[b"XREADGROUP", b"GROUP", b"g", b"c1", b"STREAMS", b"s", b">"]).await;
+    let reply = call(&state, &[b"XCLAIM", b"s", b"g", b"c2", b"0", b"1-0", b"JUSTID"]).await;
+    // Reply should be a flat array of ids — no nested fields.
+    let raw = String::from_utf8_lossy(&reply.raw).to_string();
+    assert!(raw.starts_with("*1\r\n$3\r\n1-0"), "expected just-id reply: {raw}");
+}
+
+#[tokio::test]
+async fn xpending_detail_filters_by_consumer() {
+    let state = test_state();
+    call(&state, &[b"XADD", b"s", b"1-0", b"f", b"a"]).await;
+    call(&state, &[b"XADD", b"s", b"2-0", b"f", b"b"]).await;
+    call(&state, &[b"XGROUP", b"CREATE", b"s", b"g", b"0"]).await;
+    // c1 takes both initially.
+    call(&state, &[b"XREADGROUP", b"GROUP", b"g", b"c1", b"STREAMS", b"s", b">"]).await;
+    // c2 claims 2-0.
+    call(&state, &[b"XCLAIM", b"s", b"g", b"c2", b"0", b"2-0"]).await;
+    // Detail filtered to c2 → 1 row, id 2-0.
+    let reply = call(&state, &[b"XPENDING", b"s", b"g", b"-", b"+", b"10", b"c2"]).await;
+    let raw = String::from_utf8_lossy(&reply.raw).to_string();
+    assert!(raw.contains("2-0") && raw.contains("c2"));
+    assert!(!raw.contains("1-0"));
+}
+
+#[tokio::test]
+async fn xinfo_groups_lists_groups() {
+    let state = test_state();
+    call(&state, &[b"XADD", b"s", b"*", b"f", b"v"]).await;
+    call(&state, &[b"XGROUP", b"CREATE", b"s", b"g1", b"0"]).await;
+    call(&state, &[b"XGROUP", b"CREATE", b"s", b"g2", b"0"]).await;
+    let reply = call(&state, &[b"XINFO", b"GROUPS", b"s"]).await;
+    let raw = String::from_utf8_lossy(&reply.raw).to_string();
+    assert!(raw.starts_with("*2\r\n"), "two groups expected: {raw}");
+    assert!(raw.contains("g1"));
+    assert!(raw.contains("g2"));
+}
+
+#[tokio::test]
+async fn xinfo_consumers_lists_consumers() {
+    let state = test_state();
+    call(&state, &[b"XADD", b"s", b"*", b"f", b"v"]).await;
+    call(&state, &[b"XGROUP", b"CREATE", b"s", b"g", b"0"]).await;
+    call(&state, &[b"XREADGROUP", b"GROUP", b"g", b"c1", b"STREAMS", b"s", b">"]).await;
+    let reply = call(&state, &[b"XINFO", b"CONSUMERS", b"s", b"g"]).await;
+    let raw = String::from_utf8_lossy(&reply.raw).to_string();
+    assert!(raw.contains("c1"), "c1 should appear: {raw}");
+}
+
+#[tokio::test]
+async fn xautoclaim_sweeps_idle_entries() {
+    let state = test_state();
+    call(&state, &[b"XADD", b"s", b"1-0", b"f", b"a"]).await;
+    call(&state, &[b"XGROUP", b"CREATE", b"s", b"g", b"0"]).await;
+    call(&state, &[b"XREADGROUP", b"GROUP", b"g", b"c1", b"STREAMS", b"s", b">"]).await;
+    // min-idle 0 → c2 claims everything immediately.
+    let reply = call(&state, &[b"XAUTOCLAIM", b"s", b"g", b"c2", b"0", b"0"]).await;
+    let raw = String::from_utf8_lossy(&reply.raw).to_string();
+    assert!(raw.contains("1-0"), "autoclaim should yield 1-0: {raw}");
+}
+
+#[tokio::test]
+async fn xack_with_no_group_returns_zero() {
+    let state = test_state();
+    call(&state, &[b"XADD", b"s", b"*", b"f", b"v"]).await;
+    call(&state, &[b"XACK", b"s", b"missing-group", b"1-0"]).await.expect_integer(0);
+}
+
+#[tokio::test]
+async fn xreadgroup_on_missing_group_errors() {
+    let state = test_state();
+    call(&state, &[b"XADD", b"s", b"1-0", b"f", b"v"]).await;
+    call(&state, &[b"XREADGROUP", b"GROUP", b"missing", b"c1", b"STREAMS", b"s", b">"])
+        .await
+        .expect_error_prefix("ERR");
+}
+
 #[tokio::test]
 async fn malformed_body_returns_parse_error() {
     let state = test_state();


### PR DESCRIPTION
## Summary

Six new commands plus extended XINFO. Builds on the base stream surface (#49) merged earlier.

- \`XGROUP CREATE | SETID | DESTROY | CREATECONSUMER | DELCONSUMER\`
- \`XREADGROUP GROUP <g> <c> [COUNT n] [BLOCK ms] [NOACK] STREAMS keys ids\`
- \`XACK key group id [id ...]\`
- \`XCLAIM key group consumer min-idle-time id [id ...] [IDLE ms] [TIME ms] [RETRYCOUNT n] [FORCE] [JUSTID]\`
- \`XPENDING key group [[IDLE ms] start end count [consumer]]\` — both summary and detail forms
- \`XAUTOCLAIM key group consumer min-idle-time start [COUNT n] [JUSTID]\`
- \`XINFO STREAM\` now reports real groups count; \`XINFO GROUPS\` / \`XINFO CONSUMERS\` return real summaries

## Why

Task-queue and event-fanout workloads almost always reach for consumer groups rather than raw \`XREAD\`. Groups live as server-side state on the stream key (not per-connection), so rustyant's one-command-per-request model can honor them faithfully — unlike \`WATCH\` / \`SUBSCRIBE\`.

Closes #50.

## Implementation notes

- **PEL serde:** \`BTreeMap<StreamId, PendingEntry>\` would need string-keyed JSON. Custom serde adapter serializes as \`Vec<(StreamId, PendingEntry)>\` and re-collects to \`BTreeMap\` on read so in-memory ordered iteration (used by XAUTOCLAIM cursor + XPENDING min/max) still works.
- **NOACK:** XREADGROUP NOACK skips PEL bookkeeping entirely — entries flow through without ever needing XACK.
- **XCLAIM JUSTID:** returns just the ids without re-serializing entry bodies.
- **XAUTOCLAIM deleted_ids:** matches Redis 7 — any PEL entries whose underlying stream entry has since been XDELed are dropped from the PEL and surfaced in the deleted-ids slot.
- **BLOCK on XREADGROUP:** parsed and ignored; same single-request caveat as XREAD.

## Test plan

- [x] 16 integration tests covering: create-with-mkstream / busygroup / dollar-marker / destroy / readgroup-new+pel / readgroup-noack / pending-summary / pending-detail-by-consumer / xack / xclaim transfer / xclaim justid / xautoclaim / xinfo-groups / xinfo-consumers / xack-missing-group / xreadgroup-missing-group
- [x] All 20 existing streams-base tests still pass
- [x] lint / fmt / typos clean
- [x] README scope updated — streams consumer groups are no longer "PRs welcome"